### PR TITLE
desktop/xss-lock: fix cmake policy obsoloscence warning

### DIFF
--- a/desktop/xss-lock/policy.diff
+++ b/desktop/xss-lock/policy.diff
@@ -1,0 +1,19 @@
+--- xss-lock-0.3.0/CMakeLists.txt	2013-11-05 02:10:10.000000000 +0900
++++ xss-lock-0.3.0/CMakeLists.txt.new	2021-04-08 08:03:28.349195750 +0900
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8.12)
+ project(xss-lock C)
+ set(PROJECT_VERSION 0.3.0)
+
+--- xss-lock-0.3.0/src/CMakeLists.txt	2013-11-05 02:10:10.000000000 +0900
++++ xss-lock-0.3.0/src/CMakeLists.txt.new	2021-04-08 08:25:15.923235654 +0900
+@@ -17,7 +17,7 @@
+     xss-lock.c
+     xcb_utils.c
+     xcb_utils.h
+-    config.h
++    config.h.in
+ )
+
+ target_link_libraries(xss-lock ${GLIB2_LIBRARIES} ${XCB_LIBRARIES})

--- a/desktop/xss-lock/xss-lock.SlackBuild
+++ b/desktop/xss-lock/xss-lock.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for xss-lock
 
-# Copyright 2021 K. Eugene Carlson  Tsukuba, Japan
+# Copyright 2021-2022 K. Eugene Carlson  Tsukuba, Japan
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -75,6 +75,9 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# Prevent obsolesence/policy cmake warnings
+patch -p1 < $CWD/policy.diff
 
 mkdir -p build
 cd build


### PR DESCRIPTION
Nothing major for now, but the warning might turn into actual trouble at some point as -current upgrades cmake.