### PR TITLE
python/pdfarranger: move to office/pdfarranger; adapted doinst.sh

### DIFF
--- a/python/pdfarranger/doinst.sh
+++ b/python/pdfarranger/doinst.sh
@@ -1,3 +1,9 @@
 if [ -x /usr/bin/update-desktop-database ]; then
   /usr/bin/update-desktop-database -q usr/share/applications >/dev/null 2>&1
 fi
+
+if [ -e usr/share/icons/hicolor/icon-theme.cache ]; then
+  if [ -x /usr/bin/gtk-update-icon-cache ]; then
+    /usr/bin/gtk-update-icon-cache -f usr/share/icons/hicolor >/dev/null 2>&1
+  fi
+fi


### PR DESCRIPTION
Hi Willy, could you please move pdfarranger to the 'office' category; it is a python3-based counterpart of pdfshuffler which lives there as well… Further, the doinst.sh has been adapted to also cater for icons. Thanks a lot.