### PR TITLE
Version bump kodi to 20.3 and inputstream.adaptive to 20.3.16

### DIFF
--- a/multimedia/inputstream.adaptive/inputstream.adaptive.SlackBuild
+++ b/multimedia/inputstream.adaptive/inputstream.adaptive.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for inputstream.adaptive
 
-# Copyright 2022-2023 Jeremy Hansen  <jebrhansen+SBo -at- gmail.com>
+# Copyright 2022-2024 Jeremy Hansen  <jebrhansen+SBo -at- gmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=inputstream.adaptive
 CODNAM=Nexus
-VERSION=${VERSION:-20.3.14}
+VERSION=${VERSION:-20.3.16}
 BENTO4VER=${BENTO4VER:-1.6.0-639-6-Nexus}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}

--- a/multimedia/inputstream.adaptive/inputstream.adaptive.info
+++ b/multimedia/inputstream.adaptive/inputstream.adaptive.info
@@ -1,9 +1,9 @@
 PRGNAM="inputstream.adaptive"
-VERSION="20.3.14"
+VERSION="20.3.16"
 HOMEPAGE="https://github.com/xbmc/inputstream.adaptive/"
-DOWNLOAD="https://github.com/xbmc/inputstream.adaptive/archive/20.3.14-Nexus/inputstream.adaptive-20.3.14-Nexus.tar.gz \
+DOWNLOAD="https://github.com/xbmc/inputstream.adaptive/archive/20.3.16-Nexus/inputstream.adaptive-20.3.16-Nexus.tar.gz \
           https://github.com/xbmc/Bento4/archive/refs/tags/1.6.0-639-6-Nexus/Bento4-1.6.0-639-6-Nexus.tar.gz"
-MD5SUM="f7fdc8cbe887e641d39b95079266212f \
+MD5SUM="bb725fe7f0e6bbcbcdf511b6ee9eac54 \
         4322bd0076bf1fde49b389e73b821efa"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""

--- a/multimedia/kodi/README
+++ b/multimedia/kodi/README
@@ -14,6 +14,7 @@ libmicrohttpd - Web interface support
 libnfs - Browse NFS shares
 lirc - Remote support
 shairplay - Airplay Support
+waylandpp - Early wayland support
 
 NOTE:
 Kodi can be compiled with jdk11 instead of zulu-openjdk11.
@@ -22,3 +23,12 @@ ADDITIONAL NOTE:
 If you are having issues with addons crashing, please ensure you're
 upgraded to at least python3-3.9.14 or later from the patches/
 directory on your favorite mirror. 3.9.12 and earlier had issues.
+
+FINAL NOTE:
+If you are running into issues with playing certain formats that should
+be supported due to optional dependencies (I had issues with AV1
+content even with dav1d installed until I rebuilt ffmpeg), you may need
+to rebuild Slackware's ffmpeg to add that support or use Kodi's
+internal version by passing FFMPEG=internal to the SlackBuild script
+(this will cause the kodi build system to require internet access so
+root can download ffmpeg).

--- a/multimedia/kodi/kodi.SlackBuild
+++ b/multimedia/kodi/kodi.SlackBuild
@@ -3,7 +3,7 @@
 # Slackware build script for kodi
 
 # Copyright 2009-2018 Larry Hajali <larryhaja[at]gmail[dot]com>
-# Copyright 2022-2023 Jeremy Hansen <jebrhansen+SBo@gmail.com>
+# Copyright 2022-2024 Jeremy Hansen <jebrhansen+SBo@gmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -28,7 +28,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=kodi
 SRCNAM=xbmc
 CODNAM=Nexus
-VERSION=${VERSION:-20.2}
+VERSION=${VERSION:-20.3}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -63,16 +63,12 @@ OUTPUT=${OUTPUT:-/tmp}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
 elif [ "$ARCH" = "i686" ]; then
   SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
 fi
 
 set -e
