### PR TITLE
python/cppy: Update README, SlackBuild format

### DIFF
--- a/python/cppy/README
+++ b/python/cppy/README
@@ -2,3 +2,6 @@ cppy is a small C++ header library which makes it easier to write Python
 extension modules. The primary feature is a PyObject smart pointer which
 automatically handles reference counting and provides convenience
 methods for performing common object operations.
+
+cppy 1.2.0 is the last possible version for Slackware 15.0. Newer
+versions require a newer python-setuptools.

--- a/python/cppy/cppy.SlackBuild
+++ b/python/cppy/cppy.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for cppy
 
-# Copyright 2022 Isaac Yu <isaacyu1@isaacyu1.com>
+# Copyright 2022-2023 Isaac Yu <isaacyu1@isaacyu1.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification,
@@ -39,9 +39,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0


### PR DESCRIPTION
1. cppy 1.2.1 requires python-setuptools >= 61.2. I have added info to the README to explain that.
2. Reformat the build script. Only commenting is changed; therefore, bumping build number is unnecessary.