### PR TITLE
gis/gdal: fix download file.

### DIFF
--- a/gis/gdal/gdal.info
+++ b/gis/gdal/gdal.info
@@ -1,7 +1,7 @@
 PRGNAM="gdal"
 VERSION="3.4.2"
 HOMEPAGE="https://www.gdal.org/"
-DOWNLOAD="https://github.com/OSGeo/gdal/archive/refs/tags/v3.4.2/gdal-3.4.2.tar.gz"
+DOWNLOAD="https://github.com/OSGeo/gdal/releases/download/v3.4.2/gdal-3.4.2.tar.gz"
 MD5SUM="ee9063b8d0887a60ff507fcfed004742"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""


### PR DESCRIPTION
using the release file from github rather than the archive source.
Somehow the archive source changed since my submission, and the archive
source has a broken symlink.
Can this be pushed quickly as currently the slackbuild doesn't work.

Signed-off-by: ArTourter <artourter@gmail.com>