### PR TITLE
python/python3-gensim: Update README

### DIFF
--- a/python/python3-gensim/README
+++ b/python/python3-gensim/README
@@ -2,7 +2,3 @@ Gensim is a Python library for topic modelling, document indexing and
 similarity retrieval with large corpora. Target audience is the
 natural language processing (NLP) and information retrieval (IR)
 community.
-
-Upstream has built Gensim > 4.1.2 with higher versions of Cython (i.e.
-at > 0.29.27). Therefore, python3-gensim will stay at 4.1.2 on
-Slackware 15.0.


### PR DESCRIPTION
The SlackBuild README is outdated. Cython is now at 0.29.36. Therefore, python3-gensim can be updated to later versions.

I am not returning to regular SlackBuild maintenance just yet (This means I am not updating the python3-gensim version).