### PR TITLE
development/jupyter-nbconvert: Update for 7.2.6

### DIFF
--- a/development/jupyter-nbconvert/jupyter-nbconvert.SlackBuild
+++ b/development/jupyter-nbconvert/jupyter-nbconvert.SlackBuild
@@ -26,7 +26,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=jupyter-nbconvert
-VERSION=${VERSION:-7.2.5}
+VERSION=${VERSION:-7.2.6}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -87,12 +87,7 @@ find -L . \
 # https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-python/nbconvert/nbconvert-7.1.0.ebuild
 sed -e 's:css = .*:raise PermissionError("You shall not fetch!"):' -i hatch_build.py
 
-# Import style.min.css into classic templates 
-mkdir -p $TMP/$SRCNAM-$VERSION/share/templates/classic/static
-cp $CWD/style.min.css $TMP/$SRCNAM-$VERSION/share/templates/classic/static/style.css
-
-# wheel build requires offline style.css
-python3 -m build --wheel --no-isolation
+python3 -m build --no-isolation
 python3 -m installer -d "$PKG" dist/*.whl
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/development/jupyter-nbconvert/jupyter-nbconvert.info
+++ b/development/jupyter-nbconvert/jupyter-nbconvert.info
@@ -1,10 +1,8 @@
 PRGNAM="jupyter-nbconvert"
-VERSION="7.2.5"
+VERSION="7.2.6"
 HOMEPAGE="https://jupyter.org/"
-DOWNLOAD="https://files.pythonhosted.org/packages/source/n/nbconvert/nbconvert-7.2.5.tar.gz \
-          https://cdn.jupyter.org/notebook/5.4.0/style/style.min.css"
-MD5SUM="be3485e08235c6d36016f22ab5f43bfd \
-        47782e517c98a53adb514cbefb4528f2"
+DOWNLOAD="https://files.pythonhosted.org/packages/source/n/nbconvert/nbconvert-7.2.6.tar.gz"
+MD5SUM="04d46ffb4ef168a1e7047a8f1b264a2a"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="bleach python3-defusedxml jupyter-nbclient jupyterlab_pygments python3-mistune pandocfilters testpath BeautifulSoup4 tinycss2 python3-hatchling"


### PR DESCRIPTION
jupyter-nbconvert 7.2.6 no longer requires an offline style.css