### PR TITLE
gis/libspatialite: Fix profiling references to build path

### DIFF
--- a/gis/libspatialite/libspatialite.SlackBuild
+++ b/gis/libspatialite/libspatialite.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for libspatialite
 #
-# Copyright 2023 Gregory J. L. Tourte <artourter@gmail.com>
+# Copyright 2023-2024 Gregory J. L. Tourte <artourter@gmail.com>
 # Copyright 2012-2015 Alexander Bruy <alexander.bruy@gmail.com>
 # All rights reserved.
 #
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=libspatialite
 VERSION=${VERSION:-5.1.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -100,7 +100,6 @@ LDFLAGS="-ldl" \
   --enable-libxml2 \
   --enable-minizip \
   --enable-geopackage \
-  --enable-gcov \
   --enable-examples \
   --build=$ARCH-slackware-linux
 


### PR DESCRIPTION
Thanks to Giancarlo Dessi for the bug report