### PR TITLE
office/focuswriter: Update README

### DIFF
--- a/office/focuswriter/README
+++ b/office/focuswriter/README
@@ -5,5 +5,5 @@ had open to make it easy to jump back in during your next writing
 session, and has many other features that make it such that only one
 thing matters: your writing.
 
-A focuswriter-legacy SlackBuild, which does not depend on qt5,
-is available.
+FocusWriter 1.7.6 is the last available version for qt5. Newer versions
+(focuswriter >= 1.8.0) require qt6.


### PR DESCRIPTION
focuswriter >= 1.8.0 requires Qt6.
Also, Slackware 15.0 does not have focuswriter-legacy.

 I have changed the README to reflect these 2 points.