### PR TITLE
desktop/gnome-session: Update SlackBuild

### DIFF
--- a/desktop/gnome-session/gnome-session.SlackBuild
+++ b/desktop/gnome-session/gnome-session.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=gnome-session
 VERSION=${VERSION:-42.0}
-BUILD=${BUILD:-3}
+BUILD=${BUILD:-4}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -54,6 +54,9 @@ elif [ "$ARCH" = "i686" ]; then
   SLKCFLAGS="-O2 -march=i686 -mtune=i686"
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "x86_64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
 else
@@ -108,6 +111,10 @@ find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | gr
 
 find $PKG/usr/man -type f -exec gzip -9 {} \;
 for i in $( find $PKG/usr/man -type l ) ; do ln -s $( readlink $i ).gz $i.gz ; rm $i ; done
+
+# Remove these duplicate desktop session entires:
+rm -f $PKG/usr/share/wayland-sessions/gnome.desktop
+rm -f $PKG/usr/share/xsessions/gnome.desktop
 
 mkdir -p $PKG/etc/X11/xinit
 cat $CWD/xinitrc.gnome > $PKG/etc/X11/xinit/xinitrc.gnome


### PR DESCRIPTION
This update removes a couple duplicate files that were installed by the gnome-session package. Also added aarch64 support to the SlackBuild, in line with the SBo templates.