### PR TITLE
audio/ncspot: Updated for version 0.10.0.

### DIFF
--- a/audio/ncspot/cargo-lock.patch
+++ b/audio/ncspot/cargo-lock.patch
@@ -1,0 +1,25 @@
+--- ncspot-0.10.0/Cargo.lock	2022-06-11 04:37:59.000000000 +0900
++++ ncspot-0.10.0/Cargo.lock.new	2022-06-11 14:47:18.366369428 +0900
+@@ -709,18 +709,18 @@
+ 
+ [[package]]
+ name = "enum-map"
+-version = "2.3.0"
++version = "2.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1284d66c2ebd284a159491ebc005c6608ef684f4f5db99c960b1837cb74b7067"
++checksum = "0348b2a57c82f98b9dbd8098b1abb2416f221823d3e50cbe24eaebdd16896826"
+ dependencies = [
+  "enum-map-derive",
+ ]
+ 
+ [[package]]
+ name = "enum-map-derive"
+-version = "0.9.0"
++version = "0.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "00d1c54e25a57236a790ecf051c2befbb57740c9b86c4273eac378ba84d620d6"
++checksum = "a63b7a0ddec6f38dcec5e36257750b7a8fcaf4227e12ceb306e341d63634da05"
+ dependencies = [
+  "proc-macro2",
+  "quote",

--- a/audio/ncspot/cargo-lock.patch
+++ b/audio/ncspot/cargo-lock.patch
@@ -1,7 +1,7 @@
 --- ncspot-0.10.0/Cargo.lock	2022-06-11 04:37:59.000000000 +0900
 +++ ncspot-0.10.0/Cargo.lock.new	2022-06-11 14:47:18.366369428 +0900
 @@ -709,18 +709,18 @@
- 
+
  [[package]]
  name = "enum-map"
 -version = "2.3.0"
@@ -12,7 +12,7 @@
  dependencies = [
   "enum-map-derive",
  ]
- 
+
  [[package]]
  name = "enum-map-derive"
 -version = "0.9.0"

--- a/audio/ncspot/doinst.sh
+++ b/audio/ncspot/doinst.sh
@@ -1,0 +1,9 @@
+if [ -x /usr/bin/update-desktop-database ]; then
+  /usr/bin/update-desktop-database usr/share/applications >/dev/null 2>&1
+fi
+
+if [ -e usr/share/icons/hicolor/icon-theme.cache ]; then
+  if [ -x /usr/bin/gtk-update-icon-cache ]; then
+    /usr/bin/gtk-update-icon-cache -f usr/share/icons/hicolor >/dev/null 2>&1
+  fi
+fi

--- a/audio/ncspot/ncspot.SlackBuild
+++ b/audio/ncspot/ncspot.SlackBuild
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Slackware build script for ncspot 
+# Slackware build script for ncspot
 
-# Copyright 2021-2022 K. Eugene Carlson  Tsukuba, Japan 
+# Copyright 2021-2022 K. Eugene Carlson  Tsukuba, Japan
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is

--- a/audio/ncspot/ncspot.SlackBuild
+++ b/audio/ncspot/ncspot.SlackBuild
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Slackware build script for ncspot
+# Slackware build script for ncspot 
 
-# Copyright 2021-2022 K. Eugene Carlson  Tsukuba, Japan
+# Copyright 2021-2022 K. Eugene Carlson  Tsukuba, Japan 
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=ncspot
-VERSION=${VERSION:-0.9.8}
+VERSION=${VERSION:-0.10.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -84,6 +84,9 @@ cd $TMP
 rm -rf $PRGNAM-$VERSION
 tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
 cd $PRGNAM-$VERSION
+
+# For cargo-1.58 incompatibilities
+patch -p1 < $CWD/cargo-lock.patch
 
 # build offline
 # configuration tells cargo to use the configured directory
@@ -148,8 +151,13 @@ CXXFLAGS="$SLKCFLAGS" \
 cargo build --release $CARGOTARGET $DRAWCOVER
 
 mkdir -p $PKG/usr/bin/
-
 find target -name $PRGNAM -exec install -m 755 {} $PKG/usr/bin/$PRGNAM \;
+
+mkdir -p $PKG/usr/share/applications
+install -m 644 misc/$PRGNAM.desktop $PKG/usr/share/applications/
+
+mkdir -p $PKG/usr/share/icons/hicolor/scalable/apps
+install -m 644 images/logo.svg $PKG/usr/share/icons/hicolor/scalable/apps/$PRGNAM.svg
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
@@ -160,6 +168,7 @@ cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc
+cat $CWD/doinst.sh > $PKG/install/doinst.sh
 
 cd $PKG
 /sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE

--- a/audio/ncspot/ncspot.info
+++ b/audio/ncspot/ncspot.info
@@ -1,19 +1,21 @@
 PRGNAM="ncspot"
-VERSION="0.9.8"
+VERSION="0.10.0"
 HOMEPAGE="https://github.com/hrkfdn/ncspot"
-DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
+DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.10.0/ncspot-0.10.0.tar.gz \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/addr2line/addr2line-0.17.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/adler/adler-1.0.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/aes/aes-0.6.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/aes-ctr/aes-ctr-0.6.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/aes-soft/aes-soft-0.6.4.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/aesni/aesni-0.10.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ahash/ahash-0.7.6.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/aho-corasick/aho-corasick-0.7.18.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/alsa/alsa-0.5.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/alsa/alsa-0.6.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/alsa-sys/alsa-sys-0.3.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/async-trait/async-trait-0.1.53.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/async-trait/async-trait-0.1.56.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/atty/atty-0.2.14.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/autocfg/autocfg-1.1.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/backtrace/backtrace-0.3.65.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/base-x/base-x-0.2.10.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/base64/base64-0.13.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/bindgen/bindgen-0.59.2.crate \
@@ -21,8 +23,8 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/block/block-0.1.6.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/block-buffer/block-buffer-0.9.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/block-buffer/block-buffer-0.10.2.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/bumpalo/bumpalo-3.9.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/bytecount/bytecount-0.6.2.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/bumpalo/bumpalo-3.10.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/bytecount/bytecount-0.6.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/byteorder/byteorder-1.4.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/bytes/bytes-1.1.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/cc/cc-1.0.73.crate \
@@ -32,8 +34,8 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/chrono/chrono-0.4.19.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/chunked_transfer/chunked_transfer-1.4.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/cipher/cipher-0.2.5.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/clang-sys/clang-sys-1.3.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/clap/clap-3.1.13.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/clang-sys/clang-sys-1.3.3.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/clap/clap-3.1.18.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/clap_lex/clap_lex-0.2.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/clipboard/clipboard-0.5.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/clipboard-win/clipboard-win-2.2.0.crate \
@@ -92,6 +94,7 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/futures-util/futures-util-0.3.21.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/generic-array/generic-array-0.14.5.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/getrandom/getrandom-0.2.6.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/gimli/gimli-0.26.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/glob/glob-0.3.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/h2/h2-0.3.13.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/half/half-1.8.2.crate \
@@ -102,20 +105,20 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/heck/heck-0.4.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/hermit-abi/hermit-abi-0.1.19.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/hmac/hmac-0.11.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/http/http-0.2.7.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/http-body/http-body-0.4.4.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/http/http-0.2.8.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/http-body/http-body-0.4.5.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/httparse/httparse-1.7.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/httpdate/httpdate-1.0.2.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/hyper/hyper-0.14.18.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/hyper/hyper-0.14.19.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/hyper-proxy/hyper-proxy-0.9.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/hyper-tls/hyper-tls-0.5.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ident_case/ident_case-1.0.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/idna/idna-0.2.3.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/indexmap/indexmap-1.8.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/indexmap/indexmap-1.8.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/instant/instant-0.1.12.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ioctl-rs/ioctl-rs-0.2.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ipnet/ipnet-2.5.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/itoa/itoa-1.0.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/itoa/itoa-1.0.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/jni/jni-0.19.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/jni-sys/jni-sys-0.3.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/jobserver/jobserver-0.1.24.crate \
@@ -123,7 +126,7 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/lazy_static/lazy_static-1.4.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/lazycell/lazycell-1.3.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/lewton/lewton-0.10.2.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/libc/libc-0.2.125.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/libc/libc-0.2.126.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/libdbus-sys/libdbus-sys-0.2.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/libloading/libloading-0.7.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/libm/libm-0.2.2.crate \
@@ -131,13 +134,13 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/libpulse-simple-binding/libpulse-simple-binding-2.25.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/libpulse-simple-sys/libpulse-simple-sys-1.19.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/libpulse-sys/libpulse-sys-1.19.3.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-audio/librespot-audio-0.3.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-core/librespot-core-0.3.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-metadata/librespot-metadata-0.3.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-playback/librespot-playback-0.3.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-protocol/librespot-protocol-0.3.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-audio/librespot-audio-0.4.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-core/librespot-core-0.4.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-metadata/librespot-metadata-0.4.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-playback/librespot-playback-0.4.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/librespot-protocol/librespot-protocol-0.4.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/lock_api/lock_api-0.4.7.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/log/log-0.4.16.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/log/log-0.4.17.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/mac-notification-sys/mac-notification-sys-0.5.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/mach/mach-0.3.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/malloc_buf/malloc_buf-0.0.6.crate \
@@ -148,8 +151,8 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/memoffset/memoffset-0.6.5.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/mime/mime-0.3.16.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/minimal-lexical/minimal-lexical-0.2.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/mio/mio-0.8.2.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/miow/miow-0.3.7.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/miniz_oxide/miniz_oxide-0.5.3.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/mio/mio-0.8.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/native-tls/native-tls-0.2.10.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ncurses/ncurses-5.101.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ndk/ndk-0.6.0.crate \
@@ -157,12 +160,10 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ndk-glue/ndk-glue-0.6.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ndk-macro/ndk-macro-0.3.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ndk-sys/ndk-sys-0.3.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/nix/nix-0.20.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/nix/nix-0.22.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/nix/nix-0.23.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/nom/nom-7.1.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/notify-rust/notify-rust-4.5.8.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/ntapi/ntapi-0.3.7.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/num/num-0.2.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/num/num-0.4.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/num-bigint/num-bigint-0.2.6.crate \
@@ -174,35 +175,39 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/num-iter/num-iter-0.1.43.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/num-rational/num-rational-0.2.4.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/num-rational/num-rational-0.4.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/num-traits/num-traits-0.2.14.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/num-traits/num-traits-0.2.15.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/num_cpus/num_cpus-1.13.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/num_enum/num_enum-0.5.7.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/num_enum_derive/num_enum_derive-0.5.7.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/num_threads/num_threads-0.1.5.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/num_threads/num_threads-0.1.6.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/numtoa/numtoa-0.1.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/objc/objc-0.2.7.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/objc-foundation/objc-foundation-0.1.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/objc_id/objc_id-0.1.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/object/object-0.28.4.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/oboe/oboe-0.4.6.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/oboe-sys/oboe-sys-0.4.5.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ogg/ogg-0.8.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/once_cell/once_cell-1.10.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/once_cell/once_cell-1.12.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/opaque-debug/opaque-debug-0.3.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/openssl/openssl-0.10.38.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/openssl/openssl-0.10.40.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/openssl-macros/openssl-macros-0.1.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/openssl-probe/openssl-probe-0.1.5.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/openssl-sys/openssl-sys-0.9.72.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/openssl-sys/openssl-sys-0.9.74.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/os_pipe/os_pipe-1.0.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/os_str_bytes/os_str_bytes-6.0.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/os_str_bytes/os_str_bytes-6.1.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/owning_ref/owning_ref-0.4.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/pancurses/pancurses-0.17.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/parking_lot/parking_lot-0.11.2.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/parking_lot/parking_lot-0.12.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/parking_lot_core/parking_lot_core-0.8.5.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/parking_lot_core/parking_lot_core-0.9.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/parse_duration/parse_duration-2.1.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/pbkdf2/pbkdf2-0.8.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/pdcurses-sys/pdcurses-sys-0.7.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/peeking_take_while/peeking_take_while-0.1.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/percent-encoding/percent-encoding-2.1.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/petgraph/petgraph-0.6.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/petgraph/petgraph-0.6.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/pin-project-lite/pin-project-lite-0.2.9.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/pin-utils/pin-utils-0.1.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/pkg-config/pkg-config-0.3.25.crate \
@@ -210,10 +215,10 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/portaudio-rs/portaudio-rs-0.3.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/portaudio-sys/portaudio-sys-0.1.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ppv-lite86/ppv-lite86-0.2.16.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/priority-queue/priority-queue-1.2.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/priority-queue/priority-queue-1.2.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/proc-macro-crate/proc-macro-crate-1.1.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/proc-macro-hack/proc-macro-hack-0.5.19.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/proc-macro2/proc-macro2-1.0.37.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/proc-macro2/proc-macro2-1.0.39.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/protobuf/protobuf-2.27.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/protobuf-codegen/protobuf-codegen-2.27.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/protobuf-codegen-pure/protobuf-codegen-pure-2.27.1.crate \
@@ -227,36 +232,37 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/redox_syscall/redox_syscall-0.2.13.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/redox_termios/redox_termios-0.1.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/redox_users/redox_users-0.4.3.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/regex/regex-1.5.5.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/regex-syntax/regex-syntax-0.6.25.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/regex/regex-1.5.6.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/regex-syntax/regex-syntax-0.6.26.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/remove_dir_all/remove_dir_all-0.5.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/reqwest/reqwest-0.11.10.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ring/ring-0.16.20.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/rodio/rodio-0.14.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/rodio/rodio-0.15.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/rspotify/rspotify-0.11.5.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/rspotify-http/rspotify-http-0.11.5.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/rspotify-macros/rspotify-macros-0.11.5.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/rspotify-model/rspotify-model-0.11.5.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/rustc-demangle/rustc-demangle-0.1.21.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/rustc-hash/rustc-hash-1.1.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/rustc-serialize/rustc-serialize-0.3.24.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/rustc_version/rustc_version-0.2.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/rustc_version/rustc_version-0.4.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/rustls/rustls-0.20.4.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/rustls/rustls-0.20.6.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/rustversion/rustversion-1.0.6.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/ryu/ryu-1.0.9.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/ryu/ryu-1.0.10.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/same-file/same-file-1.0.6.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/schannel/schannel-0.1.19.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/schannel/schannel-0.1.20.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/scopeguard/scopeguard-1.1.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/sct/sct-0.7.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/security-framework/security-framework-2.6.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/security-framework-sys/security-framework-sys-2.6.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/semver/semver-0.9.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/semver/semver-1.0.7.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/semver/semver-1.0.10.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/semver-parser/semver-parser-0.7.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/serde/serde-1.0.136.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/serde/serde-1.0.137.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_cbor/serde_cbor-0.11.2.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_derive/serde_derive-1.0.136.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_json/serde_json-1.0.80.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_derive/serde_derive-1.0.137.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_json/serde_json-1.0.81.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/serde_urlencoded/serde_urlencoded-0.7.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/sha-1/sha-1-0.9.8.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/sha-1/sha-1-0.10.0.crate \
@@ -266,7 +272,7 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/shannon/shannon-0.2.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/shell-words/shell-words-1.1.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/shlex/shlex-1.1.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/signal-hook/signal-hook-0.3.13.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/signal-hook/signal-hook-0.3.14.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/signal-hook-registry/signal-hook-registry-1.4.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/slab/slab-0.4.6.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/smallvec/smallvec-1.8.0.crate \
@@ -285,15 +291,16 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/strum_macros/strum_macros-0.22.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/strum_macros/strum_macros-0.24.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/subtle/subtle-2.4.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/syn/syn-1.0.92.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/syn/syn-1.0.96.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/synstructure/synstructure-0.12.6.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/tempfile/tempfile-3.3.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/term_size/term_size-0.3.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/termcolor/termcolor-1.1.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/termion/termion-1.5.6.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/textwrap/textwrap-0.15.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/thiserror/thiserror-1.0.30.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/thiserror-impl/thiserror-impl-1.0.30.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/thiserror/thiserror-1.0.31.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/thiserror-impl/thiserror-impl-1.0.31.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/thread-id/thread-id-4.0.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/time/time-0.1.44.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/time/time-0.2.27.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/time/time-0.3.9.crate \
@@ -301,29 +308,28 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/time-macros-impl/time-macros-impl-0.1.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/tinyvec/tinyvec-1.6.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/tinyvec_macros/tinyvec_macros-0.1.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio/tokio-1.18.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio-macros/tokio-macros-1.7.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio/tokio-1.19.2.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio-macros/tokio-macros-1.8.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio-native-tls/tokio-native-tls-0.3.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio-stream/tokio-stream-0.1.8.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio-util/tokio-util-0.6.9.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio-util/tokio-util-0.7.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio-stream/tokio-stream-0.1.9.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/tokio-util/tokio-util-0.7.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/toml/toml-0.5.9.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/tower-service/tower-service-0.3.1.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/tracing/tracing-0.1.34.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/tracing-attributes/tracing-attributes-0.1.21.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/tracing-core/tracing-core-0.1.26.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/tracing/tracing-0.1.35.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/tracing-core/tracing-core-0.1.27.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/tree_magic_mini/tree_magic_mini-3.0.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/try-lock/try-lock-0.2.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/typenum/typenum-1.15.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-bidi/unicode-bidi-0.3.8.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-ident/unicode-ident-1.0.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-normalization/unicode-normalization-0.1.19.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-segmentation/unicode-segmentation-1.9.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-width/unicode-width-0.1.9.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-xid/unicode-xid-0.2.2.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/unicode-xid/unicode-xid-0.2.3.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/untrusted/untrusted-0.7.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/ureq/ureq-2.4.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/url/url-2.2.2.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/uuid/uuid-0.8.2.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/uuid/uuid-1.1.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/vcpkg/vcpkg-0.2.15.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/vergen/vergen-3.2.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/version_check/version_check-0.9.4.crate \
@@ -350,10 +356,16 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-util/winapi-util-0.1.5.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/windows/windows-0.24.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/windows-sys/windows-sys-0.36.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.36.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/windows_i686_gnu/windows_i686_gnu-0.24.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/windows_i686_gnu/windows_i686_gnu-0.36.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/windows_i686_msvc/windows_i686_msvc-0.24.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/windows_i686_msvc/windows_i686_msvc-0.36.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.24.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.36.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.24.0.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.36.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/winreg/winreg-0.5.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/winreg/winreg-0.10.1.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/winrt-notification/winrt-notification-0.5.1.crate \
@@ -362,21 +374,23 @@ DOWNLOAD="https://github.com/hrkfdn/ncspot/archive/v0.9.8/ncspot-0.9.8.tar.gz \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/xcb/xcb-0.8.2.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/xi-unicode/xi-unicode-0.3.0.crate \
           https://crates-io.s3-us-west-1.amazonaws.com/crates/xml-rs/xml-rs-0.8.4.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/zerocopy/zerocopy-0.3.0.crate \
-          https://crates-io.s3-us-west-1.amazonaws.com/crates/zerocopy-derive/zerocopy-derive-0.2.0.crate"
-MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/zerocopy/zerocopy-0.6.1.crate \
+          https://crates-io.s3-us-west-1.amazonaws.com/crates/zerocopy-derive/zerocopy-derive-0.3.1.crate"
+MD5SUM="c430461a993c2fde6781a9eb8431de74 \
+        c4c6ae55973b5054bf10f574fe49317f \
+        669215548c64019c08c92b2c1afd3deb \
         bd53a9f0ec43690f84e8c96bba8e538d \
         db6f9a586bda62de931be1b2bce9cd34 \
         b14b12cd0e866930de1993132c85705b \
         58a6326364dbe6f5168f3f3a341f360e \
         7d2520c6776b66559165d0a666e995ff \
         425b8fdf70df59998d9b7c89083e48d1 \
-        fce951b34a5c1b8edb8c104987637fd3 \
         bd278d96770173a5298bea9ebdba03f7 \
         730ff1a5c2f3becc07743810ad47e66e \
-        bf0b0b400310197651da77a525526e82 \
+        449a5d837917df1680d641b541664cbc \
         142cb4b9a653e56e56311f0c883b8582 \
         05d77ef52e90ad161fdd41b252420467 \
+        b47959c03cf9213e50a15ab86090c9d9 \
         80b445001cdf9afc955e1ccf557e6153 \
         80a2c27647a6acb1890a3a7de8fded72 \
         51cef6d77ce79c186bcd69779376c03b \
@@ -384,8 +398,8 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         ea2d23ceb9f98853a7dffc6c02884464 \
         c7fbaf61245dc847237ab7c72b3ee9ea \
         2d4d81d5a0b77bd9e7a88a728bfb9bfc \
-        79173170388e20507a241b355ef521e3 \
-        6ab4bc6dbea118709e05033cdf05d6dd \
+        67b7cc02856cad7f081e9dc0d8a74427 \
+        389fdc843f52c6ae84519f4592bd6780 \
         1e704be5ddde9d6b5383ef1035309f91 \
         df3ac16302a9dd29508eda92aa402a9b \
         8e3a4d0980acef2c4e74485a45de29a9 \
@@ -395,8 +409,8 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         1581b390d17f6e73a43ffc8a7b009e57 \
         1f145acaad7dce34cd8c820655b99933 \
         5184822d3fd9f30dfa4bc922ffa4143c \
-        ad93a9f51606d9d5eba5c8c057a14f14 \
-        06e606e0e6c6c1c1c97f65287179c209 \
+        f3eb3c26c84733d06a9d4ba181d4dc06 \
+        a7d2140f1c0165b6282e435d2082854b \
         35e379582134753cca7735abca4cb92f \
         7aa34fd63d9334802314b4305c78021a \
         eb6e4217d79aefec36a4d1068b4ae278 \
@@ -455,6 +469,7 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         8071e8e030bee77619611dbb4e508864 \
         4824dbe307f1d20e74a4ebad2b7e4d6e \
         8a9e0a43625da8d29c57e742c4d3d385 \
+        ac4775c8640cd2c698e1639e7cd6e788 \
         e7c07242a95ee1df865efe9534e10a34 \
         576e03703c56261f14e5aeccfba0b4c9 \
         fea840ce07a32bdace46c59c41362f3b \
@@ -465,20 +480,20 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         4fd75413081a400a1c230f0700732611 \
         0b7994d1256215201bdfb810a357ffa2 \
         656eb112c9634812796a81803b04a3e6 \
-        faae9d595fd99faa52abe8e1059b01e9 \
-        e685b43c1f198999c125bc7bbe084ab3 \
+        5a454a33646271c81e6b2f70e8ca1b83 \
+        c21c16e3bdc619cf65a31b23136d62ce \
         c1784ff333f8e33380c087208e1b42ff \
         4918da28fbc2f6888ad71c159996a9b5 \
-        788a9b419ae36cde8db79117dc8cbba9 \
+        74837c8570567d6b63e9c217a73a96a7 \
         31667fab2083c342c85bb51c2cba6d58 \
         6540f0c2d7dce570f06661292fc68cab \
         fe77a3f609b6fd8d5b08f3b2ef14d2ad \
         f50aaf5171cbc0327f8d18a4ec7405fb \
-        2db2b6694ada626b1a2c328e99ad971a \
+        4aa525c71ec0e2bf650c1e1f1af0de22 \
         5f153f7135dceb02f88266121c836b4e \
         916bae8326e21f1d60fa9cba2b7dfbcb \
         d1ec0fbb99abe45e73d651418496b08b \
-        5c98b89b530b563b6e5f6e1b631c4b35 \
+        dfd1e3e07982e8245a772e6e63e5c4bc \
         b30ef1414dde99d96e89aeea2b3fc094 \
         73272fe4aadb91d550dca8fc7ead8bf7 \
         3aefa31e8413112958290a6ca004b096 \
@@ -486,7 +501,7 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         fba3b040a55c01be7376d3dd5c4d4920 \
         23cc9e52c52465f5b225e62ab7cc3457 \
         d3d110551104b00b42c9920958939391 \
-        e83dc3dbd3de1f5f2b4b248c521eeaec \
+        c58d450f13e76e4a034fde8f20710266 \
         b572f0c3d1144e7c35dcdfd4f08913f8 \
         a087f8a5947ecf4e734ac9cfe695469c \
         0764d84de2302fda8d1d72b95f31a0b8 \
@@ -494,13 +509,13 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         d07af7d3cab8ed749a8310a89be6b1ff \
         4ba60e706b5e69a88192ff773b27a229 \
         58d0064087bc800cf6ee10d667651491 \
-        2721e88844fd0335095f7e99df1ebbb9 \
-        e85f829193ea1afa080dcff7f77cf945 \
-        9e3ea187f6e3f01e3c9590782c744b3e \
-        c000dfa6a77a58ede02be41418056bf3 \
-        9e0bf233b47424b8449a928bd31a1470 \
+        aff9d61edeb9a53144e0a58cd6cf68c0 \
+        99468393d29c63b1787201aa22f2c3e4 \
+        fa0a15e8fe050620612798d7930d1436 \
+        34bad08297667d4500eff240dcafd870 \
+        a5aa9fd7453596e70f7fd4699f1b9153 \
         1c1e406fe68d3223a6c58e9c1987b6ce \
-        347ff775f67cc930e0b2f7e9851d9c7e \
+        b31bf94ffe7e0f2ada93afae1076eaeb \
         6ae49429a14a9251e6ddb162c95a7637 \
         7b3195612bc6090f0fa759e747a9e91c \
         7c81e7a61ec172a229d6fdbc553e883d \
@@ -511,8 +526,8 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         76124c2327f642cddf19a4aa50cbcb7d \
         a362e890dd0dfe51ecd95a4a1be6e28c \
         8b708bc4b33c5e1683467444c9ed41b0 \
-        3143984e54dc6fa6871ebb62060d3448 \
-        4604959975c2154a14f6b5e97444e2c8 \
+        4b343c4628bdfa094b2bb027d7853561 \
+        110b5ea3d4fc1e9bb304e74f7a3165ee \
         83c88f2bd69c44122955bf94ad9377a1 \
         81f3d69af8142596468325954a52dea3 \
         1a6e77e2f6f916ef7a5a9481ed426b76 \
@@ -520,12 +535,10 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         5f5168cd7b4aad8ae68f4d1e32a1e0e2 \
         97b832ecaac0eee2b644fd42f2931160 \
         b235f97b3139681d61419166e7c00e3c \
-        2e504fc2b79dc46f983c960e30be1702 \
         00182a0bd2b30bb3694008ba56adadcb \
         675fcfdbc94cd10b26b71965d3c3807b \
         b4f83cacd53b7dc0d12ba582d27cbc1a \
         4d68eee026543542bc58bb8dee526969 \
-        0650ea82267b13e7dcf3841ac2624a86 \
         d69aa359a9e7dd2d67a7b7712e30a19e \
         1081c01b2d9b17a33c3d0156193be592 \
         6b1db46a36bc0dc590270d2c952d30c4 \
@@ -537,35 +550,39 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         44ef8a2279dadf391881a69c60d29197 \
         99e024622d98dc28a8a5f37afccaf20a \
         0cd34d83344babdcb0aa123b5e672182 \
-        c0e036fd990d0c9cae11b5876a5cb572 \
+        a0de6eabdeb1320350abcbd7c02df6ac \
         c5e50e299295e662ad19c58428d6e085 \
         e0fb2ffb3e0dea049696adbdddfbc670 \
         d7a0654f358557755dc7b8a58b553c29 \
-        fe7687027106fe205fd7945d9f4b8a1b \
+        ae2471729f689287aec9da43f8106a4b \
         bbda7e9c572f651774dfdb0006b9f085 \
         b4dcac855af5df71f3383d86c4a96b78 \
         aecd889de42c8168e1bc97a6f2720d8f \
         fd9aa273ad560dedd00ddcf3dbe808ce \
+        382e93f458f75ba7fa3dc1ab0f4294eb \
         980c225025b646fa54a9450d22688ad0 \
         af692853d165edb9c5df23627b2f8e04 \
         e460418ee4f5508bc53c97e809331882 \
-        0a56079b59a262a80e33d13e6604cc4e \
+        d2898eb94e8ec220fa09df7fa0ebb692 \
         653e04baa68a4484b3b839c19221e474 \
-        a1688f08e7a5cb1b03d10d62ba17b43b \
+        1babe6b3077bea6540b8fb5ecaadc255 \
+        73212ff5e0f8cd8844081a2461393707 \
         907244c0d3791f3f981c7cc8e4cad0a3 \
-        50bcf9c0d46f49e8fdbbe9ffa1a73c56 \
+        096fb86ba1404393413cc933ed39bf0d \
         52c2dce84094bc11d1feb9b61f5e8e8c \
-        8ee1436104d86d91d56bafc3b0322e4f \
+        ceb4ba55f783e6834b6914f56f451d0e \
         6fb245ba04d6859fadef5fe22806355b \
         ef6fc33d718cd6aa793a60f884d62611 \
         12e4ba5909e1f30b9142932571eaa4da \
+        1be45f99109d447849f4244b58c5a470 \
         233dee08f26c9cbe78f29b66c0c20ccd \
+        f3c211bc33fcf71ca981d02f9fa2813c \
         d27d4ebe09da25387352db8f3621fc40 \
         cf2f0435bd5b5111fea46e8d9dc6522d \
         fbb87d3e5015e2ac193545f18bc5d20f \
         7e264bc8f23a45ad680668cb5e57d9fd \
         f490982aceabdbd515348f63e638a782 \
-        4d0ff178d60b687baab415e6919f3373 \
+        e940d7307f0c3c3273dbd91f92b50ce8 \
         ce6dde2ea2691fdd97632fb8c9b3e042 \
         07c75fec267864bcbb800ca7709ceae2 \
         b478ee84018082806ea8da763f0b3f1f \
@@ -573,10 +590,10 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         1262dd2afb9bbb47b9075ead3102da9e \
         ec96d03983725371e10bd4dad4fdd232 \
         ae91c97885d67994a342820cf7d59fb2 \
-        d6291d0e18f55b8364b36a7f5e1af699 \
+        f928d1a5d88f85979fa0e3a1a36dfe06 \
         9ca09a08411defb5fab6b9467d208ce0 \
         c7c38eb603bed6f42edbc4294806a44a \
-        11034ad82271b27907c7f970374864ef \
+        a081866d627a3feb598df6960be8adc8 \
         256e8677308aa17acc8c82b54d8a4fae \
         1810d970f84683a419d7b9aa6740f8a6 \
         aca51d2a40262bfd8e69fbf6b2b01ed2 \
@@ -590,36 +607,37 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         2e69b77050ab91b1d0bb941e843a05cb \
         c5b23985f2b07389edcda3900fc8a751 \
         2793ed3e6807d79ff72271baec586531 \
-        6b5c7401117316735435311bf551515b \
-        82401c70623ccc1bfc0bcb5c3b0ac8b7 \
+        8cfc5b8dac188c6b4b790175902df1bc \
+        c3789f11772f0c40ad7cc1f6e4b7bf2c \
         0538d1da369f3e3f0412aa4d735c1b61 \
         21990b71d50e2a25c55a99f5ac7ba951 \
         17462a66e5dda514a57afefa0295d8f0 \
-        4ac453abdecd6346f92989b4f789ac84 \
+        ee620998fafcd5665f24897e37c0d57e \
         c0d0de72a13afcad01d8cb4f8bd778e1 \
         fde4b7b02f2bafd493f8979688c2c3ac \
         ea68ecfc493dfb1ae1b7d41f31f8df65 \
         640a669efe0e5e85f777302e68382f26 \
+        6eb014e73f66bc13226e0ef6d815d375 \
         7b1261ea730a9314bc9bcdf4a379bf98 \
         5e4ad69737043efed21e99c959727ef5 \
         4d101ab24d14c54937c5f45ece8fad5f \
         fdf3aa5e1f6c33e4f68b0f7b08e1e94e \
-        b3d6c4d660f8e4406e25f32aa4e0c326 \
+        d7d853163d2a0246919fdb37753f68a2 \
         7f5968a4b096a6441764934c8df4438f \
-        7fe15f165a1812b23e5b1980aa364de2 \
+        23851f50f90a08187e6587bbb8fb76ce \
         2d8d8b377d144f5e32b4f65a69eb0b24 \
-        f505a218806e44b2369671089d65e839 \
+        47a2e9a3f22a0199c7f8292f43d5fa3d \
         b4a0a98a54439a5a37952c8879187ee3 \
         97925b5e8882e9af3c54753eb0184ce4 \
         4b09fe533b3580ace8ae485a477b4532 \
         ffbaf84e19c894443b584605e668b6ea \
         64111c20b69aa1532fb66b70c4660b55 \
-        94d442b9a8dad7bd56a51644cab96755 \
+        c1ce9a606f286b2a3b7d885046d47ecb \
         8b4d8c7b6e3a060d365bc1ad650929fa \
-        c8ae0dd2469d51f273abdbfb24adceac \
+        31553e8c2d0d2f2e7474cc48a03337d8 \
         30f8c7ce8e7a3a98039d34a07556435d \
-        7c532e05dc3b2bd295136a297260c4dc \
-        eb5315425cfac8638ba8168682c99dab \
+        3d3fef13feb53a62c0f434a092f526bf \
+        78187fa5db3eb2eeba6d865363ad1a40 \
         47151b766b6b73e638fabe6fae7b723d \
         82078b82ed1c52aac9552a39ead691a0 \
         b4f91f8bac0c0d47b85ca04e6b69255d \
@@ -629,7 +647,7 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         31bc883e6f9b36925f55460401197274 \
         ce622fdb8d18cd1c13ed8fadc5400c10 \
         0bfb08b9dd5df72ba5ed7d74dd5fe6eb \
-        b077f27c741a438d0a7a474a41e22a62 \
+        8532a59ccbacb95018a128b2d7b2601a \
         21b43d5721b3a9c16059acb691f4314d \
         be6b7845e52831416901caba0b97a360 \
         6249245cf12427da0a4f37bc3d294ff4 \
@@ -648,15 +666,16 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         5b80104a258d778b74583757a3a5d43c \
         bb16e7b2b05136600fdd453c99d854c6 \
         8e053c23f1d36fbf3f276fbf501e3e35 \
-        8b3ee9107af33d280d42485282f7c4a6 \
+        751491de7145e350a774641391c49e66 \
         8f6b6cc71be0473b79c65abfea592c07 \
         f29a1bb1b5f3f29cedb36f40f720d765 \
         73d602cc41e3e431bf4fabd129ae1616 \
         40ce77bc7803d0ff8734f6a11c4e8814 \
         5e7f9a17d31e264f87d3e14b85d7da3f \
         7bfb933cd096d342c9d6f77f5d3c4b94 \
-        cc180843b3b626ede01ebd9a0d9fbdaa \
-        3e61457993a6e3fdaaf2fbe82bd7dff3 \
+        a8ae09f39c6e68744ca70bf8db61df71 \
+        ac76b35d8c76c7fa25c73b8863d5d055 \
+        66345b13fd97229fefe61ba6457dfe66 \
         c6c50e4feea5f4cc4e1fb3c7e88606a5 \
         ea1d6cb5bae32581bf49dc8fe44e76e7 \
         ad3f3c7bb184e63919b633dc35805cf4 \
@@ -664,29 +683,28 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         80e8c99ee71404715887fc65fdb1bbd0 \
         5f0470696baaa4e5953bddbf196998f9 \
         7bfcad253aff26bc26c5e3521f3ba891 \
-        2a473165b2d315381674537a430206aa \
-        64c940cf10c49b34761e1a4dbf2b023f \
+        24088a366d553724adafdc0db6adddda \
+        45273943465d6fc2a3f8bf282460508a \
         5b6b7a1faf12d38ce800162fd5236f57 \
-        97aab350fb2614818580f00d1fb284ad \
-        3b23aa9eb619cbfd68d96719db904597 \
-        4d1e9706415df3ab38e4ebe841c4feee \
+        5af6f23ddc5761b8e8becc9f3514c113 \
+        f4685e02b86d7559259b1e41ae9b11c8 \
         b02f8aae39609bfe759838fbe0616c1a \
         519bfbdd19531f1d7b775bfa7ce4ee80 \
-        c1354e5b35b7dc25b94e7d1433257ec7 \
-        c794d7a6ccc134f547ee0afb5f239dbd \
-        69e69b855333b1e7f3dd36f0eff7b99b \
+        627a40c8adb895809c18a05a780ab7a3 \
+        cc63e9933c65eada212c3baa5fcc5ed1 \
         bd5c630b1c9e06074ea101f5133c26ed \
         e876964c7b83db85fb7897bee7ad0f45 \
         7b38b145ae3f6d7d09a1a7a98396f1a2 \
         bd0cd532c61dac2087ecd7e0fef0d011 \
+        1415b48fcebe79916396ef3383ef9b3a \
         10291d9a0022076bc0827250816d3476 \
         2e8e0a121121087295e708b2eb4b54d5 \
         a42cc2834b2150027d7b427558a87803 \
-        087bfc476e9d73628cebd265590f11f7 \
+        763a3a6901bbb11a6998d29867d39b3c \
         240cfb5665ad3457b28bcdc139393e6d \
         276cb054ab4cf02534f3558a52e667d6 \
         eb721c4d9e5dba8f93e9de0a80036ec3 \
-        43f743c17293ad2404a9a4967f4e570b \
+        d5c9fc84c532e42f148d7f9b9982230f \
         e900a384ac7dbb320fe6a7279fbfef89 \
         c4769705079e88d68739e6089e8769a3 \
         d18d362345c4fe512ef67b738b239fb8 \
@@ -713,10 +731,16 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         b9e37d5fc4ad28b612b78ad37816684d \
         09de9d01e7331ff3da11f58be8bef0df \
         e31804b340a314ddf9af85dd53b43eb9 \
+        b3083009944ab58cbd9c4941f4965545 \
+        776128629d743f0d6127db259a0d8844 \
         b5a8bbd50068e8c2785085df048824f1 \
+        7f60b76e78bd2a190cf3ddc2b4c4920b \
         b26bee7254adb23b0d6fd2ca62c2c546 \
+        ce798410cba61fe713f3487cd6cafef4 \
         b4b7f1878c10aeffc51209a7f4c5d517 \
+        f55176d04297df9dd5ccae7c748e26c7 \
         a9a0f02bf85a0bcd1cd71d2787152da7 \
+        8e285ddee403a9abe62d6fe2bfbb736a \
         d9c86ac3f5060d384d3a4c3f99fdadeb \
         8aa3cbf525ad9e68c3619664a3401dbe \
         595f25a8a38b505cdb231f8cf0a02078 \
@@ -725,8 +749,8 @@ MD5SUM="2036efbb31d80f9714dd28d1933fb90b \
         aa21a0ccffbd119424b5ab3b14a1d753 \
         a78d9b7d812b68bc4b27b4f23d46ced1 \
         430f3d28d1407a31b3347ec9ec9ebf03 \
-        7a5233ce3372d0ac3adc2c85f616e3ad \
-        338a919a7f8b6a7b1eb23272a2b7a237"
+        2af5c75a55a2e46662c060100d5c3222 \
+        fc9aaeab86439522f816869aac997098"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="%README%"


### PR DESCRIPTION
The author decided to push one of his crate dependencies to something requiring `rust-1.61`. `Cargo.lock` can be patched for the time being, but a version freeze might be needed eventually.