### PR TITLE
development/d-tools: Updated for version 2.077.1

### DIFF
--- a/development/d-tools/README
+++ b/development/d-tools/README
@@ -6,6 +6,7 @@ The following tools are included:
 * ddemangle - D symbol demangler.
 * rdmd - D build tool.
 * dustmite - Test case minimization tool.
+* D-Scanner - Swiss-army knife for D source code.
 
 By default DMD is used to build all tools but you can build them with GDC as
 well. DMD is not required in this case. Specify $DC variable for that:

--- a/development/d-tools/d-tools.SlackBuild
+++ b/development/d-tools/d-tools.SlackBuild
@@ -23,11 +23,12 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 PRGNAM=d-tools
-VERSION=${VERSION:-2.077.0}
+VERSION=${VERSION:-2.077.1}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 
 DUB_VERSION=${DUB_VERSION:-1.6.0}
+DSCANNER_VERSION=${DSCANNER_VERSION:-0.4.1}
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
@@ -70,11 +71,7 @@ rm -rf dub-$DUB_VERSION
 tar xvf $CWD/dub-$DUB_VERSION.tar.gz
 cd dub-$DUB_VERSION
 chown -R root:root .
-find -L . \
- \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
-  -o -perm 511 \) -exec chmod 755 {} \; -o \
- \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
-  -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+chmod -R u+w,go-w,a+rX-st .
 
 case "$DC" in
   *gdc) sh build-gdc.sh
@@ -90,6 +87,8 @@ cd $TMP
 rm -rf tools-$VERSION
 tar xvf $CWD/tools-$VERSION.tar.gz
 cd tools-$VERSION
+chown -R root:root .
+chmod -R u+w,go-w,a+rX-st .
 
 for binary in rdmd ddemangle; do
   echo "Build $binary..."
@@ -108,6 +107,22 @@ case "$DC" in
      *) $DC -release -od. -of$PKG/usr/bin/dustmite DustMite/*.d
         ;;
 esac
+
+# Build D-Scanner.
+cd $TMP
+rm -rf D-Scanner-$DSCANNER_VERSION
+tar xvf $CWD/D-Scanner-$DSCANNER_VERSION.tar.xz
+cd D-Scanner-$DSCANNER_VERSION
+chown -R root:root .
+chmod -R u+w,go-w,a+rX-st .
+
+case "$DC" in
+  *gdc) make gdcbuild
+        ;;
+     *) make dmdbuild
+        ;;
+esac
+mv bin/dscanner $PKG/usr/bin
 
 # Copy documentation.
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION

--- a/development/d-tools/d-tools.info
+++ b/development/d-tools/d-tools.info
@@ -1,10 +1,12 @@
 PRGNAM="d-tools"
-VERSION="2.077.0"
+VERSION="2.077.1"
 HOMEPAGE="https://dlang.org"
 DOWNLOAD="http://download.dlackware.com/hosted-sources/d-tools/dub-1.6.0.tar.gz \
-          http://download.dlackware.com/hosted-sources/d-tools/tools-2.077.0.tar.gz"
+          http://download.dlackware.com/hosted-sources/d-tools/tools-2.077.1.tar.gz \
+          http://download.dlackware.com/hosted-sources/d-tools/D-Scanner-0.4.1.tar.gz"
 MD5SUM="c379f5d22c2e2f1591b9938b94e71ff4 \
-        e31c333cb76162de5917fe3eb81dbc80"
+        c422fee2fdf85b646a8e0fd1312f1dbd \
+        fe48c62f5123f090f543aabbe4426b0c"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="dmd"


### PR DESCRIPTION
I added one additional common tool and replaced
```sh
find -L . \
 \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
  -o -perm 511 \) -exec chmod 755 {} \; -o \
 \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
  -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
```
with
```
chmod -R u+w,go-w,a+rX-st .
```
to make the code a bit shorter since there are 3 directories the commands should be run on. I hope it isn't a problem.