### PR TITLE
python/python3-pandas: Update README

### DIFF
--- a/python/python3-pandas/README
+++ b/python/python3-pandas/README
@@ -2,3 +2,6 @@ The Python Data Analysis Library (Pandas) is an open source,
 BSD-licensed library providing high-performance, easy-to-use data
 structures and data analysis tools for the Python programming
 language.
+
+python3-pandas 1.4.2 is the last possible version for Slackware 15.0.
+Newer versions require a newer Cython (as a build dependency).


### PR DESCRIPTION
python3-pandas 1.4.3 requires Cython 0.29.30 as a build dependency (for context, Slackware 15.0 has Cython 0.29.27).