### PR TITLE
development/android-tools: Fix go modules being downloaded

### DIFF
--- a/development/android-tools/README
+++ b/development/android-tools/README
@@ -1,6 +1,3 @@
 These are the adb, append2simg, fastboot, img2simg, mke2fs.android
 and simg2img tools from the android sdk.
 
-Warning: This SlackBuild requires network access when it runs, meaning
-it downloads files from the Internet with root access. You should
-decide for yourself whether or not you think this is a good idea.

--- a/development/android-tools/android-tools.SlackBuild
+++ b/development/android-tools/android-tools.SlackBuild
@@ -28,7 +28,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=android-tools
 VERSION=${VERSION:-31.0.3p1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -81,13 +81,16 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+export GOCACHE=$(pwd)/build/go-cache
+export GO111MODULE=off
+
 mkdir -p build
 cd build
   cmake \
     -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
     -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
     -DCMAKE_INSTALL_PREFIX=/usr \
-    -GNinja \
+    -GNinja -Wno-dev \
     -DCMAKE_BUILD_TYPE=Release ..
   "${NINJA:=ninja}"
   DESTDIR=$PKG $NINJA install


### PR DESCRIPTION
This fixes some issues with this slackbuild:
- Some go modules were being downloaded while building.
- Some files were being created in /root

With these fixes the warning in the README does not seem to be necessary anymore, so I removed it.

With the GOCACHE variable the go cache is being changed to the build directory in the source. When the slackbuild is rerun it's also being deleted so it's always build with a clean cache.
I hope this is SBo worthy behaviour;-)