### PR TITLE
python/python3-automat: sets m2r as optional dependency

### DIFF
--- a/python/python3-automat/README
+++ b/python/python3-automat/README
@@ -1,3 +1,5 @@
 Automat is a library for concise, idiomatic Python expression of
 finite-state automata (particularly deterministic finite-state
 transducers).
+
+python-m2r is an optional dependency for better documentations.

--- a/python/python3-automat/python3-automat.info
+++ b/python/python3-automat/python3-automat.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://pypi.python.org/packages/source/A/Automat/Automat-20.2.0.tar.g
 MD5SUM="d6cef9886b037b8857bfbc686f3ae30a"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-attrs wheel python-m2r"
+REQUIRES="python3-attrs wheel"
 MAINTAINER="Yth - Arnaud"
 EMAIL="yth@ythogtha.org"


### PR DESCRIPTION
python-m2r depends on mistune which can't (yet) easily be updated.
As m2r is not a runtime dependency, but only creates better documentations inside the package, I set it up as optional to avoid forcing people to install an out-of-date and possibly insecure mistune.
This changes nothing for packages using Automat, namely Twisted and stuff relying on Twisted.