### PR TITLE
development/kotlin: Fix typo

### DIFF
--- a/development/kotlin/kotlin.SlackBuild
+++ b/development/kotlin/kotlin.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for kotlin
 
-# Copyright 2017 Willy Sudiarto Raharjo <willysr@slackbuilds.org
+# Copyright 2017 Willy Sudiarto Raharjo <willysr@slackbuilds.org>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is


### PR DESCRIPTION
@willysr, There is a little typo in kotlin.SlackBuild.