### PR TITLE
games/nestopia: Updated for version 1.51.1.

### DIFF
--- a/games/nestopia/README
+++ b/games/nestopia/README
@@ -8,12 +8,4 @@ A 1Ghz CPU and 128MB RAM are required to get the best performance.
 A Disk System BIOS (disksys.rom) is optional and, of course, not
 included. If you have one, put it in ~/.nestopia
 
-This builds both the standalone application and the Libretro core (for
-use with RetroArch). To use the Libretro core, one step is to copy the
-following file to your RetroArch BIOS directory:
-
-    /usr/share/nestopia/NstDatabase.xml
-
-Enable GTK GUI needs newer version of gtk3 (default GTK=no)
-
-GTK=yes ./nestopia.SlackBuild
+Since 1.51, nestopia need fltk from Slackware's /extra directory.

--- a/games/nestopia/doinst.sh
+++ b/games/nestopia/doinst.sh
@@ -1,9 +1,3 @@
 if [ -x /usr/bin/update-desktop-database ]; then
   /usr/bin/update-desktop-database -q usr/share/applications >/dev/null 2>&1
 fi
-
-if [ -e usr/share/icons/hicolor/icon-theme.cache ]; then
-  if [ -x /usr/bin/gtk-update-icon-cache ]; then
-    /usr/bin/gtk-update-icon-cache -f usr/share/icons/hicolor >/dev/null 2>&1
-  fi
-fi

--- a/games/nestopia/nestopia.SlackBuild
+++ b/games/nestopia/nestopia.SlackBuild
@@ -3,13 +3,32 @@
 # Slackware build script for Nestopia
 
 # Written by Dugan Chen (thedoogster@gmail.com)
-# Editd by RuohShoei LIN
+# Maintained by RuohShoei LIN
+
+# Copyright 2020-2022 RuohShoei LIN
+# All rights reserved.
+#
+# Redistribution and use of this script, with or without modification, is
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of this script must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+#  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+#  EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+#  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+#  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+#  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=nestopia
-LIBNAM=${PRGNAM}_libretro
-VERSION=${VERSION:-1.50}
+VERSION=${VERSION:-1.51.1}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -67,13 +86,6 @@ find -L . \
 
 autoreconf -vif
 
-# --enable-gui requires a newer GTK than what's in 14.2.
-GTK=${GTK:-no}
-case "$GTK" in
-    [yY]|[yY][eE][sS]) GTK="--enable-gui" ;;
-    *) GTK="--disable-gui" ;;
-esac
-
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 ./configure \
@@ -83,23 +95,18 @@ CXXFLAGS="$SLKCFLAGS" \
   --localstatedir=/var \
   --mandir=/usr/man \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
-  --build=$ARCH-slackware-linux \
-  --enable-doc \
-  $GTK
+  --build=$ARCH-slackware-linux
 
 make
 make install DESTDIR=$PKG
 
-make -C libretro
-
-install -Dm0644 libretro/$LIBNAM.so \
-  $PKG/usr/lib${LIBDIRSUFFIX}/libretro/$LIBNAM.so
-install -Dm0644 $CWD/$LIBNAM.info \
-  $PKG/usr/lib${LIBDIRSUFFIX}/libretro/info/$LIBNAM.info
-
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
+mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
+cp -a \
+  COPYING COPYRIGHT \
+  $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install

--- a/games/nestopia/nestopia.info
+++ b/games/nestopia/nestopia.info
@@ -1,10 +1,8 @@
 PRGNAM="nestopia"
-VERSION="1.50"
-HOMEPAGE="http://0ldsk00l.ca/nestopia/"
-DOWNLOAD="https://github.com/0ldsk00l/nestopia/archive/1.50/nestopia-1.50.tar.gz \
-          https://raw.githubusercontent.com/libretro/libretro-super/6043e5f/dist/info/nestopia_libretro.info"
-MD5SUM="09f24c934663d93b1266aa6e8afa4592 \
-        1813bb09acf63d4772e50adc4182d259"
+VERSION="1.51.1"
+HOMEPAGE="https://0ldsk00l.ca/nestopia/"
+DOWNLOAD="https://github.com/0ldsk00l/nestopia/archive/1.51.1/nestopia-1.51.1.tar.gz"
+MD5SUM="91cf4d844648be2455309557443a31e6"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES=""


### PR DESCRIPTION
 - remove libretro build
 - since 1.51, gui depend fltk instead of gtk3