### PR TITLE
development/jupyter-notebook: Fix errors associated with traitlets>=5.10

### DIFF
--- a/development/jupyter-notebook/fix-traitlets-error.patch
+++ b/development/jupyter-notebook/fix-traitlets-error.patch
@@ -1,0 +1,21 @@
+--- a/notebook/notebookapp.py
++++ b/notebook/notebookapp.py
+@@ -1408,7 +1408,7 @@
+             # and allow jupyter_server contents managers to pass
+             # through. If jupyter_server is not installed, this class
+             # will be ignored.
+-            'jupyter_server.contents.services.managers.ContentsManager'
++            "jupyter_server.services.contents.managers.ContentsManager",
+         ],
+         config=True,
+         help=_('The notebook manager class to use.')
+--- a/notebook/traittypes.py
++++ b/notebook/traittypes.py
+@@ -1,5 +1,6 @@
+ import inspect
+-from traitlets import ClassBasedTraitType, Undefined, warn
++from warnings import warn
++from traitlets import ClassBasedTraitType, Undefined
+ 
+ # Traitlet's 5.x includes a set of utilities for building
+ # description strings for objects. Traitlets 5.x does not

--- a/development/jupyter-notebook/jupyter-notebook.SlackBuild
+++ b/development/jupyter-notebook/jupyter-notebook.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=jupyter-notebook
 VERSION=${VERSION:-6.5.4}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -78,6 +78,10 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# Fix traitlets warning and error:
+# https://github.com/jupyter/notebook/pull/7051
+patch -p1 < $CWD/fix-traitlets-error.patch
 
 python3 setup.py install --root=$PKG
 


### PR DESCRIPTION
I received the following error and warning (respectively) from running jupyter-notebook:

```
Traceback (most recent call last):
  File "/usr/lib64/python3.9/site-packages/notebook/traittypes.py", line 235, in _resolve_classes
    klass = self._resolve_string(klass)
  File "/usr/lib64/python3.9/site-packages/traitlets/traitlets.py", line 2028, in _resolve_string
    return import_item(string)
  File "/usr/lib64/python3.9/site-packages/traitlets/utils/importstring.py", line 31, in import_item
    module = __import__(package, fromlist=[obj])
ModuleNotFoundError: No module named 'jupyter_server.contents'

Traceback (most recent call last):
  File "/usr/bin/jupyter-notebook", line 33, in <module>
    sys.exit(load_entry_point('notebook==6.5.4', 'console_scripts', 'jupyter-notebook')())
  File "/usr/lib64/python3.9/site-packages/jupyter_core/application.py", line 281, in launch_instance
    super().launch_instance(argv=argv, **kwargs)
  File "/usr/lib64/python3.9/site-packages/traitlets/config/application.py", line 1051, in launch_instance
    app = cls.instance(**kwargs)
  File "/usr/lib64/python3.9/site-packages/traitlets/config/configurable.py", line 581, in instance
    inst = cls(*args, **kwargs)
  File "/usr/lib64/python3.9/site-packages/traitlets/traitlets.py", line 1313, in __new__
    inst.setup_instance(*args, **kwargs)
  File "/usr/lib64/python3.9/site-packages/traitlets/traitlets.py", line 1356, in setup_instance
    super(HasTraits, self).setup_instance(*args, **kwargs)
  File "/usr/lib64/python3.9/site-packages/traitlets/traitlets.py", line 1332, in setup_instance
    init(self)
  File "/usr/lib64/python3.9/site-packages/notebook/traittypes.py", line 226, in instance_init
    self._resolve_classes()
  File "/usr/lib64/python3.9/site-packages/notebook/traittypes.py", line 238, in _resolve_classes
    warn(f"{klass} is not importable. Is it installed?", ImportWarning)
TypeError: warn() missing 1 required keyword-only argument: 'stacklevel'
```

traitlets at version >=5.10 had brought about this issue.

My patch is drawn from the following discussion (by the way, the pull request below was already merged in jupyter-notebook 6.5.6):
https://github.com/jupyter/notebook/pull/7051

I am not upgrading to jupyter-notebook 7, as it requires jupyterlab 4 (which itself I cannot upgrade due to requiring python-requests > 2.26).
I am also not upgrading to jupyter-notebook 6.5.6 - it invokes requirements of jupyter_client <8 and pyzmq <25 (these requirements were already added in jupyter-notebook 6.5.5). I will not ask Christoph to downgrade pyzmq.
Therefore, I think the only logical conclusion is to add this patch.