### PR TITLE
academic/scipy3: Update README

### DIFF
--- a/academic/scipy3/README
+++ b/academic/scipy3/README
@@ -22,3 +22,6 @@ If you need to build scipy for debugging, set DEBUG=y.
 
 NOTE: this is for Python 3. If you need Python 2 support, install
 scipy.
+
+scipy3 1.9.1 is the last possible version for Slackware 15.0. Newer
+versions require a newer Cython (as a build dependency).


### PR DESCRIPTION
scipy 1.9.2 requires Cython >= 0.29.32.
For context, Slackware 15.0 has Cython 0.29.27.