### PR TITLE
development/rstudio-desktop: Update for 2022.07.1+554

### DIFF
--- a/development/rstudio-desktop/disable_quarto.patch
+++ b/development/rstudio-desktop/disable_quarto.patch
@@ -1,0 +1,13 @@
+--- a/CMakeGlobals.txt	2022-07-06 12:59:49.000000000 -0700
++++ b/CMakeGlobals.txt	2022-07-18 11:51:59.266963561 -0700
+@@ -253,8 +253,8 @@
+    message(STATUS "quarto is not supported on Centos7; disabling quarto")
+    set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
+ else()
+-   # enable by default
+-   set(QUARTO_ENABLED TRUE CACHE INTERNAL "")
++   # disable by default
++   set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
+    add_definitions(-DQUARTO_ENABLED)
+ endif()
+ 

--- a/development/rstudio-desktop/pandoc_version.patch
+++ b/development/rstudio-desktop/pandoc_version.patch
@@ -1,14 +1,14 @@
 This patch was taken from the Arch Linux AUR:
 https://aur.archlinux.org/cgit/aur.git/tree/pandoc_version.patch?h=rstudio-desktop
 diff -ur a/CMakeGlobals.txt b/CMakeGlobals.txt
---- a/CMakeGlobals.txt	2022-03-18 10:10:38.000000000 +1300
-+++ b/CMakeGlobals.txt	2022-04-28 10:46:17.695649880 +1200
-@@ -214,7 +214,7 @@
+--- a/CMakeGlobals.txt	2022-07-06 12:59:49.000000000 -0700
++++ b/CMakeGlobals.txt	2022-07-17 20:10:59.016516702 -0700
+@@ -231,7 +231,7 @@
  endif()
  
  # pandoc version
--set(PANDOC_VERSION "2.16.2" CACHE INTERNAL "Pandoc version")
+-set(PANDOC_VERSION "2.18" CACHE INTERNAL "Pandoc version")
 +set(PANDOC_VERSION "current" CACHE INTERNAL "Pandoc version")
  
- # quarto support
- if(LINUX AND UNAME_M STREQUAL aarch64)
+ # detect Centos 7, because we don't support Quarto on Centos7
+ set(IS_CENTOS7 FALSE)

--- a/development/rstudio-desktop/rstudio-desktop.SlackBuild
+++ b/development/rstudio-desktop/rstudio-desktop.SlackBuild
@@ -27,13 +27,12 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rstudio-desktop
 SRCNAM=rstudio
-VERSION=${VERSION:-2022.02.3+492}
+VERSION=${VERSION:-2022.07.1+554}
 SRCVER=${SRCVER:-$(echo $VERSION | sed 's/+/-/g')}
-GITCOMMIT_VER=8acbd38
-GWT_SDK_VER=${GWT_SDK_VER:-2.8.2}
-NODE_VER=${NODE_VER:-14.17.5}
+GITCOMMIT_VER=7872775
+NODE_VER=${NODE_VER:-16.14.0}
 PANDOCVER=current
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -86,21 +85,9 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
-  | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
-
-GWT_DIR=src/gwt
-LIB_DIR=$GWT_DIR/lib
-mkdir -p $LIB_DIR
-
-GWT_SDK_ZIP=$CWD/gwt-$GWT_SDK_VER.zip
-
-mkdir -p $LIB_DIR/gwt
-unzip -qo $GWT_SDK_ZIP -d $LIB_DIR/gwt
-mv $LIB_DIR/gwt/gwt-$GWT_SDK_VER $LIB_DIR/gwt/$GWT_SDK_VER
-
 # patches 
 patch -p1 < $CWD/pandoc_version.patch     # Do not use outdated pandoc version number
+patch -p1 < $CWD/disable_quarto.patch     # cmake ignores -DQUARTO_ENABLED for some reason
 
 cd dependencies/common
 mkdir -p pandoc/$PANDOCVER
@@ -185,6 +172,9 @@ cd build
   make
   make install DESTDIR=$PKG
 cd ..
+
+find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
+  | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/bin
 (

--- a/development/rstudio-desktop/rstudio-desktop.info
+++ b/development/rstudio-desktop/rstudio-desktop.info
@@ -1,14 +1,12 @@
 PRGNAM="rstudio-desktop"
-VERSION="2022.02.3+492"
+VERSION="2022.07.1+554"
 HOMEPAGE="http://rstudio.com"
 DOWNLOAD="UNSUPPORTED"
 MD5SUM=""
-DOWNLOAD_x86_64="https://github.com/rstudio/rstudio/archive/refs/tags/v2022.02.3+492/rstudio-2022.02.3-492.tar.gz \
-                 https://storage.googleapis.com/gwt-releases/gwt-2.8.2.zip \
-                 https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-x64.tar.gz"
-MD5SUM_x86_64="4a546d0ed141ab1304be1b4967ca5aac \
-               c295406d68c5ef364e445068599aa6d4 \
-               3cd3b18e1412067aabd2e1b23b93106e"
+DOWNLOAD_x86_64="https://github.com/rstudio/rstudio/archive/refs/tags/v2022.07.1+554/rstudio-2022.07.1-554.tar.gz \
+                 https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-x64.tar.gz"
+MD5SUM_x86_64="e57b59a213f2be140d26b122c1ea24bc \
+               a46e501a201be6c3c05c0f770c375372"
 REQUIRES="R pandoc-bin yaml-cpp hunspell-en yarn apache-ant zulu-openjdk8 mathjax2 soci"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu1@isaacyu1.com"


### PR DESCRIPTION
Changes:
- Stripping ELF binaries should be done after building rstudio-desktop with cmake, not before
- Use the gwt from rstudio instead
- Add disable_quarto patch (cmake ignores -DQUARTO_ENABLED=FALSE for some reason)