### PR TITLE
python/python3-platformdirs: Edit README

### DIFF
--- a/python/python3-platformdirs/README
+++ b/python/python3-platformdirs/README
@@ -1,6 +1,2 @@
 platformdirs is a small Python module for determining appropriate
 platform-specific directories, e.g. a "user data dir".
-
-Newer versions of platformdirs require python3-hatch-vcs as a build
-dependency. python3-hatch-vcs itself requires a newer version of
-python-setuptools_scm from Slackware.


### PR DESCRIPTION
I can actually update python3-platformdirs within Slackware 15.0.

I am not updating python3-platformdirs though (even though python3-platformdirs 3.0.0 is available upstream).
It's just that if I update it, jupyter_core (and by extension, jupyter-notebook and jupyterlab) breaks.