### PR TITLE
games/vcmi-resolutions: updated for version 20151113

### DIFF
--- a/games/vcmi-resolutions/vcmi-resolutions.SlackBuild
+++ b/games/vcmi-resolutions/vcmi-resolutions.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=vcmi-resolutions
 SRCNAM=vcmi
-VERSION=${VERSION:-20141001}
+VERSION=${VERSION:-20151113}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/games/vcmi-resolutions/vcmi-resolutions.info
+++ b/games/vcmi-resolutions/vcmi-resolutions.info
@@ -1,5 +1,5 @@
 PRGNAM="vcmi-resolutions"
-VERSION="20141001"
+VERSION="20151113"
 HOMEPAGE="http://forum.vcmi.eu/viewtopic.php?p=13121"
 DOWNLOAD="http://download.vcmi.eu/mods/repository/vcmi.zip"
 MD5SUM="8a92757943ffca0e97830f0b2ac7d7a3"


### PR DESCRIPTION
This actually only reflects the real date of the file downloaded, that change should have happened more than 6 years ago.
As for all vcmi-{addons}, it only downloads and repackage the file on http://download.vcmi.eu/ and the only pertinent version is the date the file was added there.