### PR TITLE
Fix setuptools scm pretend version (python3-filelock and python3-virtualenv)

### DIFF
--- a/python/python3-filelock/python3-filelock.SlackBuild
+++ b/python/python3-filelock/python3-filelock.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-filelock
 VERSION=${VERSION:-3.9.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -78,7 +78,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-export SETUPTOOLS_SCM_PRETEND_VERSION=6.3.2
+export SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION
 
 python3 -m build --no-isolation
 python3 -m installer -d "$PKG" dist/*.whl

--- a/python/python3-virtualenv/python3-virtualenv.SlackBuild
+++ b/python/python3-virtualenv/python3-virtualenv.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-virtualenv
 VERSION=${VERSION:-20.17.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -64,7 +64,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-export SETUPTOOLS_SCM_PRETEND_VERSION=6.3.2
+export SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION
 
 python3 setup.py install --root=$PKG
 


### PR DESCRIPTION
A user faced issues with the SETUPTOOLS_SCM_PRETEND_VERSION.
I have made the fixes accordingly.