### PR TITLE
python/argon2-cffi: Change build method to python3-flit_core

### DIFF
--- a/python/argon2-cffi/argon2-cffi.SlackBuild
+++ b/python/argon2-cffi/argon2-cffi.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=argon2-cffi
 VERSION=${VERSION:-21.3.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -80,27 +80,15 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-# Use this setup.py shim:
-cat << EOF > setup.py
-from setuptools import setup, find_packages
-setup(name='${PRGNAM}',
-    version='${VERSION}',
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-)
-EOF
-
-# With the shim, it's a good idea to use "unshare -n" to prevent downloading
-# anything extra:
-env ARGON2_CFFI_USE_SYSTEM=1 \
-  unshare -n python3 setup.py install --root=$PKG || exit 1
+python3 -m build --no-isolation
+python3 -m installer -d "$PKG" dist/*.whl
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \
-  AUTHORS.rst CHANGELOG.md FAQ.rst LICENSE README.rst \
+  AUTHORS.rst CHANGELOG.md FAQ.rst README.rst \
   $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 

--- a/python/argon2-cffi/argon2-cffi.info
+++ b/python/argon2-cffi/argon2-cffi.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/hynek/argon2-cffi/archive/21.3.0/argon2-cffi-21.3.0
 MD5SUM="f3a9d1691961b789ca2f7b8a49a4b270"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="argon2-cffi-bindings"
+REQUIRES="argon2-cffi-bindings python3-build python3-flit_core"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu1@isaacyu1.com"


### PR DESCRIPTION
Also, remove the environmental variable ARGON2_CFFI_USE_SYSTEM=1.
That has no effect for this package, unlike with argon2-cffi-bindings.