### PR TITLE
python/python3-lazy-object-proxy: Fixed dependencies.

### DIFF
--- a/python/python3-lazy-object-proxy/README
+++ b/python/python3-lazy-object-proxy/README
@@ -1,1 +1,3 @@
 A fast and thorough lazy object proxy.
+
+Dependency setuptools-scm needs to have been built with python3 support.

--- a/python/python3-lazy-object-proxy/python3-lazy-object-proxy.info
+++ b/python/python3-lazy-object-proxy/python3-lazy-object-proxy.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/ad/57/a36f682668ffc453e86ddfb5
 MD5SUM="0a904e9b6112c1337f404811e10cb53e"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3"
+REQUIRES="python3 setuptools-scm"
 MAINTAINER="Markus Rinne"
 EMAIL="markus.ka.rinne@gmail.com"


### PR DESCRIPTION
If dependency setuptools-scm was not present, the SlackBuild tried to download it.