### PR TITLE
system/tbsm: Fix SlackBuild

### DIFF
--- a/system/tbsm/README.SLACKWARE
+++ b/system/tbsm/README.SLACKWARE
@@ -1,6 +1,13 @@
 tbsm may run desktop sessions, such as dwm, without dbus support.
-Thus, given that tbsm detects available .desktop files from
-/usr/share/xsessions, create a copy of the .desktop file and modify
-the Name and Exec lines as such:
-Name=dwm-dbus
-Exec=dbus-launch --sh-syntax --exit-with-session dwm
+Thus, here are 2 methods for autostarting dbus upon login:
+
+1. Please add the following line to .xinitrc or .xsession:
+exec dbus-launch --sh-syntax --exit-with-session dwm
+
+2. Please add the following lines to autostart.sh (dwm has an optional
+patch for autostarting ~/.dwm/autostart.sh):
+
+# Start DBUS session bus:
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+   eval $(dbus-launch --sh-syntax --exit-with-session)
+fi

--- a/system/tbsm/tbsm.SlackBuild
+++ b/system/tbsm/tbsm.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for tbsm
 
-# Copyright 2019-2022 Isaac Yu <isaacyu1@isaacyu1.com>
+# Copyright 2019-2023 Isaac Yu <isaacyu1@isaacyu1.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,21 +26,12 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=tbsm
 VERSION=${VERSION:-0.7}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
-if [ -z "$ARCH" ]; then
-  case "$( uname -m )" in
-    i?86) ARCH=i586 ;;
-    arm*) ARCH=arm ;;
-       *) ARCH=$( uname -m ) ;;
-  esac
-fi
+ARCH=noarch
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0
@@ -49,20 +40,6 @@ fi
 TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
-
-if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
-else
-  SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
-fi
 
 set -e
 
@@ -79,17 +56,20 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# Change doc folder location from /usr/share/tbsm to /usr/doc/tbsm-0.7/doc
+sed -i 's/share\/doc\/${MyName}/doc\/$(notdir $(CURDIR))\/doc/g' Makefile
+
+# within the tbsm binary, change docpath from /usr/share/tbsm/doc to /usr/doc/tbsm-0.7/doc
+sed -i 's/share\/doc\/tbsm/doc\/${myName}-${myVersion}\/doc/g' src/tbsm
+
 make
 make install PREFIX=/usr DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
-# Redundant directory
-rm -r $PKG/usr/share/doc/tbsm
-
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a doc/ themes/ changelog license readme-install.txt README.md $PKG/usr/doc/$PRGNAM-$VERSION
+cp -a themes/ changelog license readme-install.txt README.md $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 cat $CWD/README.SLACKWARE > $PKG/usr/doc/$PRGNAM-$VERSION/README.SLACKWARE
 


### PR DESCRIPTION
1. Build package as noarch.
2. Instead of manually removing /usr/share/doc/tbsm, change build options so that doc folder location is on /usr/doc/tbsm-0.7/doc
3. In particular, fix SlackBuild so that the command `tbsm doc` works.
4. Edit README.SLACKWARE (the list of additional instructions)