### PR TITLE
desktop/lxqt-panel: Do not install files that conflict with lxqt-menu-data (fix)

### DIFF
--- a/desktop/lxqt-panel/README
+++ b/desktop/lxqt-panel/README
@@ -10,3 +10,7 @@ To add support for the CPU Load and Network Monitor plugins, pass
 LIBSTATGRAB=yes to the SlackBuild.
 To add support for the System Stats plugin, pass
 LIBSYSSTAT=yes to the SlackBuild.
+
+For a default panel configuration, copy the example file provided by
+LXQt to the user $HOME config:
+cp /usr/share/lxqt/panel.conf $HOME/.config/lxqt/

--- a/desktop/lxqt-panel/lxqt-do_not_require_lxmenu_data.patch
+++ b/desktop/lxqt-panel/lxqt-do_not_require_lxmenu_data.patch
@@ -1,0 +1,20 @@
+--- a/menu/CMakeLists.txt
++++ b/menu/CMakeLists.txt
+@@ -8,17 +8,3 @@
+ )
+ add_custom_target(desktop_directories_files ALL DEPENDS ${DIRECTORY_FILES})
+ #************************************************
+-
+-install(FILES
+-    ${DIRECTORY_FILES}
+-    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/desktop-directories"
+-    COMPONENT Runtime
+-)
+-
+-install(FILES
+-    lxqt-applications.menu
+-    lxqt-applications-compact.menu
+-    lxqt-applications-simple.menu
+-    DESTINATION "${LXQT_ETC_XDG_DIR}/menus"
+-    COMPONENT Runtime
+-)

--- a/desktop/lxqt-panel/lxqt-panel.SlackBuild
+++ b/desktop/lxqt-panel/lxqt-panel.SlackBuild
@@ -82,6 +82,9 @@ find -L . \
 # Build with libsysstat as optional dependency (enable System Stats plugin)
 [ ${LIBSYSSTAT:-no} = yes ] && ENABLE_SYSSTAT=YES || ENABLE_SYSSTAT=NO
 
+# lxqt-panel should not install files already included within lxqt-menu-data
+patch -p1 < $CWD/lxqt-do_not_require_lxmenu_data.patch
+
 mkdir build
 cd build
   cmake \

--- a/desktop/lxqt-panel/lxqt-panel.SlackBuild
+++ b/desktop/lxqt-panel/lxqt-panel.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for lxqt-panel
 
-# Copyright 2022-2023 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2022-2024 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=lxqt-panel
 VERSION=${VERSION:-1.3.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -77,18 +77,10 @@ find -L . \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
 # Build with libstatgrab as optional dependency (enable CPU Load and Network Monitor plugins)
-if [ ${LIBSTATGRAB:-no} = yes ]; then
-	ENABLE_STATGRAB=YES
-else
-	ENABLE_STATGRAB=NO
-fi
+[ ${LIBSTATGRAB:-no} = yes ] && ENABLE_STATGRAB=YES || ENABLE_STATGRAB=NO
 
 # Build with libsysstat as optional dependency (enable System Stats plugin)
-if [ ${LIBSYSSTAT:-no} = yes ]; then
-	ENABLE_SYSSTAT=YES
-else
-	ENABLE_SYSSTAT=NO
-fi
+[ ${LIBSYSSTAT:-no} = yes ] && ENABLE_SYSSTAT=YES || ENABLE_SYSSTAT=NO
 
 mkdir build
 cd build

--- a/desktop/lxqt-panel/lxqt-panel.info
+++ b/desktop/lxqt-panel/lxqt-panel.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/lxqt/lxqt-panel/releases/download/1.3.0/lxqt-panel-
 MD5SUM="98f8b9b8f47ec0b1e7bc5eca475b7f45"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="lxqt-globalkeys lxmenu-data"
+REQUIRES="lxqt-globalkeys lxqt-menu-data"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
lxqt-menu-data already installs the following files:
```
/etc/xdg/menus/lxqt-applications-compact.menu
/etc/xdg/menus/lxqt-applications-simple.menu
/etc/xdg/menus/lxqt-applications.menu
/usr/share/desktop-directories/lxqt-leave.directory
/usr/share/desktop-directories/lxqt-settings.directory
```

By default, lxqt-panel installs these files as well.
This conflicts with lxqt-menu-data - once lxqt-panel is installed, its version of the files (ex. lxqt-applications-compact.menu) overwrites those previously installed by lxqt-menu-data.

lxqt-panel's menu files by default rely on lxmenu-data rather than on lxqt-menu-data.
Therefore, once lxqt-panel gets installed, it will look for menu files offered by lxmenu-data. This causes the main menu to render incorrectly (if lxmenu-data is not installed).

This patch prevents those duplicate files from installing (so that lxqt-panel's menu files are based solely on those from lxqt-menu-data).