### PR TITLE
Fix LUA_ROOT path

### DIFF
--- a/development/lua52/lua52.SlackBuild
+++ b/development/lua52/lua52.SlackBuild
@@ -92,7 +92,7 @@ sed -i \
   src/Makefile
 
 sed -i \
-  -e '/^#define LUA_ROOT/s,".*,"/usr",' \
+  -e '/^#define LUA_ROOT/s,".*,"/usr/",' \
   -e '/^#define LUA_CDIR/s,"lib,&'"${LIBDIRSUFFIX}"',' \
   src/luaconf.h
 

--- a/development/lua53/lua53.SlackBuild
+++ b/development/lua53/lua53.SlackBuild
@@ -92,7 +92,7 @@ sed -i \
   src/Makefile
 
 sed -i \
-  -e '/^#define LUA_ROOT/s,".*,"/usr",' \
+  -e '/^#define LUA_ROOT/s,".*,"/usr/",' \
   -e '/^#define LUA_CDIR/s,"lib,&'"${LIBDIRSUFFIX}"',' \
   src/luaconf.h
 


### PR DESCRIPTION
The build script omitted a trailing '/' when removing "local" from the LUA_ROOT definition.  This caused Hamlib bindings for Lua to be installed in "/usrlib*/ instead of "/usr/lib*".
