### PR TITLE
system/trash-cli: Add python3-psutil as dependency

### DIFF
--- a/system/trash-cli/slack-desc
+++ b/system/trash-cli/slack-desc
@@ -11,9 +11,9 @@ trash-cli:
 trash-cli: trash-cli trashes files recording the original path, deletion date,
 trash-cli: and permissions. It uses the same trashcan used by KDE, GNOME, and
 trash-cli: XFCE, but you can invoke it from the command line (and scripts).
-trash-cli: It provides these commands:
-trash-cli: trash-put     : trashes files and directories.
-trash-cli: trash-empty   : empty the trashcan(s).
-trash-cli: trash-list    : list trashed files.
-trash-cli: trash-restore : restore a trashed file.
-trash-cli: trash-rm      : remove individual files from trash can.
+trash-cli:
+trash-cli:
+trash-cli:
+trash-cli:
+trash-cli:
+trash-cli:

--- a/system/trash-cli/trash-cli.info
+++ b/system/trash-cli/trash-cli.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/andreafrancia/trash-cli/archive/0.22.10.20/trash-cl
 MD5SUM="54e8c14f763f69673fa5143b3159f21d"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES=""
+REQUIRES="python3-psutil"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu1@isaacyu1.com"


### PR DESCRIPTION
The SlackBuild requires python3-psutil as a build dependency.

Also clean up slack-desc.