### PR TITLE
development/rust16: Update README.

### DIFF
--- a/development/rust16/README
+++ b/development/rust16/README
@@ -12,6 +12,9 @@ else
   export LD_LIBRARY_PATH="/opt/rust16/lib$LIBDIRSUFFIX:$LD_LIBRARY_PATH"
 fi
 
+If your SlackBuild experiences build failures on 64-bit systems, please
+ensure that the LIBDIRSUFFIX variable is set.
+
 rust16 is not intended as a substitute for rustup or for the Slackware
 rust package in terms of rust development purposes.
 


### PR DESCRIPTION
Just adding a reminder that scripts building with this version of `rust` do need `LIBDIRSUFFIX`.