### PR TITLE
python/python3-kiwisolver: Update README, SlackBuild format

### DIFF
--- a/python/python3-kiwisolver/README
+++ b/python/python3-kiwisolver/README
@@ -7,7 +7,7 @@ the original Cassowary solver with typical use cases gaining a 40x
 improvement. Memory savings are consistently > 5x.
 
 This is the Python 3 version of kiwisolver and will coexist with SBo's
-kiwisolver package.
+python2-kiwisolver package.
 
 python3-kiwisolver 1.4.1 is the last possible version for Slackware
 15.0. Newer versions would require a newer python-setuptools.

--- a/python/python3-kiwisolver/python3-kiwisolver.SlackBuild
+++ b/python/python3-kiwisolver/python3-kiwisolver.SlackBuild
@@ -3,7 +3,7 @@
 # Slackware build script for python3-kiwisolver
 
 # Copyright 2018 Serban Udrea <s.udrea@gsi.de>
-# Copyright 2022 Isaac Yu <isaacyu1@isaacyu1.com>
+# Copyright 2022-2023 Isaac Yu <isaacyu1@isaacyu1.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification,
@@ -41,9 +41,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0


### PR DESCRIPTION
1. The README should mention that python3-kiwisolver may coexist with python2-kiwisolver, not kiwisolver. Please recall that Serban Udrea uploaded python2-kiwisolver a few months ago.
2. Reformat the build script. Only commenting is changed; therefore, bumping build number is unnecessary.