### PR TITLE
multimedia/subtitleeditor: Both ``CFLAGS`` and ``CXXFLAGS`` shall be equal to ``SLKCFLAGS``

### DIFF
--- a/multimedia/subtitleeditor/subtitleeditor.SlackBuild
+++ b/multimedia/subtitleeditor/subtitleeditor.SlackBuild
@@ -81,6 +81,7 @@ find -L . \
  -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
 CFLAGS="$SLKCFLAGS" \
+CXXFLAGS="$SLKCFLAGS" \
 ./autogen.sh \
   --prefix=/usr \
   --libdir=/usr/lib${LIBDIRSUFFIX} \


### PR DESCRIPTION
I was building subtitleeditor right now and perceived that my ``CFLAGS`` settings weren't being in fact used, so checked out the code and figured out that ``CXXFLAGS`` wasn't being set as ``SLKCFLAGS``. Anyway, small but useful fix.