### PR TITLE
development/rstudio-desktop: Update for 2023.03.0+386

### DIFF
--- a/development/rstudio-desktop/README
+++ b/development/rstudio-desktop/README
@@ -4,5 +4,8 @@ This builds the Linux desktop version.
 
 RStudio currently only supports 64-bit systems.
 
+This SlackBuild requires network access - it downloads external node
+modules with root access.
+
 The last supported version of RStudio for 32-bit systems is 1.1.463.
 A rstudio-desktop-legacy SlackBuild for 32-bit systems is available.

--- a/development/rstudio-desktop/rstudio-desktop.SlackBuild
+++ b/development/rstudio-desktop/rstudio-desktop.SlackBuild
@@ -3,7 +3,7 @@
 # Slackware build script for rstudio-desktop
 
 # Copyright 2018 Ekin Akoglu, Erdemli/Mersin, Turkey <ekinakoglu@gmail.com>
-# Copyright 2022 Isaac Yu <isaacyu1@isaacyu1.com>
+# Copyright 2022-2023 Isaac Yu <isaacyu1@isaacyu1.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -27,9 +27,9 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rstudio-desktop
 SRCNAM=rstudio
-VERSION=${VERSION:-2022.12.0+353}
+VERSION=${VERSION:-2023.03.0+386}
 SRCVER=${SRCVER:-$(echo $VERSION | sed 's/+/-/g')}
-GITCOMMIT_VER=7d165dc
+GITCOMMIT_VER=3c53477
 NODE_VER=${NODE_VER:-16.14.0}
 PANDOCVER=current
 BUILD=${BUILD:-1}
@@ -44,9 +44,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0
@@ -85,8 +82,8 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-# patches 
-patch -p1 < $CWD/pandoc_version.patch     # Do not use outdated pandoc version number
+# Do not use outdated pandoc version number
+patch -p1 < $CWD/pandoc_version.patch
 
 cd dependencies/common
 mkdir -p pandoc/$PANDOCVER
@@ -100,18 +97,21 @@ cd node && tar xvf $CWD/node-v$NODE_VER-linux-x64.tar.gz
 cd ../
 mv node/node-v$NODE_VER-linux-x64 node/$NODE_VER
 export PATH=$TMP/$SRCNAM-$SRCVER/dependencies/common/node/$NODE_VER/bin:$PATH     # use bundled node
-cd $TMP/$SRCNAM-$SRCVER/src/gwt/panmirror/src/editor
 
-# Prevent creation of cache files in /usr/local/share/
-env YARN_DISABLE_SELF_UPDATE_CHECK=true \
-  YARN_CACHE_FOLDER=$TMP/$SRCNAM-$SRCVER/cache/yarn \
-  yarn install --ignore-engines
+# Panmirror is picked up now from Quarto repo
+cd $TMP/$SRCNAM-$SRCVER/src/gwt/lib
+unzip $CWD/rstudio-cherry-blossom.zip
+mv quarto-release-rstudio-cherry-blossom quarto
 
 # Fix links for src/cpp/session/CMakeLists.txt
 cd $TMP/$SRCNAM-$SRCVER/dependencies
 ln -sfT common/dictionaries dictionaries
 ln -sfT common/mathjax-27 mathjax-27
 ln -sfT common/pandoc pandoc
+
+# Prevent creation of cache files in /usr/local/share/
+export YARN_DISABLE_SELF_UPDATE_CHECK=true
+export YARN_CACHE_FOLDER=$TMP/$SRCNAM-$SRCVER/cache/yarn
 
 cd $TMP/$SRCNAM-$SRCVER
 

--- a/development/rstudio-desktop/rstudio-desktop.info
+++ b/development/rstudio-desktop/rstudio-desktop.info
@@ -1,12 +1,14 @@
 PRGNAM="rstudio-desktop"
-VERSION="2022.12.0+353"
+VERSION="2023.03.0+386"
 HOMEPAGE="http://rstudio.com"
 DOWNLOAD="UNSUPPORTED"
 MD5SUM=""
-DOWNLOAD_x86_64="https://github.com/rstudio/rstudio/archive/refs/tags/v2022.12.0+353/rstudio-2022.12.0-353.tar.gz \
-                 https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-x64.tar.gz"
-MD5SUM_x86_64="b3b88d79a7b7924e797d142318e8585d \
-               a46e501a201be6c3c05c0f770c375372"
+DOWNLOAD_x86_64="https://github.com/rstudio/rstudio/archive/refs/tags/v2023.03.0+386/rstudio-2023.03.0-386.tar.gz \
+                 https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-x64.tar.gz \
+                 https://github.com/quarto-dev/quarto/archive/refs/heads/release/rstudio-cherry-blossom.zip"
+MD5SUM_x86_64="0981e9006094e26d1bbb0d87efd48be5 \
+               a46e501a201be6c3c05c0f770c375372 \
+               8b3e5247648e622c1c461a1b6362c7f5"
 REQUIRES="R pandoc-bin yaml-cpp hunspell-en yarn apache-ant zulu-openjdk8 mathjax2 soci"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu1@isaacyu1.com"


### PR DESCRIPTION
Also, this SlackBuild will download online external node modules.
The README will let users know of that.