### PR TITLE
python/pywayland: Add CVE-2007-4559 patch, update README

### DIFF
--- a/python/pywayland/CVE_2007_4559.patch
+++ b/python/pywayland/CVE_2007_4559.patch
@@ -1,0 +1,38 @@
+This patch was taken from upstream pywayland 0.4.15:
+https://github.com/flacjacket/pywayland/pull/42
+--- a/doc/protocol_build.py	2022-07-24 11:03:10.000000000 -0700
++++ b/doc/protocol_build.py	2022-12-20 20:00:48.659884422 -0800
+@@ -14,6 +14,24 @@
+     )
+ )
+ 
++def _is_within_directory(directory, target):
++    """Helper to check for CVE-2007-4559"""
++    abs_directory = os.path.abspath(directory)
++    abs_target = os.path.abspath(target)
++
++    prefix = os.path.commonprefix([abs_directory, abs_target])
++
++    return prefix == abs_directory
++
++
++def _safe_extractall(tar, path=".", members=None, *, numeric_owner=False):
++    """Helper to check for CVE-2007-4559"""
++    for member in tar.getmembers():
++        member_path = os.path.join(path, member.name)
++        if not is_within_directory(path, member_path):
++            raise Exception("Attempted Path Traversal in Tar File")
++
++    tar.extractall(path, members, numeric_owner=numeric_owner) 
+ 
+ def protocols_build(output_dir):
+     from pywayland.scanner import Protocol
+@@ -26,7 +44,7 @@
+     protocol_dest = "wayland-protocols-{}".format(protocols_version)
+     urllib.request.urlretrieve(protocols_source, protocol_dest + ".tar.xz")
+     with tarfile.open(protocol_dest + ".tar.xz") as f:
+-        f.extractall()
++        _safe_extractall(f)
+ 
+     # walk the directory and generate all the protocols
+     protocol_files = [wayland_file] + sorted(

--- a/python/pywayland/README
+++ b/python/pywayland/README
@@ -1,3 +1,6 @@
 PyWayland provides a wrapper to the libwayland library using the CFFI
 library to provide access to the Wayland library calls and written in
 pure Python.
+
+pywayland 0.4.14 is the last possible version for Slackware 15.0.
+Newer versions of pywayland require a newer python-setuptools.

--- a/python/pywayland/pywayland.SlackBuild
+++ b/python/pywayland/pywayland.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=pywayland
 VERSION=${VERSION:-0.4.14}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -78,6 +78,10 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# Backport patch from pywayland 0.4.15 for directory traversal vulnerability 
+# The patch is relevant for building docs
+patch -p1 < $CWD/CVE_2007_4559.patch   
 
 python3 setup.py install --root=$PKG
 


### PR DESCRIPTION
1. Security researchers at Trellix (@TrellixVulnTeam) have found a directory traversal vulnerability.
The patch for CVE-2007-4559 addresses that.
More details regarding the patch are available at the link below:
https://github.com/flacjacket/pywayland/pull/42

2. On Slackware 15.0, pywayland does not update to 0.4.15.
This is because the upstream setup.py invokes the following command: `from setuptools.command.build import build`