### PR TITLE
system/cdemu-daemon: Fix cdemu-daemon udev rule

### DIFF
--- a/system/cdemu-daemon/cdemu-daemon.SlackBuild
+++ b/system/cdemu-daemon/cdemu-daemon.SlackBuild
@@ -4,7 +4,7 @@
 
 # Copyright 2008 Niklas "Nille" Åkerström
 # Copyright 2010-2013 Niels Horn, Rio de Janeiro, RJ, Brazil <niels.horn@gmail.com>
-# Copyright 2018-2022 Isaac Yu <isaacyu1@isaacyu1.com>
+# Copyright 2018-2023 Isaac Yu <isaacyu1@isaacyu1.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -31,7 +31,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=cdemu-daemon
 VERSION=${VERSION:-3.2.6}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -124,7 +124,7 @@ cp $CWD/config/cdemu-daemon-dbus.conf \
 sed -i 's/group="root"/group="'$GROUP'"/' \
   $PKG/etc/dbus-1/system.d/cdemu-daemon-dbus.conf.new
 mkdir -p $PKG/etc/udev/rules.d
-echo 'KERNEL=="vhba_ctl", NAME="%k", MODE="0660", OWNER="root", GROUP="'$GROUP'"' \
+echo 'KERNEL=="vhba_ctl", MODE="0660", OWNER="root", GROUP="'$GROUP'"' \
   > $PKG/etc/udev/rules.d/99-vhba.rules.new
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION


### PR DESCRIPTION
A slackbuild user mentioned this message:
`/var/log/syslog: "Apr 14 12:31:34 overlord udevd[731]:  NAME="%k" is ignored, because it breaks kernel supplied names, please remove it from /etc/udev/rules.d/99-vhba.rules:1"`

My change fixes this issue.