### PR TITLE
Allow acpi_call to be built with 5.x kernels.

### DIFF
--- a/system/acpi_call/acpi_call.SlackBuild
+++ b/system/acpi_call/acpi_call.SlackBuild
@@ -65,6 +65,7 @@ find -L . \
  -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
 patch -p0 < $CWD/fix-acpi-include.patch
+patch -p0 < $CWD/fix-5.x-kernel.patch
 
 make KDIR=$KERNELPATH
 

--- a/system/acpi_call/fix-5.x-kernel.patch
+++ b/system/acpi_call/fix-5.x-kernel.patch
@@ -1,0 +1,29 @@
+--- acpi_call.c.orig	2020-10-28 23:05:01.875849692 +0100
++++ acpi_call.c	2020-10-28 23:07:50.658179392 +0100
+@@ -7,6 +7,7 @@
+ #include <linux/slab.h>
+ #include <asm/uaccess.h>
+ #include <linux/acpi.h>
++#include <linux/uaccess.h>
+
+ MODULE_LICENSE("GPL");
+
+@@ -317,11 +318,18 @@
+     return ret;
+ }
+
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++static struct proc_ops proc_acpi_operations = {
++        .proc_read  = acpi_proc_read,
++        .proc_write = acpi_proc_write,
++};
++#else
+ static struct file_operations proc_acpi_operations = {
+         .owner    = THIS_MODULE,
+         .read     = acpi_proc_read,
+         .write    = acpi_proc_write,
+ };
++#endif
+
+ #else
+ static int acpi_proc_read(char *page, char **start, off_t off,


### PR DESCRIPTION
Current `acpi_call` code can't be built with 5.2.x and 5.9.x kernels due API changes. This commit provides a patch that will address that.