### PR TITLE
desktop/lxqt-panel: Explicitly require lxqt-menu-data for compliation

### DIFF
--- a/desktop/lxqt-panel/lxqt-do_not_require_lxmenu_data.patch
+++ b/desktop/lxqt-panel/lxqt-do_not_require_lxmenu_data.patch
@@ -1,3 +1,13 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,6 +42,7 @@
+ find_package(KF5WindowSystem ${KF5_MINIMUM_VERSION} REQUIRED)
+ find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
+ find_package(lxqt-globalkeys-ui ${LXQT_GLOBALKEYS_MINIMUM_VERSION} REQUIRED)
++find_package(lxqt-menu-data 1.4.1 REQUIRED)
+ 
+ # Patch Version
+ set(LXQT_PANEL_PATCH_VERSION 0)
 --- a/menu/CMakeLists.txt
 +++ b/menu/CMakeLists.txt
 @@ -8,17 +8,3 @@

--- a/desktop/lxqt-panel/lxqt-panel.SlackBuild
+++ b/desktop/lxqt-panel/lxqt-panel.SlackBuild
@@ -83,6 +83,7 @@ find -L . \
 [ ${LIBSYSSTAT:-no} = yes ] && ENABLE_SYSSTAT=YES || ENABLE_SYSSTAT=NO
 
 # lxqt-panel should not install files already included within lxqt-menu-data
+# Also, explicitly set the lxqt-menu-data requirement
 patch -p1 < $CWD/lxqt-do_not_require_lxmenu_data.patch
 
 mkdir build


### PR DESCRIPTION
Last week, I was especially concerned that I only changed the dependency info (from lxmenu-data to lxqt-menu-data) without adding a patch preventing the installation of files already covered by lxqt-menu-data. This risked breaking the lxqt-panel ui (especially with lxmenu-data uninstalled).

I made the correction accordingly - however, (unlike with lxqt-panel) I did not explicitly set an lxqt-menu-data requirement for compilation.

This pull request adds this requirement.

I decided not to bump the build number (I'm not interested in getting other users to recompile lxqt-panel).