### PR TITLE
system/vhba-module: Allow building with custom kernel versions

### DIFF
--- a/system/vhba-module/README
+++ b/system/vhba-module/README
@@ -6,3 +6,7 @@ CD/DVD-ROM device emulator for linux.
 
 NOTE:
 The resulting package will be specific for the kernel it was built on.
+
+It is possible to build package for a different kernel version by
+setting the KERNEL variable as in:
+    KERNEL=5.15.94 ./vhba-module.SlackBuild

--- a/system/vhba-module/doinst.sh
+++ b/system/vhba-module/doinst.sh
@@ -1,2 +1,1 @@
-chroot . /sbin/depmod -a
-
+chroot . /sbin/depmod -a @KERNEL@

--- a/system/vhba-module/vhba-module.SlackBuild
+++ b/system/vhba-module/vhba-module.SlackBuild
@@ -4,7 +4,7 @@
 
 # Copyright 2008-2009 Heinz Wiesinger, Amsterdam, The Netherlands
 # Copyright 2010-2012 Niels Horn, Rio de Janeiro, RJ, Brazil <niels.horn@gmail.com>
-# Copyright 2018-2022 Isaac Yu <isaacyu1@isaacyu1.com>
+# Copyright 2018-2023 Isaac Yu <isaacyu1@isaacyu1.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -84,7 +84,7 @@ cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc
-cat $CWD/doinst.sh > $PKG/install/doinst.sh
+sed "s%@KERNEL@%$KERNEL%" $CWD/doinst.sh > $PKG/install/doinst.sh
 
 cd $PKG
 /sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-${VERSION}_$PKGKERNEL-$SLKARCH-$BUILD$TAG.$PKGTYPE


### PR DESCRIPTION
This will allow users to rebuild vhba-module after upgrading the kernel (without rebooting).

Another Slackware user made this suggestion.