### PR TITLE
libraries/vst3sdk: Fix directory ownership and pc file

### DIFF
--- a/libraries/vst3sdk/vst3sdk.SlackBuild
+++ b/libraries/vst3sdk/vst3sdk.SlackBuild
@@ -77,7 +77,7 @@ cp -a \
 $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
-chmod -R 644 $PKG/usr/include/vst3sdk
+chmod -R 755 $PKG/usr/include/vst3sdk
 chmod -R 644 $PKG/usr/doc/$PRGNAM-$VERSION
 find $PKG/usr/doc/$PRGNAM-$VERSION -type d -exec chmod 755 {} +
 find $PKG/usr/include/vst3sdk -type d -exec chmod 755 {} +

--- a/libraries/vst3sdk/vst3sdk.SlackBuild
+++ b/libraries/vst3sdk/vst3sdk.SlackBuild
@@ -54,10 +54,9 @@ tar xf $CWD/$PRGNAM-$VERSION.tar.gz
 cd $PRGNAM-$VERSION
 chown -R root:root .
 
-#handle if its 32bit but this should be in lib64 but lib: is not set
-mkdir -p $PKG/usr/lib/pkgconfig
-cp $CWD/vst3sdk.pc $PKG/usr/lib/pkgconfig/
-sed -i "s/VERSION/$VERSION_$SDK_BUILD/g" $PKG/usr/lib/pkgconfig/vst3sdk.pc
+mkdir -p $PKG/usr/share/pkgconfig
+cp $CWD/vst3sdk.pc $PKG/usr/share/pkgconfig/
+sed -i "s/VERSION/$VERSION_$SDK_BUILD/g" $PKG/usr/share/pkgconfig/vst3sdk.pc
 
 mkdir -p             $PKG/usr/include/vst3sdk
 cp -a base           $PKG/usr/include/vst3sdk/
@@ -81,6 +80,7 @@ cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 chmod -R 644 $PKG/usr/include/vst3sdk
 chmod -R 644 $PKG/usr/doc/$PRGNAM-$VERSION
 find $PKG/usr/doc/$PRGNAM-$VERSION -type d -exec chmod 755 {} +
+find $PKG/usr/include/vst3sdk -type d -exec chmod 755 {} +
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc


### PR DESCRIPTION
Hi think I messed up here regarding errors for another build:

cp: setting permissions for 'subprojects/vst3/base': Operation not supported
cp: setting permissions for 'subprojects/vst3/cmake': Operation not supported
cp: setting permissions for 'subprojects/vst3/pluginterfaces': Operation not supported
cp: setting permissions for 'subprojects/vst3/public.sdk': Operation not supported
cp: setting permissions for 'subprojects/vst3/vstgui4': Operation not supported
cp: setting permissions for 'subprojects/vst3/base': Operation not supported
cp: setting permissions for 'subprojects/vst3/cmake': Operation not supported
cp: setting permissions for 'subprojects/vst3/pluginterfaces': Operation not supported
cp: setting permissions for 'subprojects/vst3/public.sdk': Operation not supported
cp: setting permissions for 'subprojects/vst3/vstgui4': Operation not supported