### PR TITLE
network/postfix: Retain license files

### DIFF
--- a/network/postfix/postfix.SlackBuild
+++ b/network/postfix/postfix.SlackBuild
@@ -172,8 +172,6 @@ make non-interactive-package \
   manpage_directory=/usr/man \
   readme_directory=/usr/doc/$PRGNAM-$VERSION/README_FILES
 
-rm -f $PKG/etc/postfix/{TLS_,}LICENSE
-
 install -D -m 0644 -oroot -groot $CWD/rc.postfix $PKG/etc/rc.d/rc.postfix.new
 find $PKG/etc/postfix -type f ! -name "*.default" ! -name "*.proto" ! -name "*.out" \
   ! -name "postfix-files" -exec mv {} {}.new \;


### PR DESCRIPTION
`/etc/postfix/{TLS_,}LICENSE` files are part of post-install scripts:

https://github.com/vdukhovni/postfix/blob/v3.3.0/postfix/conf/postfix-files#L143-L144

Removing them gives me the error:
`chown: cannot access '/etc/postfix/LICENSE': No such file or directory`

In the file:
https://github.com/vdukhovni/postfix/blob/v3.3.0/postfix/conf/post-install#L570

Retaining them works.