### PR TITLE
development/rust16: Updated for version 1.66.1.

### DIFF
--- a/development/rust16/README
+++ b/development/rust16/README
@@ -5,8 +5,12 @@ would be possible with system rust.
 To use the rust16 binaries in a SlackBuild, make the following export
 statements:
 
-  export PATH="/opt/rust16/bin:$PATH"
+export PATH="/opt/rust16/bin:$PATH"
+if [ -z "$LD_LIBRARY_PATH" ]; then
+  export LD_LIBRARY_PATH="/opt/rust16/lib$LIBDIRSUFFIX"
+else
   export LD_LIBRARY_PATH="/opt/rust16/lib$LIBDIRSUFFIX:$LD_LIBRARY_PATH"
+fi
 
 rust16 is not intended as a substitute for rustup or for the Slackware
 rust package in terms of rust development purposes.

--- a/development/rust16/rust16.SlackBuild
+++ b/development/rust16/rust16.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust16
 SRCNAM=rust
-VERSION=${VERSION:-1.65.0}
+VERSION=${VERSION:-1.66.1}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -67,14 +67,20 @@ else
   LIBDIRSUFFIX=""
 fi
 
+if [ "$ARCH" = "arm" ]; then
+  TRIPLET="$ARCH-unknown-linux-gnueabihf"
+else
+  TRIPLET="$ARCH-unknown-linux-gnu"
+fi
+
 set -e
 
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
-rm -rf $PRGNAM-$VERSION-unknown-linux-gnu
-tar xvf $CWD/$SRCNAM-$VERSION-$ARCH-unknown-linux-gnu.tar.gz
-cd $SRCNAM-$VERSION-$ARCH-unknown-linux-gnu
+rm -rf $SRCNAM-$VERSION-$TRIPLET
+tar xvf $CWD/$SRCNAM-$VERSION-$TRIPLET.tar.gz
+cd $SRCNAM-$VERSION-$TRIPLET
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
@@ -86,11 +92,12 @@ find -L . \
   --destdir=$PKG \
   --prefix="opt/rust16" \
   --disable-ldconfig \
-  --without=rust-docs,\
+  --without=rust-docs-json-preview,\
+rust-docs,\
 clippy-preview,\
 rls-preview,\
 llvm-tools-preview,\
-rust-analysis-$ARCH-unknown-linux-gnu,\
+rust-analysis-$TRIPLET,\
 rust-analyzer-preview,\
 rust-demangler-preview,\
 rustfmt-preview

--- a/development/rust16/rust16.info
+++ b/development/rust16/rust16.info
@@ -1,10 +1,12 @@
 PRGNAM="rust16"
-VERSION="1.65.0"
+VERSION="1.66.1"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-i686-unknown-linux-gnu.tar.gz"
-MD5SUM="cd5a051af8290ee760e0f7b38b45f559"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="51d6eb460e982f01290a90a53d7dfbf9"
+DOWNLOAD="https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="f834f22e3a03b50499d6cfe738285ebb \
+        613c6932cddbc17567777fe9152e3828"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="4c09996d0c917950f80fdbd106e8f7db"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"


### PR DESCRIPTION
Currently, the following have rust16 as a dependency:

* bat
* bottom
* clamav
* dust
* fd
* ncspot

I verified that they all build under x86_64 and i686 with rust16-1.66.1.

@aclemons I don't have any ARM equipment for testing, but I'll try to get a VM up and running.