### PR TITLE
python/python3-anyio: Update README

### DIFF
--- a/python/python3-anyio/README
+++ b/python/python3-anyio/README
@@ -2,3 +2,7 @@ AnyIO is an asynchronous networking and concurrency library that works
 on top of either asyncio or trio. It implements trio-like structured
 concurrency (SC) on top of asyncio, and works in harmony with the
 native SC of trio itself.
+
+python3-anyio 3.6.2 is the last possible version for Slackware 15.0.
+Newer versions would require a newer python-setuptools and
+python-setuptools_scm.

--- a/python/python3-anyio/python3-anyio.SlackBuild
+++ b/python/python3-anyio/python3-anyio.SlackBuild
@@ -40,9 +40,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0


### PR DESCRIPTION
1. python3-anyio 3.7.0 has just been released; however, it depends on python-setuptools >=64 and python-setuptools_scm >= 6.4.
2. I have also removed some commenting (to fix formatting).