### PR TITLE
development/jupyterlab: Edit README

### DIFF
--- a/development/jupyterlab/README
+++ b/development/jupyterlab/README
@@ -7,3 +7,6 @@ JupyterLab will eventually replace the classic Jupyter Notebook.
 Jupyter kernels are needed for JupyterLab to be fully functional. The
 following kernels are currently available as SlackBuilds:
 * jupyter-ipykernel
+
+jupyterlab 3.5.3 is the last possible version for Slackware 15.0.
+Newer versions would require a newer jupyterlab_server.


### PR DESCRIPTION
jupyterlab 3.6.0 has just been released. However, it requires jupyterlab_server 2.19.0.
Slackware 15.0 can only install jupyterlab_server 2.16.3 (any later version of jupyterlab_server requires python-requests >= 2.28. For context Slackware 15.0 has python-requests 2.26.)