### PR TITLE
libraries/grpc: Remove Python 3 support

### DIFF
--- a/libraries/grpc/README
+++ b/libraries/grpc/README
@@ -2,3 +2,6 @@ gRPC is a modern, open source, high-performance remote procedure call
 (RPC) framework that can run anywhere. gRPC enables client and server
 applications to communicate transparently, and simplifies the building
 of connected systems.
+
+This SlackBuild builds gRPC in C++. python3-grpcio contains the Python 3
+build of gRPC.

--- a/libraries/grpc/grpc.SlackBuild
+++ b/libraries/grpc/grpc.SlackBuild
@@ -103,15 +103,6 @@ CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 make install-grpc-cli prefix=$PKG/usr V=1
 
-if $(python3 -c 'import Cython' 2>/dev/null); then
-  GRPC_PYTHON_BUILD_WITH_CYTHON=True \
-  GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True \
-  GRPC_PYTHON_BUILD_SYSTEM_ZLIB=True \
-  GRPC_PYTHON_BUILD_SYSTEM_CARES=True \
-  CFLAGS="$SLKCFLAGS" \
-  python3 setup.py install --root=$PKG
-fi
-
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 


### PR DESCRIPTION
I plan on uploading python3-grpcio this week.
At the moment, the grpc SlackBuild builds Python 3 files.

Due to the overlap between grpc and python3-grpcio files, I would like Python 3 support removed from grpc (and then upload python3-grpcio as a separate SlackBuild).

bear and sysdig (dependencies of python3-grpcio) do not require Python 3 support for grpc, so they remain unaffected by this change.

I would like to do more with this SlackBuild (for example, add abseil-cpp to .info as a DEP, rather than downloading abseil-cpp and building with that). I would also like to get grpc updated to a later version.
However, I do not know enough about grpc at the moment to make these changes.