### PR TITLE
python/python3-anyio: Update README

### DIFF
--- a/python/python3-anyio/README
+++ b/python/python3-anyio/README
@@ -2,7 +2,3 @@ AnyIO is an asynchronous networking and concurrency library that works
 on top of either asyncio or trio. It implements trio-like structured
 concurrency (SC) on top of asyncio, and works in harmony with the
 native SC of trio itself.
-
-python3-anyio 3.6.2 is the last possible version for Slackware 15.0.
-Newer versions would require a newer python-setuptools and
-python-setuptools_scm.


### PR DESCRIPTION
fourtysixandtwo's python3-setuptools-opt and python3-setuptools-scm-opt can be used to update python3-anyio.
I have decided to remove the blurb that states "Newer versions would remove a newer python-setuptools..."

However, I am not updating python3-anyio (even the most recent versions of jupyter_server work on any python3-anyio >= 3.1.0).