### PR TITLE
network/vdirsyncer: add new dependencies

### DIFF
--- a/network/vdirsyncer/vdirsyncer.info
+++ b/network/vdirsyncer/vdirsyncer.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/c9/77/4c6a43d26b75811885aff211
 MD5SUM="4d2513d9a4e460a6abb4b7b98778ce9d"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="click click-log click-threading requests-toolbelt python-urwid"
+REQUIRES="click click-log click-threading requests-toolbelt python-urwid python3-aiohttp python3-aiostream"
 MAINTAINER="Tonus"
 EMAIL="tonus1@free.fr"


### PR DESCRIPTION
Now that the missing python3-aiostream has been merged, here is the correction of the missing deps for vdirsyncer