### PR TITLE
academic/root +x README and subdirs

### DIFF
--- a/academic/root/root.SlackBuild
+++ b/academic/root/root.SlackBuild
@@ -215,7 +215,9 @@ cp -a README/ README.md LICENSE LGPL2_1.txt ../src/CONTRIBUTING.md \
 find $PKG/usr/doc/$PRGNAM-$VERSION -type f -exec chmod 644 {} \;
 cp -a README/ LICENSE \
     $PKG$PREFIX
-chmod -R 644 $PKG$PREFIX/README
+# README is a directory
+find $PKG$PREFIX/README -type d -exec chmod 755 {} \;
+find $PKG$PREFIX/README -type f -exec chmod 644 {} \;
 chmod -R 644 $PKG$PREFIX/LICENSE
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 


### PR DESCRIPTION
A minor fix. Previously, README was just a file, now (actually, for quite a while) it is a directory. For 5th ROOT version `root.Slackbuild` was setting README's permissions to 644 and this line was just C&P to the current slackbuild, thus nobody except the superuser could actually read the README content.