### PR TITLE
python/python3-webcolors: Update README

### DIFF
--- a/python/python3-webcolors/README
+++ b/python/python3-webcolors/README
@@ -1,1 +1,4 @@
 webcolors is a module for working with HTML/CSS color definitions.
+
+python3-webcolors 1.1.2 is the last possible version for Slackware 15.0.
+Newer versions would require a newer python-setuptools.


### PR DESCRIPTION
python3-webcolors 1.13 requires python-setuptools >= 61.0 (for context, Slackware 15.0 has python-setuptools 57.5.0).