### PR TITLE
python/traitlets: Change build method to python3-hatchling

### DIFF
--- a/python/traitlets/traitlets.SlackBuild
+++ b/python/traitlets/traitlets.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=traitlets
 VERSION=${VERSION:-5.4.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -80,36 +80,15 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-# Use this setup.py shim:
-cat << EOF > setup.py
-from distutils.core import setup
-import os
-here = os.path.abspath(os.path.dirname(__file__))
-pjoin = os.path.join
-packages = []
-for d, _, _ in os.walk(pjoin(here, 'traitlets')):
-    if os.path.exists(pjoin(d, '__init__.py')):
-        packages.append(d[len(here)+1:].replace(os.path.sep, '.'))
-version_ns = {}
-with open(pjoin(here, 'traitlets', '_version.py')) as f:
-    exec(f.read(), {}, version_ns)
-setup(name='${PRGNAM}',
-    version=version_ns['__version__'],
-    packages=packages,
-    package_data={'': ['*']},  
-)
-EOF
-
-# With the shim, it's a good idea to use "unshare -n" to prevent downloading
-# anything extra:
-unshare -n python3 setup.py install --root=$PKG || exit 1
+python3 -m build --no-isolation
+python3 -m installer -d "$PKG" dist/*.whl
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \
-  CHANGES.txt CONTRIBUTING.md COPYING.md README.md \
+  CHANGES.txt CONTRIBUTING.md README.md \
   $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 

--- a/python/traitlets/traitlets.info
+++ b/python/traitlets/traitlets.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/t/traitlets/traitlets-5
 MD5SUM="940cadcc64217d4b3df149850a5379b6"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="decorator"
+REQUIRES="decorator python3-hatchling"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu1@isaacyu1.com"


### PR DESCRIPTION
Someone reported having problems building traitlets using my setup.py shim.
For this reason, I decided to change build method to python3-hatchling instead.