### PR TITLE
libraries/gupnp-av add patch for libxml2

### DIFF
--- a/libraries/gupnp-av/gupnp-av.SlackBuild
+++ b/libraries/gupnp-av/gupnp-av.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=gupnp-av
 VERSION=${VERSION:-0.14.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -75,6 +75,8 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+patch -Np1 -i "$CWD/use_xmlReadMemory_instead_of_xmlRecoverMemory.patch"
 
 mkdir build
 cd build

--- a/libraries/gupnp-av/use_xmlReadMemory_instead_of_xmlRecoverMemory.patch
+++ b/libraries/gupnp-av/use_xmlReadMemory_instead_of_xmlRecoverMemory.patch
@@ -1,0 +1,34 @@
+From 4dbc4c1da2a033c497d84a1291c46f416a9cac51 Mon Sep 17 00:00:00 2001
+From: David Anes <david.anes@suse.com>
+Date: Thu, 4 May 2023 11:54:02 +0200
+Subject: use xmlReadMemory instead of xmlRecoverMemory, as it's been
+ deprecated in libxml2 2.11.0
+
+Since version 2.11.0, some private symbols have been removed.
+---
+Index: gupnp-av-0.14.1/libgupnp-av/gupnp-didl-lite-parser.c
+===================================================================
+--- gupnp-av-0.14.1.orig/libgupnp-av/gupnp-didl-lite-parser.c
++++ gupnp-av-0.14.1/libgupnp-av/gupnp-didl-lite-parser.c
+@@ -230,7 +230,7 @@ gupnp_didl_lite_parser_parse_didl_recurs
+         GUPnPAVXMLDoc *xml_doc = NULL;
+         gboolean       result;
+ 
+-        doc = xmlRecoverMemory (didl, strlen (didl));
++        doc = xmlReadMemory (didl, strlen (didl), NULL, NULL, XML_PARSE_RECOVER);
+         if (doc == NULL) {
+                 g_set_error (error,
+                              G_MARKUP_ERROR,
+Index: gupnp-av-0.14.1/libgupnp-av/gupnp-feature-list-parser.c
+===================================================================
+--- gupnp-av-0.14.1.orig/libgupnp-av/gupnp-feature-list-parser.c
++++ gupnp-av-0.14.1/libgupnp-av/gupnp-feature-list-parser.c
+@@ -114,7 +114,7 @@ gupnp_feature_list_parser_parse_text
+         xmlNode      *element;
+         GList        *feature_list = NULL;
+ 
+-        doc = xmlRecoverMemory (text, strlen (text));
++        doc = xmlReadMemory (text, strlen (text), NULL, NULL, XML_PARSE_RECOVER);
+         if (doc == NULL) {
+                 g_set_error (error,
+                              G_MARKUP_ERROR,


### PR DESCRIPTION
The current gupnp-av build fails to build since the latest updates to libxml2 in Slackware 15.0. This patch fixes building gupnp-av with the latest versions of libxml2.