### PR TITLE
desktop/dwmblocks: Change version formatting

### DIFF
--- a/desktop/dwmblocks/dwmblocks.SlackBuild
+++ b/desktop/dwmblocks/dwmblocks.SlackBuild
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=dwmblocks
-VERSION=${VERSION:-2022.01.07}
+VERSION=${VERSION:-20220107}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/desktop/dwmblocks/dwmblocks.info
+++ b/desktop/dwmblocks/dwmblocks.info
@@ -1,5 +1,5 @@
 PRGNAM="dwmblocks"
-VERSION="2022.01.07"
+VERSION="20220107"
 HOMEPAGE="https://github.com/torrinfail/dwmblocks"
 DOWNLOAD="https://github.com/torrinfail/dwmblocks/archive/a933ce0/dwmblocks-a933ce0d6109524b393feb3e7156cbf0de88b42c.tar.gz"
 MD5SUM="7d0399af33c7c1d9fe33136357aa392d"


### PR DESCRIPTION
There isn't a dwmblocks source tarball with the version number 2022.01.07 or 20220107.
Rather, the version number is the date of the git commit.
I would like the verison number to be formatted to 20220107 rather than 2022.01.07 (that is, remove the periods).

Other slackbuilds of this type do not have periods in their version numbers.