### PR TITLE
system/pass-import: Update README (list python3-pykeepass as optional DEP)

### DIFF
--- a/system/pass-import/README
+++ b/system/pass-import/README
@@ -1,2 +1,6 @@
 pass import is a pass extension for importing data from most existing
 password managers.
+
+python3-pykeepass (optional) provides support for importing passwords
+directly from Keepass databases. For example, with this command:
+pass import keepass file.kdbx

--- a/system/pass-import/pass-import.SlackBuild
+++ b/system/pass-import/pass-import.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for pass-import
 
-# Copyright 2021-2022 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2021-2024 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is


### PR DESCRIPTION
python3-pykeepass has been approved for uploading to SlackBuilds.org.
Therefore, I am listing python3-pykeepass as an optional dependency in the README.
Also, I am bumping the year in the .SlackBuild file.