### PR TITLE
python/python3-lsp-black: Update README

### DIFF
--- a/python/python3-lsp-black/README
+++ b/python/python3-lsp-black/README
@@ -1,2 +1,5 @@
 Python LSP Black is the Black plugin for the Python LSP Server.
 This plugin adds support to Black autoformatter.
+
+python3-lsp-black 1.3.0 is the last available version for Slackware
+15.0. Newer versions would require python3-black >= 23.11.0.


### PR DESCRIPTION
python3-lsp-black 2.0.0 (the newest version) requires python3-black >= 23.11.0 (for context, python3-black is held back at version 22.12.0).