@@ -103,12 +99,19 @@ if pkg-config --exists libnfs ; then NFS=ON; else NFS=OFF; fi
 if pkg-config --exists lirc ; then LIRC=ON; else LIRC=OFF; fi
 if [ -f /usr/bin/shairplay ] ; then AIRPLAY=ON; else AIRPLAY=OFF; fi
 
-# Adding early support for wayland. Needs waylandpp submitted to SBo.
+# Adding early support for wayland. Needs libraries/waylandpp from SBo.
 PLATFORM="x11 gbm"
 if pkg-config --exists wayland-client++; then PLATFORM="$PLATFORM wayland"; fi
 
 mkdir -p $TMP/$PRGNAM-build
 cd $TMP/$PRGNAM-build
+
+# Some optional features may not be supported with Slackware's default
+# ffmpeg package without being rebuilt. If the user would rather use
+# kodi's internal package, that might include playback support for
+# optional dependencies. Use Kodi's internal ffmpeg version by passing
+# FFMPEG=internal to the SlackBuild.
+if [ "${FFMPEG}" == "internal" ]; then FFMPEG=ON; else FFMPEG=OFF; fi
 
 # Reasons for internal programs
 # (so I can remember in the future why we're using them)
@@ -130,6 +133,7 @@ cd $TMP/$PRGNAM-build
     -DENABLE_INTERNAL_UDFREAD=ON \
     -DENABLE_INTERNAL_FMT=ON \
     -DENABLE_INTERNAL_SPDLOG=ON \
+    -DENABLE_INTERNAL_FFMPEG=$FFMPEG \
     -DENABLE_AIRTUNES=$AIRPLAY \
     -DENABLE_AVAHI=$AVAHI \
     -DENABLE_CEC=$CEC \

--- a/multimedia/kodi/kodi.info
+++ b/multimedia/kodi/kodi.info
@@ -1,7 +1,7 @@
 PRGNAM="kodi"
-VERSION="20.2"
+VERSION="20.3"
 HOMEPAGE="https://kodi.tv/"
-DOWNLOAD="https://github.com/xbmc/xbmc/archive/20.2-Nexus/xbmc-20.2-Nexus.tar.gz \
+DOWNLOAD="https://github.com/xbmc/xbmc/archive/20.3-Nexus/xbmc-20.3-Nexus.tar.gz \
           https://github.com/xbmc/crossguid/archive/ca1bf4b/crossguid-ca1bf4b810e2d188d04cb6286f957008ee1b7681.tar.gz \
           https://github.com/xbmc/libdvdcss/archive/refs/tags/1.4.3-Next-Nexus-Alpha2-2/libdvdcss-1.4.3-Next-Nexus-Alpha2-2.tar.gz \
           https://github.com/xbmc/libdvdnav/archive/refs/tags/6.1.1-Next-Nexus-Alpha2-2/libdvdnav-6.1.1-Next-Nexus-Alpha2-2.tar.gz \
@@ -11,7 +11,7 @@ DOWNLOAD="https://github.com/xbmc/xbmc/archive/20.2-Nexus/xbmc-20.2-Nexus.tar.gz
           https://github.com/miloyip/rapidjson/archive/v1.1.0/rapidjson-1.1.0.tar.gz \
           https://code.videolan.org/videolan/libudfread/-/archive/1.1.2/libudfread-1.1.2.tar.gz \
           https://fstrcmp.sourceforge.net/fstrcmp-0.7.D001.tar.gz"
-MD5SUM="3536687f5cb5b646116bfef3b9c57d63 \
+MD5SUM="ba4b0ad41d3d8ecf153dfca015d9824b \
         d4a8d62f3f8d6d946be75cf5bfa92687 \
         42dc3770ae928103e8033a18b007e79d \
         2349cde54d950af21fa4936371ad3349 \


### PR DESCRIPTION
multimedia/kodi: Version bump to 20.3
\- Add extra optional dependency to README for wayland support and optional support to use kodi's internal ffmpeg
multimedia/inputstream.adaptive: Version bump to 20.3.16