### PR TITLE
python/python3-pypng: Add wheel to REQUIRES

### DIFF
--- a/python/python3-pypng/python3-pypng.SlackBuild
+++ b/python/python3-pypng/python3-pypng.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-pypng
 VERSION=${VERSION:-0.20220715.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 

--- a/python/python3-pypng/python3-pypng.info
+++ b/python/python3-pypng/python3-pypng.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/p/pypng/pypng-0.2022071
 MD5SUM="7d9cce86ceb19524784ade86fb13a063"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-build python3-installer"
+REQUIRES="python3-build python3-installer wheel"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu1@isaacyu1.com"


### PR DESCRIPTION
Erich Ritz mentioned that this SlackBuild requires wheel as well (for compiling python3-pypng).