### PR TITLE
gis/gdal: fix building when freexl is installed.

### DIFF
--- a/gis/gdal/gdal.SlackBuild
+++ b/gis/gdal/gdal.SlackBuild
@@ -4,7 +4,7 @@
 
 # Copyright 2009 Marco Cecchetti <mrc.ild@gmail.com>
 # Updated 2019-2021 Benjamin Trigona-Harany <slackbuilds@jaxartes.net>
-# Updated 2021 Gregory J. L. Tourte <artourter@gmail.com>
+# Updated 2021-2022 Gregory J. L. Tourte <artourter@gmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -30,7 +30,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=gdal
 VERSION=${VERSION:-3.4.1}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -78,9 +78,9 @@ tar xvf $CWD/$PRGNAM-$VERSION.tar.?z*
 cd $PRGNAM-$VERSION
 chown -R root:root .
 find -L . \
- \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
+  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
- \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
+  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
 # OpenCL, webp, Spatialite and Grass support need special arrangements.
@@ -133,6 +133,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-static=no \
   --with-threads=yes \
   --with-cpp14=yes \
+  --without-libtool \
   --with-bash-completion \
   --with-geos=yes \
   --with-libz=yes \


### PR DESCRIPTION
Don't use libtool for building the libraries. Otherwise the build
process looks for freexl .la file which is no longer packaged.

Signed-off-by: ArTourter <artourter@gmail.com>