### PR TITLE
system/greetd: Updated mirror link in greetd.info

### DIFF
--- a/system/greetd/greetd.info
+++ b/system/greetd/greetd.info
@@ -48,7 +48,7 @@ DOWNLOAD="https://static.crates.io/crates/async-trait/async-trait-0.1.60.crate \
           https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.42.0.crate \
           https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.42.0.crate \
           https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.42.0.crate \
-          https://git.sr.ht/~kennylevinsen/greetd/archive/0.9.0.tar.gz"
+          https://github.com/kennylevinsen/greetd/archive/0.9.0/greetd-0.9.0.tar.gz"
 MD5SUM="fdfbe819b079678795b1ee1e1c61b9cb \
         05d77ef52e90ad161fdd41b252420467 \
         a295edb6953237ebbdfa8e731229f9a3 \


### PR DESCRIPTION
update info to use github mirror, as main site is down for days now.