### PR TITLE
cargo: avoid writing to $HOME/.cargo

### DIFF
--- a/desktop/bukubrow/bukubrow.SlackBuild
+++ b/desktop/bukubrow/bukubrow.SlackBuild
@@ -141,6 +141,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --release $CARGOTARGET

--- a/development/mdbook/mdbook.SlackBuild
+++ b/development/mdbook/mdbook.SlackBuild
@@ -141,6 +141,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --release $CARGOTARGET

--- a/development/racer/racer.SlackBuild
+++ b/development/racer/racer.SlackBuild
@@ -153,6 +153,7 @@ if ! rustup toolchain list | grep "$RUST_NIGHTLY" > /dev/null 2>&1 ; then
 fi
 
 PATH="$(pwd)/rustup-bin:$PATH" \
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 rustup run "$RUST_NIGHTLY" cargo build --release $CARGOTARGET

--- a/development/rustup/rustup.SlackBuild
+++ b/development/rustup/rustup.SlackBuild
@@ -147,6 +147,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 cargo build --release --features no-self-update $CARGOTARGET
 
 mkdir -p $PKG/usr/bin/

--- a/gis/whitebox-tools/whitebox-tools.SlackBuild
+++ b/gis/whitebox-tools/whitebox-tools.SlackBuild
@@ -141,6 +141,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --offline --release $CARGOTARGET

--- a/network/newsboat/newsboat.SlackBuild
+++ b/network/newsboat/newsboat.SlackBuild
@@ -146,6 +146,8 @@ if [ "$CARGOTARGET" != "" ] ; then
   sed -i "s|target/release|target/$RELEASEDIR/release|" Makefile
 fi
 
+export CARGO_HOME=.cargo
+
 CXXFLAGS="$SLKCFLAGS" \
 CARGO_FLAGS="$CARGOTARGET" \
 make -j1 prefix=/usr

--- a/network/suricata/suricata.SlackBuild
+++ b/network/suricata/suricata.SlackBuild
@@ -79,6 +79,8 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+export CARGO_HOME=.cargo
+
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 ./configure \

--- a/python/cryptography/cryptography.SlackBuild
+++ b/python/cryptography/cryptography.SlackBuild
@@ -131,6 +131,8 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+export CARGO_HOME=.cargo
+
 sed -i '/install_requires/d' setup.py
 python3 setup.py install --root=$PKG
 

--- a/system/alacritty/alacritty.SlackBuild
+++ b/system/alacritty/alacritty.SlackBuild
@@ -142,6 +142,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --release $CARGOTARGET

--- a/system/bat/bat.SlackBuild
+++ b/system/bat/bat.SlackBuild
@@ -155,6 +155,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --offline --release $CARGOTARGET

--- a/system/dust/dust.SlackBuild
+++ b/system/dust/dust.SlackBuild
@@ -155,6 +155,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --offline --release $CARGOTARGET

--- a/system/exa/exa.SlackBuild
+++ b/system/exa/exa.SlackBuild
@@ -140,6 +140,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --release $CARGOTARGET

--- a/system/fd/fd.SlackBuild
+++ b/system/fd/fd.SlackBuild
@@ -140,6 +140,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --release $CARGOTARGET

--- a/system/ripgrep/ripgrep.SlackBuild
+++ b/system/ripgrep/ripgrep.SlackBuild
@@ -141,6 +141,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 PCRE2_SYS_STATIC=0 \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \

--- a/system/skim/skim.SlackBuild
+++ b/system/skim/skim.SlackBuild
@@ -141,6 +141,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --offline --release $CARGOTARGET

--- a/system/system76-power/system76-power.SlackBuild
+++ b/system/system76-power/system76-power.SlackBuild
@@ -171,6 +171,8 @@ find -L . \
 # Prevent syslog messasge 'Unknown group "sudo" in message bus configuration file'.
 patch -p1 < $CWD/fix_groups.patch
 
+export CARGO_HOME=.cargo
+
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 make

--- a/system/vtcol/vtcol.SlackBuild
+++ b/system/vtcol/vtcol.SlackBuild
@@ -140,6 +140,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 cargo build --release $CARGOTARGET


### PR DESCRIPTION
Unless `CARGO_HOME` is set explicitly, cargo will create `$HOME/.cargo/.package_cache` for the running user if it does not already exist.

There may be more scripts that cause this behavior, but these were the ones I was able to find.