### PR TITLE
academic/sage-bin: Fix .info.

### DIFF
--- a/academic/sage-bin/sage-bin.info
+++ b/academic/sage-bin/sage-bin.info
@@ -1,9 +1,9 @@
 PRGNAM="sage-bin"
 VERSION="9.4"
-HOMEPAGE="http://www.sagemath.org"
+HOMEPAGE="https://www.sagemath.org"
 DOWNLOAD="UNSUPPORTED"
 MD5SUM=""
-DOWNLOAD_x86_64="http://mirrors.mit.edu/sage/linux/64bit/sage-9.4-Debian_GNU_Linux_11-x86_64.tar.bz2 \
+DOWNLOAD_x86_64="https://mirrors.mit.edu/sage/linux/64bit/sage-9.4-Debian_GNU_Linux_11-x86_64.tar.bz2 \
 		 https://sourceforge.net/projects/slackbuildsdirectlinks/files/sage-bin/debian_binaries-11.2.tar.xz \
 		 https://sourceforge.net/projects/slackbuildsdirectlinks/files/sage-bin/debian_libraries-11.2.tar.xz"
 MD5SUM_x86_64="3128ef3530f514932cabcaf62b78030a \


### PR DESCRIPTION
Home page URL starts "https" as per https://repology.org/repository/slackbuilds/problems.
Also changed 1st download to start "https://mirrors.mit.edu" which matches network/openntpd but not academic/sage.