### PR TITLE
desktop/nwg-shell-config: Updated for version 0.5.24

### DIFF
--- a/desktop/nwg-shell-config/nwg-shell-config.SlackBuild
+++ b/desktop/nwg-shell-config/nwg-shell-config.SlackBuild
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=nwg-shell-config
-VERSION=${VERSION:-0.5.23}
+VERSION=${VERSION:-0.5.24}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -73,7 +73,7 @@ rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
 rm -rf $PRGNAM-$VERSION
-tar xvf $CWD/$PRGNAM-$VERSION.tar.?z || tar xvf $CWD/v$VERSION.tar.?z
+tar xvf $CWD/$PRGNAM-$VERSION.tar.?z
 cd $PRGNAM-$VERSION
 chown -R root:root .
 
@@ -93,9 +93,9 @@ cp nwg-shell-config.desktop $PKG/usr/share/applications
 cp *.svg $PKG/usr/share/pixmaps
 
 # Include Slackware logo on System Info screen
-# https://commons.wikimedia.org/wiki/File:Slackware_logo.svg
-# Licensed under the GPL by Bob Moser
-cp $CWD/Slackware_logo.svg $PKG/usr/share/pixmaps/Slackware.svg
+# Antü Plasma-KDE Theme licensed under the CREATIVE COMMONS BY-SA 3.0.
+# https://github.com/fabianalexisinostroza/Antu-icons by Fabián Alexis.
+cp $CWD/Antu_distributor-logo-slackware.svg $PKG/usr/share/pixmaps/Slackware.svg
 
 # manually remove installed Arch specific updater bins
 # if these aren't removed, a non-working applet will appear in WM

--- a/desktop/nwg-shell-config/nwg-shell-config.info
+++ b/desktop/nwg-shell-config/nwg-shell-config.info
@@ -1,10 +1,10 @@
 PRGNAM="nwg-shell-config"
-VERSION="0.5.23"
+VERSION="0.5.24"
 HOMEPAGE="https://github.com/nwg-piotr/nwg-shell-config/"
-DOWNLOAD="https://github.com/nwg-piotr/nwg-shell-config/archive/v0.5.23/nwg-shell-config-0.5.23.tar.gz \
-          https://slackware.lngn.net/pub/source/nwg-shell-config/Slackware_logo.svg"
-MD5SUM="fef97d85c8c0c7d8b9b3d5c031a37196 \
-        275ee1d6ab047f12df0da19a4e99963d"
+DOWNLOAD="https://github.com/nwg-piotr/nwg-shell-config/archive/v0.5.24/nwg-shell-config-0.5.24.tar.gz \
+          https://slackware.lngn.net/pub/source/nwg-shell-config/Antu_distributor-logo-slackware.svg"
+MD5SUM="ddb4bdc470753958e4e91063e0ca13db \
+        bae7126cf7fbb634e09ddedd861a133d"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="gtklock playerctl geopy i3ipc python3-wheel wlsunset"


### PR DESCRIPTION
I've also updated the Slackware logo svg to a better suited image that scales properly in the gui.