### PR TITLE
development/jupyter_packaging: Update README

### DIFF
--- a/development/jupyter_packaging/README
+++ b/development/jupyter_packaging/README
@@ -1,5 +1,2 @@
 Jupyter Packaging contains tools to help build and install Jupyter
 Python packages.
-
-jupyter_packaging 0.11.1 is the last possible version for Slackware
-15.0. Newer versions would require a newer python-setuptools.

--- a/development/jupyter_packaging/jupyter_packaging.SlackBuild
+++ b/development/jupyter_packaging/jupyter_packaging.SlackBuild
@@ -38,9 +38,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0


### PR DESCRIPTION
Fourtysixandtwo's python3-setuptools-opt package has allowed the building of packages with setuptools >= 60.

For example, jupyter_packaging 0.12.3, which requires setuptools >= 60.2.0, may be able to be built with the additional python3-setuptools-opt dependency.

However, I suspect that setuptools is a runtime dependency for jupyter_packaging (rather than merely being a build-time one).

That being said, I will not update jupyter_packaging (I might update it when Pat updates Slackware to 15.1, though).