### PR TITLE
system/yabsm: ensure builds with system perl

### DIFF
--- a/system/yabsm/yabsm.SlackBuild
+++ b/system/yabsm/yabsm.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=yabsm
 VERSION=${VERSION:-3.15.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -62,7 +62,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-perl Makefile.PL \
+/usr/bin/perl Makefile.PL \
   PREFIX=/usr \
   INSTALLDIRS=vendor \
   INSTALLVENDORMAN1DIR=/usr/man/man1 \


### PR DESCRIPTION
I updated yabsm.SlackBuild to explicitly run yabsm's Makefile.PL with /usr/bin/perl instead of just "perl". If an alternative perl were to come first in $PATH then the shebang of the yabsm executable script will point to this perl. Depending on the version and configuration of that perl, yabsm may run improperly.