### PR TITLE
games/ppsspp: Updated for version 1.14.4.

### DIFF
--- a/games/ppsspp/README
+++ b/games/ppsspp/README
@@ -12,8 +12,5 @@ keyboard
 
 snappy is an optional dependency.
 
-QT=on will enable QT GUI and require qt5 installed (default is
-'QT=off').
-
-SYSTEM_FFMPEG=on: dynamically link against system FFMPEG (default is
-'SYSTEM_FFMPEG=off', using upstream's modified version).
+QT=ON will enable QT GUI and require qt5 installed (default is
+'QT=OFF').

--- a/games/ppsspp/ppsspp-qt.desktop
+++ b/games/ppsspp/ppsspp-qt.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Version=1.0
-Name=PPSSPP (Qt)
-Exec=ppsspp-qt %f
-Icon=ppsspp
-Type=Application
-GenericName=PSP Emulator
-Comment=ppsspp (fast and portable PSP emulator)
-Categories=Game

--- a/games/ppsspp/ppsspp.SlackBuild
+++ b/games/ppsspp/ppsspp.SlackBuild
@@ -3,7 +3,7 @@
 # Slackware build script for ppsspp
 
 # Copyright 2016  Hunter Sezen California, USA
-# Copyright 2019-2022  Ruoh-Shoei LIN
+# Copyright 2019-2023  Ruoh-Shoei LIN
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,7 +26,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=ppsspp
-VERSION=${VERSION:-1.12.3}
+VERSION=${VERSION:-1.14.4}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -71,31 +71,8 @@ rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
 rm -rf $PRGNAM-$VERSION
-tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
+tar xvf $CWD/$PRGNAM-$VERSION.tar.?z
 cd $PRGNAM-$VERSION
-
-# The submodules are in a separate archive. This is equivalent to
-# git submodule update --init --recursive
-tar -xvf $CWD/zstd-a488ba1*.tar.gz \
-    -C ext/zstd --strip-components=1
-tar -xvf $CWD/miniupnp-3a87be3*.tar.gz \
-    -C ext/miniupnp --strip-components=1
-tar -xvf $CWD/glslang-dc11add*.tar.gz \
-    -C ext/glslang --strip-components=1
-tar -xvf $CWD/SPIRV-Cross-9acb9ec*.tar.gz \
-    -C ext/SPIRV-Cross --strip-components=1
-tar -xvf $CWD/armips-7885552*.tar.gz \
-    -C ext/armips --strip-components=1
-
-SYSTEM_FFMPEG=${SYSTEM_FFMPEG:-off}
-if [ "$SYSTEM_FFMPEG" = "off" ]; then
-  tar -xvf $CWD/ppsspp-ffmpeg-a5baf97*.tar.gz \
-    --exclude '*/Windows*' --exclude '*/android' \
-    --exclude '*/ios' --exclude '*/blackberry'\
-    --exclude '*/macosx' --exclude '*/wiiu' \
-    --exclude '*/symbian' \
-    -C ffmpeg --strip-components=1
-fi
 
 chown -R root:root .
 find -L . \
@@ -110,58 +87,44 @@ sed -i -e '/include(ccache)/d' CMakeLists.txt
 # set git-version
 sed -i "s/unknown/${VERSION}/" git-version.cmake
 
-mkdir -p build-qt build-sdl
+QT=${QT:-OFF}
 
-QT=${QT:-off}
-if [ "$QT" = "on" ]; then
-  cd build-qt
-  cmake \
+if [ "${QT,,}" = ON ]; then
+    cmake -B build-qt \
+	-DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
+	-DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
+	-DCMAKE_INSTALL_PREFIX=/usr \
+	-DCMAKE_SKIP_RPATH=TRUE \
+	-DUSING_QT_UI=ON \
+	-DUSE_SYSTEM_LIBZIP=ON \
+	-DUSE_SYSTEM_FFMPEG=ON \
+	-DUSE_DISCORD=OFF \
+	-DUSE_SYSTEM_ZSTD=ON \
+	-DCMAKE_BUILD_TYPE=Release
+    make -C build-qt
+    install -Dm755 build-qt/PPSSPPQt -t $PKG/usr/bin/
+    install -Dm644 build-qt/ppsspp.desktop $PKG/usr/share/applications/PPSSPPQt.desktop
+fi
+
+cmake -B build-sdl \
     -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
     -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_SKIP_RPATH=TRUE \
-    -Wno-dev \
-    -DUSING_QT_UI=ON \
+    -DUSING_QT_UI=OFF \
     -DUSE_SYSTEM_LIBZIP=ON \
-    -DUSE_SYSTEM_FFMPEG=$SYSTEM_FFMPEG \
+    -DUSE_SYSTEM_FFMPEG=ON \
     -DUSE_DISCORD=OFF \
-    -DCMAKE_BUILD_TYPE=Release ..
-  make
-  cd ..
-  install -Dm755 build-qt/PPSSPPQt $PKG/usr/games/ppsspp-qt
-  install -Dm644 $CWD/ppsspp-qt.desktop $PKG/usr/share/applications/ppsspp-qt.desktop
-fi
-
-cd build-sdl
-cmake \
-  -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
-  -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
-  -DCMAKE_INSTALL_PREFIX=/usr \
-  -DCMAKE_SKIP_RPATH=TRUE \
-  -Wno-dev \
-  -DUSING_QT_UI=OFF \
-  -DHEADLESS='ON' \
-  -DUSE_SYSTEM_LIBZIP=ON \
-  -DUSE_SYSTEM_FFMPEG=$SYSTEM_FFMPEG \
-  -DUSE_DISCORD=OFF \
-  -DCMAKE_BUILD_TYPE=Release ..
-make
-cd ..
-install -Dm755 build-sdl/PPSSPPHeadless $PKG/usr/games/ppsspp-headless
-install -Dm755 build-sdl/PPSSPPSDL $PKG/usr/games/ppsspp-sdl
-
-mkdir -p $PKG/usr/{games,share/{applications,icons/hicolor,pixmaps,ppsspp}}
-install -Dm644 $CWD/ppsspp.desktop $PKG/usr/share/applications/ppsspp.desktop
-cp -r assets $PKG/usr/share/ppsspp
-cp -r icons/hicolor/* $PKG/usr/share/icons/hicolor
-cp icons/icon-512.svg $PKG/usr/share/pixmaps/ppsspp.svg
+    -DUSE_SYSTEM_ZSTD=ON \
+    -DCMAKE_BUILD_TYPE=Release
+make -C build-sdl
+make install DESTDIR=$PKG -C build-sdl
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
-mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a LICENSE.TXT README.md history.md headless/headless.txt \
-   $PKG/usr/doc/$PRGNAM-$VERSION
+install -Dm644 LICENSE.TXT README.md history.md \
+   -t $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install

--- a/games/ppsspp/ppsspp.desktop
+++ b/games/ppsspp/ppsspp.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Version=1.0
-Name=PPSSPP (SDL)
-Exec=ppsspp-sdl %f
-Icon=ppsspp
-Type=Application
-GenericName=PSP Emulator
-Comment=ppsspp (fast and portable PSP emulator)
-Categories=Game

--- a/games/ppsspp/ppsspp.info
+++ b/games/ppsspp/ppsspp.info
@@ -1,20 +1,8 @@
 PRGNAM="ppsspp"
-VERSION="1.12.3"
+VERSION="1.14.4"
 HOMEPAGE="https://www.ppsspp.org/"
-DOWNLOAD="https://github.com/hrydgard/ppsspp/archive/v1.12.3/ppsspp-1.12.3.tar.gz \
-          https://github.com/hrydgard/glslang/archive/dc11adde23c455a24e13dd54de9b4ede8bdd7db8/glslang-dc11adde23c455a24e13dd54de9b4ede8bdd7db8.tar.gz \
-          https://github.com/KhronosGroup/SPIRV-Cross/archive/9acb9ec31f5a8ef80ea6b994bb77be787b08d3d1/SPIRV-Cross-9acb9ec31f5a8ef80ea6b994bb77be787b08d3d1.tar.gz \
-          https://github.com/Kingcom/armips/archive/7885552b208493a6a0f21663770c446c3ba65576/armips-7885552b208493a6a0f21663770c446c3ba65576.tar.gz \
-          https://github.com/hrydgard/miniupnp/archive/3a87be33e797ba947b2b2a5f8d087f6c3ff4d93e/miniupnp-3a87be33e797ba947b2b2a5f8d087f6c3ff4d93e.tar.gz \
-          https://github.com/facebook/zstd/archive/a488ba114ec17ea1054b9057c26a046fc122b3b6/zstd-a488ba114ec17ea1054b9057c26a046fc122b3b6.tar.gz \
-          https://github.com/hrydgard/ppsspp-ffmpeg/archive/a5baf97df4579b4614cd5e643241c7acfc36b0c4/ppsspp-ffmpeg-a5baf97df4579b4614cd5e643241c7acfc36b0c4.tar.gz"
-MD5SUM="1884395ddfd53cdfef869b454643774b \
-        939584490f40840c06301849a445e505 \
-        1338c24baf927d9ed170759370a0462c \
-        4731977e287eee39ddcc247d75095758 \
-        1b54e744eeeb42c444f4c07ff2cda6af \
-        d6a2ae6d5172aa8a64cd6898af9b476e \
-        b8c1813e193922663a58e751c1020fb4"
+DOWNLOAD="https://github.com/hrydgard/ppsspp/releases/download/v1.14.4/ppsspp-1.14.4.tar.xz"
+MD5SUM="ea4fa6919f27ad0b3495b460aaf51449"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES=""

--- a/games/ppsspp/slack-desc
+++ b/games/ppsspp/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
       |-----handy-ruler------------------------------------------------------|
-ppsspp: ppsspp (a fast and portable PSP emulator)
+ppsspp: ppsspp (fast and portable PSP emulator)
 ppsspp:
 ppsspp: PPSSPP can run your PSP games on your PC in full HD resolution. It
 ppsspp: can even upscale textures that would otherwise be too blurry as they


### PR DESCRIPTION
 - use upstream release files
 - remove unused desktop files
 - always use system ffmpeg
 - default build with: sdl