### PR TITLE
development/rstudio-desktop: Move /usr/lib to /usr/lib64

### DIFF
--- a/development/rstudio-desktop/rstudio-desktop.SlackBuild
+++ b/development/rstudio-desktop/rstudio-desktop.SlackBuild
@@ -29,7 +29,7 @@ PRGNAM=rstudio-desktop
 SRCNAM=rstudio
 VERSION=${VERSION:-2023.03.0+386}
 SRCVER=${SRCVER:-$(echo $VERSION | sed 's/+/-/g')}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -61,7 +61,10 @@ set -e
 
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
-cd $PKG
+cd $TMP
+rm -rf rstudio-${VERSION/+/-}
+mkdir rstudio-${VERSION/+/-}
+cd rstudio-${VERSION/+/-}
 bsdtar -xvf $CWD/$SRCNAM-$SRCVER-$PACKAGESUFFIX.rpm
 chown -R root:root .
 find -L . \
@@ -70,15 +73,23 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+mkdir -p $PKG/usr/{bin,lib64}
+cp -a usr/lib/rstudio $PKG/usr/lib64
+cp -a usr/share $PKG/usr
+
+cd $PKG/usr/bin
+ln -s ../lib64/rstudio/rstudio .
+cd -
+
+# We use the symlink in /usr/bin
+sed -i 's:/usr/lib/rstudio/rstudio:rstudio:' $PKG/usr/share/applications/rstudio.desktop
+
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
-mkdir -p $PKG/usr/bin
-ln -sf /usr/lib/rstudio/rstudio $PKG/usr/bin
-
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \
-  $PKG/usr/lib/rstudio/resources/app/{COPYING,INSTALL,NOTICE,README.md,SOURCE} \
+  $PKG/usr/lib64/rstudio/resources/app/{COPYING,INSTALL,NOTICE,README.md,SOURCE} \
   $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 


### PR DESCRIPTION
Credits to @slackalaxy.

I now better understand his rstudio-desktop [SlackBuild](https://github.com/slackalaxy/misc/blob/master/preliminary/rstudio-desktop-bin).

slackalaxy extracts the rstudio binary to $TMP, then copies the extracted directories to $PKG (under /usr/lib64).
Therefore, only /usr/lib64 (without /usr/lib) is present in the .tgz package.