### PR TITLE
development/rstudio-desktop: Fix MD5SUM

### DIFF
--- a/development/rstudio-desktop/rstudio-desktop.info
+++ b/development/rstudio-desktop/rstudio-desktop.info
@@ -8,7 +8,7 @@ DOWNLOAD_x86_64="https://github.com/rstudio/rstudio/archive/refs/tags/v2023.03.0
                  https://github.com/quarto-dev/quarto/archive/refs/heads/release/rstudio-cherry-blossom.zip"
 MD5SUM_x86_64="0981e9006094e26d1bbb0d87efd48be5 \
                a46e501a201be6c3c05c0f770c375372 \
-               8b3e5247648e622c1c461a1b6362c7f5"
+               59f83489b873ac3516e47f130956b8cf"
 REQUIRES="R pandoc-bin yaml-cpp hunspell-en yarn apache-ant zulu-openjdk8 mathjax2 soci"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu1@isaacyu1.com"


### PR DESCRIPTION
I am unsure whether the MD5SUM for the rstudio-cherry-blossom zip file changes over time.