### PR TITLE
Update piper and jupyter-ipykernel (HOMEPAGE and README)

### DIFF
--- a/development/jupyter-ipykernel/README
+++ b/development/jupyter-ipykernel/README
@@ -1,1 +1,4 @@
 Python 3 kernel for Jupyter.
+
+jupyter-ipykernel 6.10.0 is the last possible version for Slackware 
+15.0. Newer versions would require a newer python-setuptools.

--- a/system/piper/piper.info
+++ b/system/piper/piper.info
@@ -1,6 +1,6 @@
 PRGNAM="piper"
 VERSION="0.6"
-HOMEPAGE="https://github.com/libratbag/libratbag"
+HOMEPAGE="https://github.com/libratbag/piper"
 DOWNLOAD="https://github.com/libratbag/piper/archive/0.6/piper-0.6.tar.gz"
 MD5SUM="87eb3893f16661d6c39aca539c970bf8"
 DOWNLOAD_x86_64=""


### PR DESCRIPTION
system/piper: HOMEPAGE should be https://github.com/libratbag/piper
development/jupyter-ipykernel: version 6.10.0 is the last possible version