### PR TITLE
development/rust16: Updated for version 1.70.0.

### DIFF
--- a/development/rust16/rust16.SlackBuild
+++ b/development/rust16/rust16.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust16
 SRCNAM=rust
-VERSION=${VERSION:-1.69.0}
+VERSION=${VERSION:-1.70.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -102,8 +102,15 @@ rust-analyzer-preview,\
 rust-demangler-preview,\
 rustfmt-preview
 
-find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
-  | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
+find $PKG/opt/$PRGNAM/lib -type f -name "*.so" -exec chmod +x {} \; 2> /dev/null || true
+# As of 1.70.0, stripping the libraries causes memory faults on Slackware64-15.0.
+if [ $ARCH = "x86_64" ]; then
+  find $PKG -print0 | xargs -0 file | grep "executable" | grep ELF \
+    | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
+else
+  find $PKG -print0 | xargs -0 file | grep -e "executable"  -e "shared object" | grep ELF \
+    | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
+fi
 
 rm -f $PKG/opt/$PRGNAM/lib/rustlib/uninstall.sh
 rm -f $PKG/opt/$PRGNAM/lib/rustlib/install.log

--- a/development/rust16/rust16.info
+++ b/development/rust16/rust16.info
@@ -1,12 +1,12 @@
 PRGNAM="rust16"
-VERSION="1.69.0"
+VERSION="1.70.0"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="0d4793166e2b080869ae51896cf4491f \
-        e3dcec04df7703c3f81e68b5ea443dac"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="36b4ff5b35b12f0d1f616937aa659fc0"
+DOWNLOAD="https://static.rust-lang.org/dist/2023-06-01/rust-1.70.0-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2023-06-01/rust-1.70.0-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="b56197499321c7b5e43812787e5dbe65 \
+        8e9fa4750ea9e33be9c1a96f6cfb1035"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-06-01/rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="b893174d8c961d426390292aebeec149"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"


### PR DESCRIPTION
All reverse dependencies build on x86_64, i686 and ARM.

I'm aware of the 20-arch `sbopkglint` failure on 64-bit. Stripping the libraries unfortunately causes memory faults on Slackware64-15.0. Sorry for any inconvenience. The plan at this point is to remain in sync with -current until some version of `rust` fixes this problem (won't be 1.71.0; already checked).