### PR TITLE
games/ppsspp: Updated for version 1.12.3.

### DIFF
--- a/games/ppsspp/README
+++ b/games/ppsspp/README
@@ -2,13 +2,18 @@ PPSSPP can run your PSP games on your PC in full HD resolution. It can
 even upscale textures that would otherwise be too blurry as they were
 made for the small screen of the original PSP.
 
-* Play in HD resolutions and more * Play on a tablet for big-screen
-mobile gaming * Customize on-screen touch controls or use an external
-controller or keyboard * Save and restore game state anywhere, anytime
-* Crank up the anisotropic filtering and texture scaling * Continue
-where you left off by transferring saves from your real PSP
+* Play in HD resolutions and more
+* Play on a tablet for big-screen mobile gaming
+* Customize on-screen touch controls or use an external controller or
+keyboard
+* Save and restore game state anywhere, anytime
+* Crank up the anisotropic filtering and texture scaling
+* Continue where you left off by transferring saves from your real PSP
 
 snappy is an optional dependency.
 
 QT=on will enable QT GUI and require qt5 installed (default is
 'QT=off').
+
+SYSTEM_FFMPEG=on: dynamically link against system FFMPEG (default is
+'SYSTEM_FFMPEG=off', using upstream's modified version).

--- a/games/ppsspp/ppsspp.SlackBuild
+++ b/games/ppsspp/ppsspp.SlackBuild
@@ -3,7 +3,7 @@
 # Slackware build script for ppsspp
 
 # Copyright 2016  Hunter Sezen California, USA
-# Copyright 2019-2020  Ruoh-Shoei LIN
+# Copyright 2019-2022  Ruoh-Shoei LIN
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -23,16 +23,10 @@
 #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# 20210218 bkw: modified by SlackBuilds.org. Use correct filenames
-# in the github URLs for the 'submodules'. This is needed because
-# we don't get to decide what user-agent the user downloads files
-# with. If the Content-Disposition header is honored (e.g. files
-# downloaded with a web browser), this build failed.
-
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=ppsspp
-VERSION=${VERSION:-1.10.3}
+VERSION=${VERSION:-1.12.3}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -82,20 +76,26 @@ cd $PRGNAM-$VERSION
 
 # The submodules are in a separate archive. This is equivalent to
 # git submodule update --init --recursive
-tar -xvf $CWD/glslang-d0850f8*.tar.gz \
+tar -xvf $CWD/zstd-a488ba1*.tar.gz \
+    -C ext/zstd --strip-components=1
+tar -xvf $CWD/miniupnp-3a87be3*.tar.gz \
+    -C ext/miniupnp --strip-components=1
+tar -xvf $CWD/glslang-dc11add*.tar.gz \
     -C ext/glslang --strip-components=1
-tar -xvf $CWD/ppsspp-lang-1c64b8f*.tar.gz \
-    -C assets/lang --strip-components=1
-tar -xvf $CWD/SPIRV-Cross-a1f7c8d*.tar.gz \
+tar -xvf $CWD/SPIRV-Cross-9acb9ec*.tar.gz \
     -C ext/SPIRV-Cross --strip-components=1
 tar -xvf $CWD/armips-7885552*.tar.gz \
     -C ext/armips --strip-components=1
-tar -xvf $CWD/ppsspp-ffmpeg-55147e5*.tar.gz \
+
+SYSTEM_FFMPEG=${SYSTEM_FFMPEG:-off}
+if [ "$SYSTEM_FFMPEG" = "off" ]; then
+tar -xvf $CWD/ppsspp-ffmpeg-a5baf97*.tar.gz \
     --exclude '*/Windows*' --exclude '*/android' \
     --exclude '*/ios' --exclude '*/blackberry'\
     --exclude '*/macosx' --exclude '*/wiiu' \
     --exclude '*/symbian' \
     -C ffmpeg --strip-components=1
+fi
 
 chown -R root:root .
 find -L . \
@@ -103,9 +103,6 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
-
-# This does build with Slackware 14.2's CMake.
-sed -i 's/VERSION 3.6/VERSION 3.5.2/' CMakeLists.txt
 
 # Don't force explicit ccache invocation.
 sed -i -e '/include(ccache)/d' CMakeLists.txt
@@ -126,6 +123,7 @@ if [ "$QT" = "on" ]; then
 	-Wno-dev \
 	-DUSING_QT_UI=ON \
 	-DUSE_SYSTEM_LIBZIP=ON \
+	-DUSE_SYSTEM_FFMPEG=$SYSTEM_FFMPEG \
 	-DUSE_DISCORD=OFF \
 	-DCMAKE_BUILD_TYPE=Release ..
     make
@@ -144,6 +142,7 @@ cmake \
   -DUSING_QT_UI=OFF \
   -DHEADLESS='ON' \
   -DUSE_SYSTEM_LIBZIP=ON \
+  -DUSE_SYSTEM_FFMPEG=$SYSTEM_FFMPEG \
   -DUSE_DISCORD=OFF \
   -DCMAKE_BUILD_TYPE=Release ..
 make
@@ -161,7 +160,8 @@ find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | gr
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -v LICENSE.TXT README.md history.md headless/headless.txt $PKG/usr/doc/$PRGNAM-$VERSION
+cp -a LICENSE.TXT README.md history.md headless/headless.txt \
+   $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install

--- a/games/ppsspp/ppsspp.info
+++ b/games/ppsspp/ppsspp.info
@@ -1,20 +1,22 @@
 PRGNAM="ppsspp"
-VERSION="1.10.3"
+VERSION="1.12.3"
 HOMEPAGE="https://www.ppsspp.org/"
-DOWNLOAD="https://github.com/hrydgard/ppsspp/archive/v1.10.3/ppsspp-1.10.3.tar.gz \
-          https://github.com/hrydgard/glslang/archive/d0850f875ec392a130ccf00018dab458b546f27c/glslang-d0850f875ec392a130ccf00018dab458b546f27c.tar.gz \
-          https://github.com/hrydgard/ppsspp-lang/archive/1c64b8fbd3cb6bd87935eb53f302f7de6f86e209/ppsspp-lang-1c64b8fbd3cb6bd87935eb53f302f7de6f86e209.tar.gz \
-          https://github.com/KhronosGroup/SPIRV-Cross/archive/a1f7c8dc8ea2f94443951ee27003bffa562c1f13/SPIRV-Cross-a1f7c8dc8ea2f94443951ee27003bffa562c1f13.tar.gz \
-          https://github.com/Kingcom/armips/archive/7885552b208493a6a0f21663770c446c3ba65576/armips-7885552b208493a6a0f21663770c446c3ba65576.tar.gz \
-          https://github.com/hrydgard/ppsspp-ffmpeg/archive/55147e5f33f5ae4904f75ec082af809267122b94/ppsspp-ffmpeg-55147e5f33f5ae4904f75ec082af809267122b94.tar.gz"
-MD5SUM="66d6f34bba99f06e4cedf8d24fc9a205 \
-        781915370eb2b2c3c2f75d33a46154ae \
-        78e170cb8e40106dc1d428f896defdd9 \
-        9c0141380c98ccdff95a084ac07d1d48 \
-        4731977e287eee39ddcc247d75095758 \
-        d529fc6f45fd4bbec825c543dab9da65"
+DOWNLOAD="https://github.com/hrydgard/ppsspp/archive/v1.12.3/ppsspp-1.12.3.tar.gz \
+	  https://github.com/hrydgard/glslang/archive/dc11adde23c455a24e13dd54de9b4ede8bdd7db8/glslang-dc11adde23c455a24e13dd54de9b4ede8bdd7db8.tar.gz \
+	  https://github.com/KhronosGroup/SPIRV-Cross/archive/9acb9ec31f5a8ef80ea6b994bb77be787b08d3d1/SPIRV-Cross-9acb9ec31f5a8ef80ea6b994bb77be787b08d3d1.tar.gz \
+	  https://github.com/Kingcom/armips/archive/7885552b208493a6a0f21663770c446c3ba65576/armips-7885552b208493a6a0f21663770c446c3ba65576.tar.gz \
+	  https://github.com/hrydgard/miniupnp/archive/3a87be33e797ba947b2b2a5f8d087f6c3ff4d93e/miniupnp-3a87be33e797ba947b2b2a5f8d087f6c3ff4d93e.tar.gz \
+	  https://github.com/facebook/zstd/archive/a488ba114ec17ea1054b9057c26a046fc122b3b6/zstd-a488ba114ec17ea1054b9057c26a046fc122b3b6.tar.gz \
+	  https://github.com/hrydgard/ppsspp-ffmpeg/archive/a5baf97df4579b4614cd5e643241c7acfc36b0c4/ppsspp-ffmpeg-a5baf97df4579b4614cd5e643241c7acfc36b0c4.tar.gz"
+MD5SUM="1884395ddfd53cdfef869b454643774b \
+	939584490f40840c06301849a445e505 \
+	1338c24baf927d9ed170759370a0462c \
+	4731977e287eee39ddcc247d75095758 \
+	1b54e744eeeb42c444f4c07ff2cda6af \
+	d6a2ae6d5172aa8a64cd6898af9b476e \
+	b8c1813e193922663a58e751c1020fb4"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES=""
 MAINTAINER="Ruoh-Shoei LIN"
-EMAIL="lin.ruohshoei [at] gmail [dot] com"
+EMAIL="lin.ruohshoei+sbo [at] gmail [dot] com"


### PR DESCRIPTION
 - update archives of submodule, thanks for fourtysixandtwo's patch.
 - remove ppsspp-lang
 - add SYSTEM_FFMPEG(default off) option
 - default build with: headless, sdl