### PR TITLE
desktop/breath-gtk-theme: Change version format

### DIFF
--- a/desktop/breath-gtk-theme/breath-gtk-theme.SlackBuild
+++ b/desktop/breath-gtk-theme/breath-gtk-theme.SlackBuild
@@ -25,12 +25,13 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=breath-gtk-theme
-VERSION=${VERSION:-da2706640f457f89de6c26312e391b244ff550b4}
+VERSION=${VERSION:-5.9.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
 SRCNAM=breath-gtk
+COMMIT=${COMMIT:-da2706640f457f89de6c26312e391b244ff550b4}
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
@@ -40,9 +41,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0
@@ -71,13 +69,13 @@ set -e
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
-rm -rf $SRCNAM-$VERSION
-TARBALL=$CWD/$VERSION.tar.gz
+rm -rf $SRCNAM-$COMMIT
+TARBALL=$CWD/$COMMIT.tar.gz
 if [ ! -e $TARBALL ] ; then
-  TARBALL=$CWD/breath-gtk-$VERSION.tar.gz
+  TARBALL=$CWD/breath-gtk-$COMMIT.tar.gz
 fi
 tar xvf $TARBALL
-cd $SRCNAM-$VERSION
+cd $SRCNAM-$COMMIT
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 -o -perm 511 \) \
@@ -90,8 +88,8 @@ cd build
   cmake -DCMAKE_C_FLAGS:STRING="${SLKCFLAGS}" \
         -DCMAKE_CXX_FLAGS:STRING="${SLKCFLAGS}" \
         -DCMAKE_INSTALL_PREFIX=/usr \
-         -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
-         ..
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
+        ..
   make
   make install DESTDIR=$PKG
 cd ..

--- a/desktop/breath-gtk-theme/breath-gtk-theme.info
+++ b/desktop/breath-gtk-theme/breath-gtk-theme.info
@@ -1,5 +1,5 @@
 PRGNAM="breath-gtk-theme"
-VERSION="da2706640f457f89de6c26312e391b244ff550b4"
+VERSION="5.9.0"
 HOMEPAGE="https://gitlab.manjaro.org/artwork/themes/breath-gtk"
 DOWNLOAD="https://gitlab.manjaro.org/artwork/themes/breath-gtk/-/archive/da2706640f457f89de6c26312e391b244ff550b4.tar.gz"
 MD5SUM="a0d510c87a9675d463190075294a08c6"


### PR DESCRIPTION
This is not actually a version update.
I have only changed the SlackBuild version format.

The Arch Linux AUR similarly lists breath-gtk-theme at version 5.9.0:
https://aur.archlinux.org/packages/breath-gtk-theme

I don't recommend breath-gtk-theme for Slackware 15.0 anyway.
It's an old package meant for GTK 3.16 (for context, Slackware 15.0 has GTK 3.24).