### PR TITLE
academic/root: fix #2603 and extend notes in the README file

### DIFF
--- a/academic/root/README
+++ b/academic/root/README
@@ -17,4 +17,20 @@ Compilation takes quite a while, thus consider to build ROOT like that:
 
 REQUIREMENTS: gl2ps libAfterImage python3-numpy tbb ftgl
 
-NOTE: ROOT's python TMVA requires python3-numpy built over blas.
+NOTES:
+  - ROOT's python TMVA requires python3-numpy being built over blas.
+
+  - This SlackBuild sets the root7 build option to ON in order to
+    prepare the migration to the new ROOT 7 release. More on the ROOT 7
+    features you can find here:
+        https://root.cern/for_developers/root7
+
+  - Starting from ROOT version 6.26/00 it uses the web-based version for
+    the TBrowser if it is build with the root7 option being ON. You can
+    switch back to the Win95-looking TBrowser by adding the following
+    line to your $HOME/.rootrc file:
+        Browser.Name: TRootBrowser
+
+  - Starting from ROOT 6.28/00 version, one can use rootssh script for
+    automatic configuration of ssh tunnel, necessary for web widgets:
+        rootssh username@remotenode

--- a/academic/root/root.SlackBuild
+++ b/academic/root/root.SlackBuild
@@ -90,6 +90,7 @@ cmake ../src \
   -Dbuiltin_davix=OFF \
   -Dbuiltin_fftw3=OFF \
   -Dbuiltin_gsl=OFF \
+  -Dbuiltin_gtest=OFF \
   -Dbuiltin_openssl=OFF \
   -Dbuiltin_tbb=OFF \
   -Dbuiltin_vc=OFF \


### PR DESCRIPTION
  - 2f103fbfc08f6fd99ef402b3c8fc9f1bce6ab460 fixes the [issue](https://github.com/SlackBuildsOrg/slackbuilds/pull/2603#issuecomment-1492641618) reported by @aclemons 
  - 1eb659b658f68cacbf400f60e1ccdb2f48079322 updates the README file with notes on the ROOT 7 features