### PR TITLE
desktop/qtile: Fix xinitrc

### DIFF
--- a/desktop/qtile/xinitrc.qtile
+++ b/desktop/qtile/xinitrc.qtile
@@ -24,7 +24,7 @@ fi
 
 # Start qtile
 if [ -z "$DESKTOP_SESSION" -a -x /usr/bin/ck-launch-session ]; then
- exec ck-launch-session qtile
+ exec ck-launch-session dbus-launch --exit-with-session qtile start
 else
- exec qtile
+ exec dbus-launch --exit-with-session qtile start
 fi


### PR DESCRIPTION
Another user mentioned that the xinitrc.qtile file is not working properly.

I fixed the xinitrc file (replaced 'qtile' with 'qtile start')

Updated version of qtile have different syntax for starting qtile.