### PR TITLE
development/jupyter-ipykernel: Fix SlackBuild setup.py shim

### DIFF
--- a/development/jupyter-ipykernel/jupyter-ipykernel.SlackBuild
+++ b/development/jupyter-ipykernel/jupyter-ipykernel.SlackBuild
@@ -88,6 +88,7 @@ from distutils.core import setup
 from glob import glob
 from ipykernel.kernelspec import KERNEL_NAME, make_ipkernel_cmd, write_kernel_spec
 import os
+import shutil
 here = os.path.abspath(os.path.dirname(__file__))
 pjoin = os.path.join
 packages = []
@@ -98,7 +99,7 @@ dest = pjoin(here, "data_kernelspec")
 if os.path.exists(dest):
     shutil.rmtree(dest)
 write_kernel_spec(dest, overrides={"argv": make_ipkernel_cmd()})
-setup(name='${PRGNAM}',
+setup(name='ipykernel',
     version='${VERSION}',
     packages=packages,
     py_modules=["ipykernel_launcher"],


### PR DESCRIPTION
Someone reported that jupyter-notebook was unable to load jupyter-ipykernel.
(However, I was able to load jupyter-ipykernel in jupyterlab).

I found the error- the setup() line should not contain `setup(name='${PRGNAM}',`
Instead, the setup() line should contain  `setup(name='ipykernel}',`

Also, the added line `import shutil` is due to the command `shutil.rmtree(dest)`