### PR TITLE
development/rust16: Updated for version 1.67.1.

### DIFF
--- a/development/rust16/README
+++ b/development/rust16/README
@@ -15,5 +15,5 @@ fi
 rust16 is not intended as a substitute for rustup or for the Slackware
 rust package in terms of rust development purposes.
 
-Separate downloads are available for i686 and x86_64. -current users can
-safely ignore rust16 as a dependency.
+Separate downloads are available for i686 and x86_64. -current users may
+be able to ignore rust16 as a dependency for some packages.

--- a/development/rust16/rust16.SlackBuild
+++ b/development/rust16/rust16.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust16
 SRCNAM=rust
-VERSION=${VERSION:-1.66.1}
+VERSION=${VERSION:-1.67.1}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/development/rust16/rust16.info
+++ b/development/rust16/rust16.info
@@ -1,12 +1,12 @@
 PRGNAM="rust16"
-VERSION="1.66.1"
+VERSION="1.67.1"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="f834f22e3a03b50499d6cfe738285ebb \
-        613c6932cddbc17567777fe9152e3828"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="4c09996d0c917950f80fdbd106e8f7db"
+DOWNLOAD="https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="925a743973266757648ec19f75585a2a \
+        06d6ec2ecda9ce3c32a322d039b3e9c5"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="8fd860b0d3420529bdb03a42043b8897"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"


### PR DESCRIPTION
The following packages are currently dependent on rust16:

* bat
* bottom
* clamav
* dust
* fd
* ncspot
* rustup

All of them build under x86_64, i686 and ARM.