### PR TITLE
python/python3-twisted: fixed for zope.interface 6.x

### DIFF
--- a/python/python3-twisted/python3-twisted.SlackBuild
+++ b/python/python3-twisted/python3-twisted.SlackBuild
@@ -30,7 +30,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=python3-twisted
 SRCNAM=${PRGNAM#python3-*}
 VERSION=${VERSION:-23.8.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -63,6 +63,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -85,6 +88,9 @@ find -L . \
 
 python3 -m build --no-isolation
 python3 -m installer -d "$PKG" dist/*.whl
+
+# Fix initialization bug with zope.interface 6+
+sed -i 's#zope-interface#zope.interface#' "$PKG/usr/lib${LIBDIRSUFFIX}/python3.9/site-packages/twisted-${VERSION}.dist-info/METADATA"
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true


### PR DESCRIPTION
zope.interface changed internal name from zope-interface, which breaks twisted dependency checks, but not immediately, hence I didn't see it early enough.
That fixes it.