### PR TITLE
python/argon2-cffi-bindings: Use system argon2

### DIFF
--- a/python/argon2-cffi-bindings/argon2-cffi-bindings.SlackBuild
+++ b/python/argon2-cffi-bindings/argon2-cffi-bindings.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=argon2-cffi-bindings
 VERSION=${VERSION:-21.2.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -38,6 +38,9 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
+# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
+# the name of the created package would be, and then exit. This information
+# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0
@@ -76,7 +79,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 600 -o -perm 444 -o -perm 440 \
   -o -perm 400 \) -exec chmod 644 {} \;
 
-python3 setup.py install --root=$PKG
+ARGON2_CFFI_USE_SYSTEM=1 python3 setup.py install --root=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true


### PR DESCRIPTION
Also, add commenting regarding the variable PRINT_PACKAGE_NAME