### PR TITLE
python/et_xmlfile: Remove Python 2 support

### DIFF
--- a/python/et_xmlfile/README
+++ b/python/et_xmlfile/README
@@ -1,3 +1,3 @@
 et_xmlfile is a low memory library for creating large XML files.
 
-This SlackBuild builds the python2 and python3 modules.
+This SlackBuild builds only the python3 modules.

--- a/python/et_xmlfile/et_xmlfile.SlackBuild
+++ b/python/et_xmlfile/et_xmlfile.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for et_xmlfile
 
-# Copyright 2020-2022 Isaac Yu <isaacyu1@isaacyu1.com>
+# Copyright 2020-2023 Isaac Yu <isaacyu1@isaacyu1.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=et_xmlfile
 VERSION=${VERSION:-1.1.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -38,9 +38,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0
@@ -75,15 +72,13 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-# Python 2 and Python 3 support
-python setup.py install --root=$PKG
 python3 setup.py install --root=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a PKG-INFO README.rst $PKG/usr/doc/$PRGNAM-$VERSION
+cp -a README.rst $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install


### PR DESCRIPTION
The only SlackBuild that depends on et_xmlfile is python3-openpyxl.