### PR TITLE
system/lxqt-config: Add lxqt-menu-data dependency

### DIFF
--- a/system/lxqt-config/lxqt-config.SlackBuild
+++ b/system/lxqt-config/lxqt-config.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=lxqt-config
 VERSION=${VERSION:-1.3.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -75,6 +75,10 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# This patch prevents conflicts with lxqt-menu-data
+# It also explicitly sets the lxqt-menu-data requirement
+patch -p1 < $CWD/use-lxqt-menu-data-files.patch
 
 mkdir build
 cd build

--- a/system/lxqt-config/lxqt-config.info
+++ b/system/lxqt-config/lxqt-config.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/lxqt/lxqt-config/releases/download/1.3.0/lxqt-confi
 MD5SUM="c925164e691dd8da4f44511f42ef5b4f"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="liblxqt lxqt-themes"
+REQUIRES="liblxqt lxqt-menu-data lxqt-themes"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"

--- a/system/lxqt-config/use-lxqt-menu-data-files.patch
+++ b/system/lxqt-config/use-lxqt-menu-data-files.patch
@@ -1,0 +1,32 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,6 +36,7 @@
+ find_package(Qt5X11Extras ${QT_MINIMUM_VERSION} REQUIRED)
+ find_package(Qt5Xml ${QT_MINIMUM_VERSION} REQUIRED)
+ find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
++find_package(lxqt-menu-data 1.4.1 REQUIRED)
+ 
+ include(LXQtPreventInSourceBuilds)
+ include(LXQtCompilerSettings NO_POLICY_SCOPE)
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -65,7 +65,3 @@
+     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications"
+     COMPONENT Runtime
+ )
+-install(FILES lxqt-config.menu
+-    DESTINATION "${LXQT_ETC_XDG_DIR}/menus"
+-    COMPONENT Runtime
+-)
+--- a/src/menuname/CMakeLists.txt
++++ b/src/menuname/CMakeLists.txt
+@@ -8,9 +8,3 @@
+ )
+ add_custom_target(desktop_directories_files ALL DEPENDS ${DIRECTORY_FILES})
+ #************************************************
+-
+-install(FILES
+-    ${DIRECTORY_FILES}
+-    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/desktop-directories"
+-    COMPONENT Runtime
+-)


### PR DESCRIPTION
lxqt-menu-data already installs the following files:
```
/etc/xdg/menus/lxqt-config.menu
/usr/share/desktop-directories/lxqt-settings-lxqt.directory
/usr/share/desktop-directories/lxqt-settings-other.directory
/usr/share/desktop-directories/lxqt-settings-system.directory
```

I added a patch that prevents lxqt-config from installing these files.
The patch also explictly sets a requirement for lxqt-menu-data.
This is similar to the patch I added for lxqt-panel.

That being said, I have not added an explicit lxqt-menu-data requirement to the lxqt-panel patch (the dependency is only listed in lxqt-panel.info). I think I will send a PR for making those modifications next week.