### PR TITLE
python/cairocffi: Update README and Homepage

### DIFF
--- a/python/cairocffi/README
+++ b/python/cairocffi/README
@@ -5,3 +5,6 @@ including image buffers, PNG, PostScript, PDF, and SVG file output.
 API compatible with Pycairo.
 
 python3-xcffib is an optional dependency.
+
+cairocffi 1.4.0 is the last available version for Slackware 15.0. Newer
+versions require a newer python-setuptools.

--- a/python/cairocffi/cairocffi.SlackBuild
+++ b/python/cairocffi/cairocffi.SlackBuild
@@ -39,9 +39,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0

--- a/python/cairocffi/cairocffi.info
+++ b/python/cairocffi/cairocffi.info
@@ -1,6 +1,6 @@
 PRGNAM="cairocffi"
 VERSION="1.4.0"
-HOMEPAGE="https://github.com/SimonSapin/cairocffi"
+HOMEPAGE="https://github.com/Kozea/cairocffi"
 DOWNLOAD="https://files.pythonhosted.org/packages/source/c/cairocffi/cairocffi-1.4.0.tar.gz"
 MD5SUM="76ba90ccde8b9664f03bdc8e093ba2f6"
 DOWNLOAD_x86_64=""

--- a/python/cairocffi/slack-desc
+++ b/python/cairocffi/slack-desc
@@ -14,6 +14,6 @@ cairocffi: Cairo is a 2D vector graphics library with support for multiple
 cairocffi: backends. including image buffers, PNG, PostScript, PDF, and SVG
 cairocffi: file output. API compatible with Pycairo.
 cairocffi:
-cairocffi: Homepage: https://github.com/SimonSapin/cairocffi
+cairocffi: Homepage: https://github.com/Kozea/cairocffi
 cairocffi:
 cairocffi:


### PR DESCRIPTION
1. cairocffi 1.5.0 requires setuptools >= 61.0.0 (for context, Slackware 15.0 has 57.5.0).
2. Remove some SlackBuild commenting
3. Change homepage. github.com/SimonSapin now redirects to github.com/Kozea