### PR TITLE
games/endless-sky: allows for building on both -current and -14.2

### DIFF
--- a/games/endless-sky/endless-sky.SlackBuild
+++ b/games/endless-sky/endless-sky.SlackBuild
@@ -22,7 +22,7 @@
 
 PRGNAM=endless-sky
 VERSION=${VERSION:-0.9.12}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 
 if [ -z "$ARCH" ]; then
@@ -64,6 +64,7 @@ tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
 cd $PRGNAM-$VERSION
 
 chown -R root:root .
+patch -p0 < $CWD/include-string.diff
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
   -o -perm 511 \) -exec chmod 755 {} \; -o \

--- a/games/endless-sky/include-string.diff
+++ b/games/endless-sky/include-string.diff
@@ -1,0 +1,11 @@
+--- source/Panel.h~	2020-05-01 21:02:38.000000000 +0200
++++ source/Panel.h	2020-12-17 15:29:57.592856826 +0100
+@@ -17,7 +17,7 @@
+ 
+ #include <functional>
+ #include <list>
+-
++#include <string>
+ #include <SDL2/SDL.h>
+ 
+ class Command;


### PR DESCRIPTION
Update only for building on -current.
If you feel there's no need, I can postpone the change until next version of endless-sky, as this won't change anything on -14.2.
But as 15.0 is drawing near, it might be worth doing.