### PR TITLE
Update to build against Qt5

### DIFF
--- a/development/xxdiff/xxdiff.SlackBuild
+++ b/development/xxdiff/xxdiff.SlackBuild
@@ -8,7 +8,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=xxdiff
 VERSION=${VERSION:-20220219_d4432be}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -62,7 +62,7 @@ find -L . \
  -exec chmod 644 {} \;
 
 cd src
-make -f Makefile.bootstrap
+make QMAKE=qmake-qt5 -f Makefile.bootstrap
 make
 cd ..
 install -m 755 -o root -g root -D bin/$PRGNAM $PKG/usr/bin/$PRGNAM


### PR DESCRIPTION
The original SlackBuild linked against Qt4, which is now deprecated in 15.0 and removed from -current.