### PR TITLE
network/netcat-openbsd: Update download URL

### DIFF
--- a/network/netcat-openbsd/netcat-openbsd.info
+++ b/network/netcat-openbsd/netcat-openbsd.info
@@ -1,7 +1,7 @@
 PRGNAM="netcat-openbsd"
 VERSION="1.217_1"
 HOMEPAGE="https://github.com/duncan-roe/netcat-openbsd"
-DOWNLOAD="https://github.com/duncan-roe/netcat-openbsd/archive/1.217-1/netcat-openbsd-1.217-1.tar.gz"
+DOWNLOAD="https://github.com/duncan-roe/netcat-openbsd/archive/refs/tags/1.217-1/netcat-openbsd-1.217-1.tar.gz"
 MD5SUM="8babccac46097ae5b746ffa00c01ac0f"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""


### PR DESCRIPTION
I had an email that the old URL had stopped working with the message "the given path has multiple possibilities: ...". Found this to be true: new URL suggested in email is good.