### PR TITLE
python/python3-autobahn: REQUIRES update

### DIFF
--- a/python/python3-autobahn/python3-autobahn.SlackBuild
+++ b/python/python3-autobahn/python3-autobahn.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=python3-autobahn
 SRCNAM=${PRGNAM#python3-*}
 VERSION=${VERSION:-23.6.2}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -58,6 +58,9 @@ elif [ "$ARCH" = "i686" ]; then
   SLKCFLAGS="-O2 -march=i686 -mtune=i686"
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "x86_64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
 else

--- a/python/python3-autobahn/python3-autobahn.info
+++ b/python/python3-autobahn/python3-autobahn.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://pypi.python.org/packages/source/a/autobahn/autobahn-23.6.2.tar
 MD5SUM="f29d3cebec06c81a87823a2776ffcc5c"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-txaio cryptography hyperlink"
+REQUIRES="python3-txaio cryptography python3-hyperlink"
 MAINTAINER="Yth - Arnaud"
 EMAIL="yth@ythogtha.org"


### PR DESCRIPTION
For acknowledging the renaming of hyperlink to python3-hyperlink.
Do not merge before validation of python3-hyperlink submission.