### PR TITLE
Fix indent spacing for terminado, testpath, threadpoolctl and traitlets

### DIFF
--- a/python/terminado/terminado.SlackBuild
+++ b/python/terminado/terminado.SlackBuild
@@ -84,11 +84,11 @@ find -L . \
 cat << EOF > setup.py
 from setuptools import setup, find_packages
 setup(name='${PRGNAM}',
-      version='${VERSION}',
-      packages=find_packages(),
-      package_data={'': ['*'], 'terminado': ['_static/*']},
-      install_requires=["ptyprocess;os_name!='nt'", "pywinpty>=1.1.0;os_name=='nt'", "tornado>=6.1.0"],
-      extras_require={'test': ['pytest']},
+    version='${VERSION}',
+    packages=find_packages(),
+    package_data={'': ['*'], 'terminado': ['_static/*']},
+    install_requires=["ptyprocess;os_name!='nt'", "pywinpty>=1.1.0;os_name=='nt'", "tornado>=6.1.0"],
+    extras_require={'test': ['pytest']},
 )
 EOF
 

--- a/python/testpath/testpath.SlackBuild
+++ b/python/testpath/testpath.SlackBuild
@@ -84,9 +84,9 @@ find -L . \
 cat << EOF > setup.py
 from distutils.core import setup
 setup(name='${PRGNAM}',
-      version='${VERSION}',
-      packages=['${PRGNAM}'],
-      package_data={'': ['*']})
+    version='${VERSION}',
+    packages=['${PRGNAM}'],
+    package_data={'': ['*']})
 EOF
 
 # With the shim, it's a good idea to use "unshare -n" to prevent downloading

--- a/python/threadpoolctl/threadpoolctl.SlackBuild
+++ b/python/threadpoolctl/threadpoolctl.SlackBuild
@@ -79,8 +79,8 @@ find -L . \
 cat << EOF > setup.py
 from distutils.core import setup
 setup(name='${PRGNAM}',
-      version='${VERSION}',
-      py_modules=['${PRGNAM}'],
+    version='${VERSION}',
+    py_modules=['${PRGNAM}'],
 )
 EOF
 

--- a/python/traitlets/traitlets.SlackBuild
+++ b/python/traitlets/traitlets.SlackBuild
@@ -88,12 +88,12 @@ here = os.path.abspath(os.path.dirname(__file__))
 pjoin = os.path.join
 packages = []
 for d, _, _ in os.walk(pjoin(here, 'traitlets')):
-   if os.path.exists(pjoin(d, '__init__.py')):
-      packages.append(d[len(here)+1:].replace(os.path.sep, '.'))
+    if os.path.exists(pjoin(d, '__init__.py')):
+        packages.append(d[len(here)+1:].replace(os.path.sep, '.'))
 setup(name='${PRGNAM}',
-      version='${VERSION}',
-      packages=packages,
-      package_data={'': ['*']},  
+    version='${VERSION}',
+    packages=packages,
+    package_data={'': ['*']},  
 )
 EOF
 


### PR DESCRIPTION
Within the python setup.py shim, each indent should be 4 spaces rather than 6 spaces.