### PR TITLE
add missing clap dependency

### DIFF
--- a/audio/yabridge/yabridge.info
+++ b/audio/yabridge/yabridge.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/robbert-vdh/yabridge/archive/5.0.1/yabridge-5.0.1.t
 MD5SUM="5805d4e4e4d0e15d0ae07e533104a3df ae2645f5bbffc52d8fedf15088765242"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="%README% wine-staging asio bitsery function2 ghc_filesystem tomlplusplus vst3sdk"
+REQUIRES="%README% wine-staging asio bitsery function2 ghc_filesystem tomlplusplus vst3sdk clap"
 MAINTAINER="Martin Bångens"
 EMAIL="marbangens@gmail.com"


### PR DESCRIPTION
Missed to add clap to yabridge.info while updating.