### PR TITLE
development/rust16: Updated for version 1.69.0.

### DIFF
--- a/development/rust16/rust16.SlackBuild
+++ b/development/rust16/rust16.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust16
 SRCNAM=rust
-VERSION=${VERSION:-1.68.2}
+VERSION=${VERSION:-1.69.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/development/rust16/rust16.info
+++ b/development/rust16/rust16.info
@@ -1,12 +1,12 @@
 PRGNAM="rust16"
-VERSION="1.68.2"
+VERSION="1.69.0"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="ceeeb627c251543b2c7c82e700f184fe \
-        29d96f426f480496ed9b0a805f8bb07c"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="08a0d1d1380e633134a1a8be877c176a"
+DOWNLOAD="https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="0d4793166e2b080869ae51896cf4491f \
+        e3dcec04df7703c3f81e68b5ea443dac"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="36b4ff5b35b12f0d1f616937aa659fc0"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"


### PR DESCRIPTION
rust16 currently has the following reverse dependencies, which built successfully on x86_64, i686 and ARM:

* alacritty
* bat
* bottom
* clamav
* dust
* fd
* hyperfine
* ncspot
* newsboat
* rustup
* skim