### PR TITLE
development/rstudio-desktop: Use bundled node

### DIFF
--- a/development/rstudio-desktop/rstudio-desktop.SlackBuild
+++ b/development/rstudio-desktop/rstudio-desktop.SlackBuild
@@ -33,7 +33,7 @@ GITCOMMIT_VER=8acbd38
 GWT_SDK_VER=${GWT_SDK_VER:-2.8.2}
 NODE_VER=${NODE_VER:-14.17.5}
 PANDOCVER=current
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -113,9 +113,13 @@ mkdir -p node
 cd node && tar xvf $CWD/node-v$NODE_VER-linux-x64.tar.gz
 cd ../
 mv node/node-v$NODE_VER-linux-x64 node/$NODE_VER
+export PATH=$TMP/$SRCNAM-$SRCVER/dependencies/common/node/$NODE_VER/bin:$PATH     # use bundled node
 cd $TMP/$SRCNAM-$SRCVER/src/gwt/panmirror/src/editor
-yarn config set ignore-engines true
-yarn install
+
+# Prevent creation of cache files in /usr/local/share/
+env YARN_DISABLE_SELF_UPDATE_CHECK=true \
+  YARN_CACHE_FOLDER=$TMP/$SRCNAM-$SRCVER/cache/yarn \
+  yarn install --ignore-engines
 
 # Fix links for src/cpp/session/CMakeLists.txt
 cd $TMP/$SRCNAM-$SRCVER/dependencies
@@ -183,7 +187,12 @@ cd build
 cd ..
 
 mkdir -p $PKG/usr/bin
-ln -sf /usr/lib/rstudio/bin/rstudio $PKG/usr/bin
+cd $PKG/usr/bin && ln -sf ../lib/rstudio/bin/rstudio rstudio
+
+# Update symlinks to be relative
+ln -sfrT /usr/share/myspell/dicts $PKG/usr/lib/rstudio/resources/dictionaries
+ln -sfrT /usr/share/mathjax2 $PKG/usr/lib/rstudio/resources/mathjax-27
+ln -sfrT /usr/bin/pandoc $PKG/usr/lib/rstudio/bin/pandoc/pandoc
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \


### PR DESCRIPTION
Matteo Bernardini (ponce) emailed me that the build does not use the bundled node.
He suggested to add the following line to the SlackBuild:
`export PATH=$TMP/$SRCNAM-$SRCVER/dependencies/common/node/$NODE_VER/bin:$PATH`