### PR TITLE
games/ags: updated for version 3.5.0.30

### DIFF
--- a/games/ags/ags.SlackBuild
+++ b/games/ags/ags.SlackBuild
@@ -24,13 +24,9 @@
 #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 PRGNAM=ags
-VERSION=${VERSION:-3.5.0.29}
+VERSION=${VERSION:-3.5.0.30}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
-
-# Dependency tarball versions.
-ALLEGRO_VERSION=${ALLEGRO_VERSION:-4.4.2}
-DUMB_VERSION=${DUMB_VERSION:-0.9.3}
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
@@ -62,18 +58,11 @@ fi
 set -e
 
 rm -rf $PKG
+rm -rf $TMP/$PRGNAM-$VERSION
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
-
-rm -rf allegro-${ALLEGRO_VERSION}
-rm -rf dumb-${DUMB_VERSION}
-rm -rf ags-v.${VERSION}
-
-# Build Allegro 4 first.
-
-tar xvf $CWD/allegro-${ALLEGRO_VERSION}.tar.gz
-cd allegro-${ALLEGRO_VERSION}
-
+tar xvf $CWD/$PRGNAM-v.${VERSION}.tar.gz
+cd $PRGNAM-v.$VERSION
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
@@ -81,69 +70,11 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-mkdir build
-cd build
-cmake \
-	-DWANT_DOCS=OFF \
-	-DWANT_EXAMPLES=OFF \
-	-DWANT_TESTS=OFF \
-	-DWANT_TOOLS=OFF \
-	-DCMAKE_INSTALL_PREFIX=/opt/ags-$VERSION \
-	-DCMAKE_BUILD_TYPE=Release \
-	..
-CFLAGS="$SLKCFLAGS" CXXFLAGS="$SLKCFLAGS" make
-make install DESTDIR=$PKG
-
-# Then build Dynamic Universal Music Bibliotheque.
-
-cd $TMP
-tar xvf $CWD/dumb-${DUMB_VERSION}.tar.gz
-cd dumb-$DUMB_VERSION
-
-chown -R root:root .
-find -L . \
- \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
-  -o -perm 511 \) -exec chmod 755 {} \; -o \
- \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
-  -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
-
-cat << EOF > make/config.txt
-include make/unix.inc
-ALL_TARGETS := core core-examples core-headers
-ALL_TARGETS += allegro allegro-examples allegro-headers
-PREFIX := $PKG/opt/ags-$VERSION
-EOF
-
-PATH="$PATH:$PKG/opt/ags-$VERSION/bin" make \
-	WFLAGS="-I$PKG/opt/ags-$VERSION/include $SLKCFLAGS" \
-	LDFLAGS="-lm -L$PKG/opt/ags-$VERSION/lib $LDFLAGS"
-make install
-
-# And finaly install Adventure Game Studio.
-
-cd $TMP
-tar xvf $CWD/v.${VERSION}.tar.gz || tar xvf $CWD/ags-v.${VERSION}.tar.gz
-cd ags-v.$VERSION
-
-chown -R root:root .
-find -L . \
- \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
-  -o -perm 511 \) -exec chmod 755 {} \; -o \
- \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
-  -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
-
-CFLAGS="-I$PKG/opt/ags-$VERSION/include $SLKCFLAGS" \
- CXXFLAGS="-I$PKG/opt/ags-$VERSION/include $SLKCFLAGS" \
- LDFLAGS="-L$PKG/opt/ags-$VERSION/lib -Wl,-rpath,/opt/ags-$VERSION/lib" \
- PATH="$PATH:$PKG/opt/ags-$VERSION/bin" \
+CFLAGS="$SLKCFLAGS" \
+ CXXFLAGS="$SLKCFLAGS" \
  make --directory=Engine
 mkdir -p $PKG/usr/bin
-cp Engine/ags $PKG/opt/ags-$VERSION/bin
-
-(
-cd $PKG/usr/bin
-ln -s ../../opt/ags-$VERSION/bin/ags .
-)
+cp Engine/ags $PKG/usr/bin
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a README.md $PKG/usr/doc/$PRGNAM-$VERSION

--- a/games/ags/ags.info
+++ b/games/ags/ags.info
@@ -1,14 +1,10 @@
 PRGNAM="ags"
-VERSION="3.5.0.29"
+VERSION="3.5.0.30"
 HOMEPAGE="https://github.com/adventuregamestudio/ags"
-DOWNLOAD="https://github.com/adventuregamestudio/ags/archive/v.3.5.0.29.tar.gz \
-          http://downloads.sourceforge.net/project/alleg/allegro/4.4.2/allegro-4.4.2.tar.gz \
-          http://downloads.sourceforge.net/project/dumb/dumb/0.9.3/dumb-0.9.3.tar.gz"
-MD5SUM="091a8cbbf447269a3bbc119352de86bd \
-        4db71b0460fc99926ae91d223199c2e6 \
-        f48da5b990aa8aa822d3b6a951baf5c2"
+DOWNLOAD="https://github.com/adventuregamestudio/ags/archive/v.3.5.0.30/ags-v.3.5.0.30.tar.gz"
+MD5SUM="091a8cbbf447269a3bbc119352de86bd"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES=""
+REQUIRES="dumb"
 MAINTAINER="Yth - Arnaud"
 EMAIL="yth@ythogtha.org"


### PR DESCRIPTION
This is a big rework of the slackbuild.
I inherited it as a complex build with its own version of allegro4 and dumb, all installed inside /opt/ags/.
I decided to use Sbo's allegro4 and add a slackbuild for dumb library.
It makes for a cleaner build, and easier maintenance of it's dependencies.

Also, this PR shouldn't be merged before the new library/dumb slackbuild is accepted from the submit form on slackbuilds.org :)