### PR TITLE
python/python3-pytest: Edit README

### DIFF
--- a/python/python3-pytest/README
+++ b/python/python3-pytest/README
@@ -9,7 +9,6 @@ with python.
 
 NOTE: py and iniconfig have automatic python3 support.
 
-Newer versions of python3-pytest (>= 7.2.0) require a newer
-python-setuptools_scm for building python3-flit_scm (which itself is
-for the new dependency python3-exceptiongroup).
+On Slackware 15.0, newer versions of python3-pytest (>= 7.2.0) require
+a newer python-setuptools_scm for building new dependencies.
 Therefore, this SlackBuild has kept python3-pytest at 7.1.3.


### PR DESCRIPTION
Simplify README. Also, the "newer python-setuptools_scm" requirement is only for Slackware 15.0.