### PR TITLE
academic/pysam: Use internal htslib-1.14

### DIFF
--- a/academic/pysam/pysam.SlackBuild
+++ b/academic/pysam/pysam.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=pysam
 VERSION=${VERSION:-0.18.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-4}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -80,10 +80,10 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-### pysam linked to htslib-1.14; SBo-htslib is at 1.14:
+### pysam linked to htslib-1.14; SBo-htslib is at 1.15:
 ### for use system htslib:
-export HTSLIB_LIBRARY_DIR=/usr/lib$LIBDIRSUFFIX
-export HTSLIB_INCLUDE_DIR=/usr/include
+#export HTSLIB_LIBRARY_DIR=/usr/lib$LIBDIRSUFFIX
+#export HTSLIB_INCLUDE_DIR=/usr/include
 
 #the source does not allow 'read' to 'other', which could cause a problem on reloading a Jupyter-notebook
 chmod 644 pysam.egg-info/*


### PR DESCRIPTION
After htslib update to version 1.15 pysam needs to use the internal htslib 1.14