### PR TITLE
python/python3-aiohttp: Remove gunicorn from DEPs

### DIFF
--- a/python/python3-aiohttp/python3-aiohttp.info
+++ b/python/python3-aiohttp/python3-aiohttp.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/5a/86/5f63de7a202550269a617a5d
 MD5SUM="faf7726dc65a940272874c0f441e8ec6"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="gunicorn async-timeout python3-attrs yarl aiosignal"
+REQUIRES="async-timeout python3-attrs yarl aiosignal"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu1@isaacyu1.com"


### PR DESCRIPTION
gunicorn is not a build or a runtime dependency for python3-aiohttp. 
Rather, gunicorn is an optional dependency - gunicorn is used for deploying the aiohttp web server.