### PR TITLE
python/python3-ZODB: fixed

### DIFF
--- a/python/python3-ZODB/python3-ZODB.SlackBuild
+++ b/python/python3-ZODB/python3-ZODB.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=python3-ZODB
 SRCNAM=${PRGNAM#python3-*}
 VERSION=${VERSION:-5.8.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 


### PR DESCRIPTION
Looks like the python3-BTrees is already in REQUIRES, so only a build bump here.