### PR TITLE
development/jupyterlab: Remove jupyter-notebook requirement from setup.cfg

### DIFF
--- a/development/jupyterlab/jupyterlab.SlackBuild
+++ b/development/jupyterlab/jupyterlab.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=jupyterlab
 VERSION=${VERSION:-3.4.4}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -82,6 +82,9 @@ find -L . \
 # Remove nbclassic dependency
 sed -e '/nbclassic/d' -i setup.cfg
 patch -p1 < $CWD/no-nbclassic.patch
+
+# Remove jupyter-notebook requirement from setup.cfg
+sed -e '/notebook/d' -i setup.cfg
 
 # Fix /etc/jupyter path 
 sed 's|etc|/etc|' -i setup.py


### PR DESCRIPTION
For jupyterlab 3.4.4, why did upstream add a jupyter-notebook requirement to setup.cfg?
Line 41 (under the install_requires section) of the source setup.cfg contains the following line:
notebook<7

I thought that because we already have jupyter-notebook_shim, we didn't need jupyter-notebook?

If you would like to check the differences between jupyterlab 3.4.3 and 3.4.4:
diff -r jupyterlab-3.4.3 jupyterlab-3.4.4