### PR TITLE
python/iniconfig: Remove Python 2 support

### DIFF
--- a/python/iniconfig/iniconfig.SlackBuild
+++ b/python/iniconfig/iniconfig.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=iniconfig
 VERSION=${VERSION:-1.1.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -38,9 +38,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0
@@ -79,7 +76,6 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-python2 setup.py install --root=$PKG
 python3 setup.py install --root=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/python/iniconfig/iniconfig.info
+++ b/python/iniconfig/iniconfig.info
@@ -1,7 +1,7 @@
 PRGNAM="iniconfig"
 VERSION="1.1.1"
 HOMEPAGE="https://github.com/RonnyPfannschmidt/iniconfig"
-DOWNLOAD="https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz"
+DOWNLOAD="https://files.pythonhosted.org/packages/source/i/iniconfig/iniconfig-1.1.1.tar.gz"
 MD5SUM="0b7f3be87481211c183eae095bcea6f1"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""


### PR DESCRIPTION
The only package that directly depends on iniconfig is python3-pytest (which is, of course, a Python 3 package).