### PR TITLE
system/fish: Don't clobber printf and time man pages

### DIFF
--- a/system/fish/fish.SlackBuild
+++ b/system/fish/fish.SlackBuild
@@ -129,7 +129,7 @@ rm -rf $PKG/usr/share/man/
 gzip $PKG/usr/man/man*/*
 
 # Remove manual pages that overwrites coreutils' man pages
-rm -f $PKG/usr/man/man1/{echo,false,pwd,test,true}.1.gz
+rm -f $PKG/usr/man/man1/{echo,false,pwd,test,true,printf,time}.1.gz
 
 cp CHANGELOG.rst CONTRIBUTING.rst COPYING README.rst $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild


### PR DESCRIPTION
Not the maintainer, but I installed and uninstalled fish a while back, and these two man pages were still present afterwards (`time.1.gz` is from `man-pages` rather than `coreutils`, but I think it belongs here).