### PR TITLE
office/pdfpc: fix compilation against current vala

### DIFF
--- a/office/pdfpc/pdfpc.SlackBuild
+++ b/office/pdfpc/pdfpc.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=pdfpc
 VERSION=${VERSION:-4.5.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -80,6 +80,8 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+patch -p1 < $CWD/vala_fix.patch
 
 mkdir -p build
 cd build

--- a/office/pdfpc/vala_fix.patch
+++ b/office/pdfpc/vala_fix.patch
@@ -1,0 +1,15 @@
+diff -Naur '-x.*.s?p' '-x*~' pdfpc-4.5.0.orig/src/classes/action/movie.vala pdfpc-4.5.0/src/classes/action/movie.vala
+--- pdfpc-4.5.0.orig/src/classes/action/movie.vala	2020-12-20 14:22:12.000000000 +0000
++++ pdfpc-4.5.0/src/classes/action/movie.vala	2021-08-09 18:16:38.092791467 +0100
+@@ -548,7 +548,11 @@
+          */
+         public void on_prepare(Gst.Element overlay, Gst.Caps caps) {
+             var info = new Gst.Video.Info();
++#if VALA_0_52
++            Gst.Video.info_from_caps(out info, caps);
++#else
+             info.from_caps(caps);
++#endif
+             this.video_w = info.width;
+             this.video_h = info.height;
+             this.scalex = (double) this.video_w/rect.width;


### PR DESCRIPTION
due to an API change in vala 0.52.x, compilation was broken. It seems
that vala will be fixed in a future release (for 0.52 and 0.54), for the
moment a patch is required as discussed in
https://github.com/pdfpc/pdfpc/issues/594