### PR TITLE
python/python3-kodipydent: Fix pip check warning

### DIFF
--- a/python/python3-kodipydent/python3-kodipydent.SlackBuild
+++ b/python/python3-kodipydent/python3-kodipydent.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for python3-kodipydent
 
-# Copyright 2023 Jeremy Hansen jebrhansen+SBo@gmail.com
+# Copyright 2023-2024 Jeremy Hansen jebrhansen+SBo@gmail.com
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=python3-kodipydent
 VERSION=${VERSION:-0.3.1}
 SRCNAM=${SRCNAM:-kodipydent}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -75,6 +75,10 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# Fix pip check warning
+# Update dependency name to newer alternate and remove version requirement
+sed -i 's/beekeeper.*/beekeeper-alt/' requirements.txt
 
 python3 setup.py install --root=$PKG
 


### PR DESCRIPTION
Update dependency name to newer alternate and remove version requirement so `pip check` doesn't complain anymore.