### PR TITLE
python/python3-pywayland: Update README

### DIFF
--- a/python/python3-pywayland/README
+++ b/python/python3-pywayland/README
@@ -1,7 +1,3 @@
 PyWayland provides a wrapper to the libwayland library using the CFFI
 library to provide access to the Wayland library calls and written in
 pure Python.
-
-python3-pywayland 0.4.14 is the last possible version for Slackware
-15.0. Newer versions of python3-pywayland require a newer
-python-setuptools.


### PR DESCRIPTION
fourtysixandtwo's python3-setuptools-opt allows me to compile later versions of python3-pywayland.

However, I still will not update python3-pywayland.
If the pywayland changelog (https://github.com/flacjacket/pywayland/releases) is of any indication, pywayland > 0.4.14 requires a higher version of wayland-protocols (1.31 for pywayland 0.4.15 vs 1.25 for Slackware 15.0).