### PR TITLE
libraries/dumb: build both static and shared libraries

### DIFF
--- a/libraries/dumb/dumb.SlackBuild
+++ b/libraries/dumb/dumb.SlackBuild
@@ -25,7 +25,7 @@
 
 PRGNAM=dumb
 VERSION=${VERSION:-2.0.3}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 
 if [ -z "$ARCH" ]; then
@@ -72,12 +72,17 @@ find -L . \
 
 mkdir build
 cd build
-  cmake \
+cmake \
+	-DCMAKE_INSTALL_PREFIX=/usr \
+	-DBUILD_SHARED_LIBS:BOOL=ON \
+	-DBUILD_ALLEGRO4:BOOL=ON \
+	-DCMAKE_BUILD_TYPE=Release ..
+make install DESTDIR=$PKG
+cmake \
 	-DCMAKE_INSTALL_PREFIX=/usr \
 	-DBUILD_SHARED_LIBS:BOOL=OFF \
 	-DBUILD_ALLEGRO4:BOOL=ON \
 	-DCMAKE_BUILD_TYPE=Release ..
-
 make install DESTDIR=$PKG
 cd ..
 


### PR DESCRIPTION
Building both static and shared libs.
Static are needed to build ags, which is the reason for this slackbuild.
But allegro autodetects the presence of libdumb and tries using it, which will fail if there are only the static libs available!
Since dumb is quite small, it's not a big deal to build it twice for shared and static.