### PR TITLE
development/rust16: Updated for version 1.68.2.

### DIFF
--- a/development/rust16/rust16.SlackBuild
+++ b/development/rust16/rust16.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust16
 SRCNAM=rust
-VERSION=${VERSION:-1.67.1}
+VERSION=${VERSION:-1.68.2}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/development/rust16/rust16.info
+++ b/development/rust16/rust16.info
@@ -1,12 +1,12 @@
 PRGNAM="rust16"
-VERSION="1.67.1"
+VERSION="1.68.2"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="925a743973266757648ec19f75585a2a \
-        06d6ec2ecda9ce3c32a322d039b3e9c5"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="8fd860b0d3420529bdb03a42043b8897"
+DOWNLOAD="https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="ceeeb627c251543b2c7c82e700f184fe \
+        29d96f426f480496ed9b0a805f8bb07c"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="08a0d1d1380e633134a1a8be877c176a"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"


### PR DESCRIPTION
All `rust16` reverse dependencies built successfully on x86_64, i686 and arm:

* `alacritty`
* `bat`
* `bottom`
* `clamav`
* `dust`
* `fd`
* `hyperfine`
* `ncspot`
* `newsboat`
* `rustup`