### PR TITLE
python/python3-dulwich: fix wrong build using updated setuptools

### DIFF
--- a/python/python3-dulwich/python3-dulwich.SlackBuild
+++ b/python/python3-dulwich/python3-dulwich.SlackBuild
@@ -28,7 +28,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=python3-dulwich
 SRCNAM=${PRGNAM#python3-*}
 VERSION=${VERSION:-0.21.5}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -67,6 +67,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+export PYTHONPATH=/opt/python3.9/site-packages/
 python3 setup.py install --root=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/python/python3-dulwich/python3-dulwich.info
+++ b/python/python3-dulwich/python3-dulwich.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://pypi.python.org/packages/source/d/dulwich/dulwich-0.21.5.tar.g
 MD5SUM="08b553a524041741604d0f5f9a45cd3d"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES=""
+REQUIRES="python3-setuptools-opt"
 MAINTAINER="Yth - Arnaud"
 EMAIL="yth@ythogtha.org"


### PR DESCRIPTION
Following discussion on SBo mailing list, this update will fix the build when python3-setuptools-opt is added by fourtysixandtwo.
Please wait until submission, and acceptance, of python3-setuptools-opt, then this should be ok immediately.

There is no need to be smart about the hardcoded python version in PYTHONPATH, because python will be updated on Slackware current, which already have a sufficiently uptodate setuptools. So this is for slackware-15.0 only, hence python 3.9 only.

Furthermore, the PYTHONPATH line does not prevent, in the absence of the given PATH, the proper build of this package on box with an updated setuptools like on slackware-current.
So this'll work everywhere.