### PR TITLE
python/python2-automat: sets m2r as optional dependency

### DIFF
--- a/python/python2-automat/README
+++ b/python/python2-automat/README
@@ -1,3 +1,5 @@
 Automat is a library for concise, idiomatic Python expression of
 finite-state automata (particularly deterministic finite-state
 transducers).
+
+python-m2r is an optional dependency for better documentations.

--- a/python/python2-automat/python2-automat.info
+++ b/python/python2-automat/python2-automat.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://pypi.python.org/packages/source/A/Automat/Automat-20.2.0.tar.g
 MD5SUM="d6cef9886b037b8857bfbc686f3ae30a"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python2-setuptools-scm python2-attrs wheel python-m2r"
+REQUIRES="python2-setuptools-scm python2-attrs wheel"
 MAINTAINER="Yth - Arnaud"
 EMAIL="yth@ythogtha.org"


### PR DESCRIPTION
cf python3-automat.