### PR TITLE
development/rstudio-desktop: Update for 2022.02.2+485

### DIFF
--- a/development/rstudio-desktop/pandoc_version.patch
+++ b/development/rstudio-desktop/pandoc_version.patch
@@ -1,0 +1,14 @@
+This patch was taken from the Arch Linux AUR:
+https://aur.archlinux.org/cgit/aur.git/tree/pandoc_version.patch?h=rstudio-desktop
+diff -ur a/CMakeGlobals.txt b/CMakeGlobals.txt
+--- a/CMakeGlobals.txt	2022-03-18 10:10:38.000000000 +1300
++++ b/CMakeGlobals.txt	2022-04-28 10:46:17.695649880 +1200
+@@ -214,7 +214,7 @@
+ endif()
+ 
+ # pandoc version
+-set(PANDOC_VERSION "2.16.2" CACHE INTERNAL "Pandoc version")
++set(PANDOC_VERSION "current" CACHE INTERNAL "Pandoc version")
+ 
+ # quarto support
+ if(LINUX AND UNAME_M STREQUAL aarch64)

--- a/development/rstudio-desktop/rstudio-desktop.SlackBuild
+++ b/development/rstudio-desktop/rstudio-desktop.SlackBuild
@@ -27,11 +27,12 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rstudio-desktop
 SRCNAM=rstudio
-VERSION=${VERSION:-2022.02.1+461}
+VERSION=${VERSION:-2022.02.2+485}
 SRCVER=${SRCVER:-$(echo $VERSION | sed 's/+/-/g')}
-GITCOMMIT_VER=fc9e217
+GITCOMMIT_VER=8acbd38
 GWT_SDK_VER=${GWT_SDK_VER:-2.8.2}
 NODE_VER=${NODE_VER:-14.17.5}
+PANDOCVER=current
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -98,10 +99,11 @@ mkdir -p $LIB_DIR/gwt
 unzip -qo $GWT_SDK_ZIP -d $LIB_DIR/gwt
 mv $LIB_DIR/gwt/gwt-$GWT_SDK_VER $LIB_DIR/gwt/$GWT_SDK_VER
 
+# patches 
 patch -p1 < $CWD/sigstksz_gcc11.patch
+patch -p1 < $CWD/pandoc_version.patch     # Do not use outdated pandoc version number
 
 cd dependencies/common
-PANDOCVER=$(grep -oP "(?<=PANDOC_VERSION=\").*(?=\"$)" install-pandoc)
 mkdir -p pandoc/$PANDOCVER
 
 ln -sfT /usr/share/myspell/dicts dictionaries

--- a/development/rstudio-desktop/rstudio-desktop.info
+++ b/development/rstudio-desktop/rstudio-desktop.info
@@ -1,12 +1,12 @@
 PRGNAM="rstudio-desktop"
-VERSION="2022.02.1+461"
+VERSION="2022.02.2+485"
 HOMEPAGE="http://rstudio.com"
 DOWNLOAD="UNSUPPORTED"
 MD5SUM=""
-DOWNLOAD_x86_64="https://github.com/rstudio/rstudio/archive/refs/tags/v2022.02.1+461/rstudio-2022.02.1-461.tar.gz \
+DOWNLOAD_x86_64="https://github.com/rstudio/rstudio/archive/refs/tags/v2022.02.2+485/rstudio-2022.02.2-485.tar.gz \
                  https://storage.googleapis.com/gwt-releases/gwt-2.8.2.zip \
                  https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-x64.tar.gz"
-MD5SUM_x86_64="5ed749937d2413784418c9a87e398c21 \
+MD5SUM_x86_64="251b74238d69d3e08fb09af8287a74c7 \
                c295406d68c5ef364e445068599aa6d4 \
                3cd3b18e1412067aabd2e1b23b93106e"
 REQUIRES="R pandoc-bin yaml-cpp hunspell-en yarn apache-ant zulu-openjdk8 mathjax2 soci"


### PR DESCRIPTION
Add a pandoc_version patch as well.