### PR TITLE
python/python3-cairocffi: updated README

### DIFF
--- a/python/python3-cairocffi/README
+++ b/python/python3-cairocffi/README
@@ -5,6 +5,3 @@ including image buffers, PNG, PostScript, PDF, and SVG file output.
 API compatible with Pycairo.
 
 python3-xcffib is an optional dependency.
-
-cairocffi 1.4.0 is the last available version for Slackware 15.0. Newer
-versions require a newer python-setuptools.


### PR DESCRIPTION
Doesn't seems like a build bump is necessary here...