### PR TITLE
libraries/luadbi: Fixed download link

### DIFF
--- a/libraries/luadbi/luadbi.info
+++ b/libraries/luadbi/luadbi.info
@@ -1,7 +1,7 @@
 PRGNAM="luadbi"
 VERSION="0.5"
 HOMEPAGE="http://code.google.com/p/luadbi/"
-DOWNLOAD="http://luadbi.googlecode.com/files/luadbi.0.5.tar.gz"
+DOWNLOAD="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/luadbi/luadbi.0.5.tar.gz"
 MD5SUM="ede2b003aadddc151aac87050c3d926e"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""


### PR DESCRIPTION
Homepage remains unchanged. Seems there is not a canonical replacement
at the moment.