### PR TITLE
python/python3-h5py: Update REQUIRES, remove build optimization

### DIFF
--- a/python/python3-h5py/python3-h5py.SlackBuild
+++ b/python/python3-h5py/python3-h5py.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-h5py
 VERSION=${VERSION:-3.7.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -85,13 +85,13 @@ find -L . \
 sed -i "s/settings\\['runtime_library_dirs'\\] = settings\\['library_dirs'\\]/pass/" setup_build.py
 
 H5PY_SYSTEM_LZF=1 python3 setup.py build 
-python3 setup.py install --root=$PKG --skip-build --optimize=1
+python3 setup.py install --root=$PKG --skip-build
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a LICENSE PKG-INFO README.rst $PKG/usr/doc/$PRGNAM-$VERSION
+cp -a LICENSE README.rst $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install

--- a/python/python3-h5py/python3-h5py.info
+++ b/python/python3-h5py/python3-h5py.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/h/h5py/h5py-3.7.0.tar.g
 MD5SUM="acb43ba2b0b853005af71eccfc456676"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="hdf5 liblzf numpy3 python3-pkgconfig"
+REQUIRES="hdf5 liblzf python3-numpy python3-pkgconfig"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu1@isaacyu1.com"


### PR DESCRIPTION
1. Change numpy3 dependency to python3-numpy
2. Remove build option --optimize=1
3. Remove PKG-INFO from /usr/doc/python3-h5py-3.7.0