### PR TITLE
Aarch64

### DIFF
--- a/academic/gpredict/gpredict.SlackBuild
+++ b/academic/gpredict/gpredict.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/development/argagg/argagg.SlackBuild
+++ b/development/argagg/argagg.SlackBuild
@@ -59,6 +59,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/development/tiled/tiled.SlackBuild
+++ b/development/tiled/tiled.SlackBuild
@@ -61,6 +61,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/games/flare-game/flare-game.SlackBuild
+++ b/games/flare-game/flare-game.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/games/flare/flare.SlackBuild
+++ b/games/flare/flare.SlackBuild
@@ -61,6 +61,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/games/gargoyle/gargoyle.SlackBuild
+++ b/games/gargoyle/gargoyle.SlackBuild
@@ -41,6 +41,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/games/planetblupi/planetblupi.SlackBuild
+++ b/games/planetblupi/planetblupi.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/graphics/graphviz/graphviz.SlackBuild
+++ b/graphics/graphviz/graphviz.SlackBuild
@@ -62,6 +62,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/libraries/DevIL/DevIL.SlackBuild
+++ b/libraries/DevIL/DevIL.SlackBuild
@@ -40,6 +40,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC -fpermissive"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC -fpermissive"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2 -fpermissive"
   LIBDIRSUFFIX=""

--- a/libraries/SDL2_sound/SDL2_sound.SlackBuild
+++ b/libraries/SDL2_sound/SDL2_sound.SlackBuild
@@ -55,6 +55,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -87,8 +90,9 @@ cd build
   make install/strip DESTDIR=$PKG
 cd ..
 
+rm -rf $PKG/usr/lib${LIBDIRSUFFIX}/*.a
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a docs/*.txt README* LICENSE* \
+cp -a docs/CHANGELOG* docs/CREDITS* LICENSE* README* \
    $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
@@ -97,4 +101,3 @@ cat $CWD/slack-desc > $PKG/install/slack-desc
 
 cd $PKG
 /sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE
-

--- a/libraries/dumb/dumb.SlackBuild
+++ b/libraries/dumb/dumb.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/libraries/htmlcxx/htmlcxx.SlackBuild
+++ b/libraries/htmlcxx/htmlcxx.SlackBuild
@@ -62,6 +62,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -101,7 +104,7 @@ make
 make install-strip DESTDIR=$PKG
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a ASF-2.0 AUTHORS COPYING ChangeLog INSTALL LGPL_V2 README \
+cp -a ASF-2.0 AUTHORS COPYING ChangeLog LGPL_V2 README \
   $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 

--- a/libraries/libcbor/libcbor.SlackBuild
+++ b/libraries/libcbor/libcbor.SlackBuild
@@ -57,6 +57,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/libraries/libjodycode/libjodycode.SlackBuild
+++ b/libraries/libjodycode/libjodycode.SlackBuild
@@ -57,6 +57,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -88,6 +91,7 @@ make PREFIX=/usr CFLAGS_EXTRA="$SLKCFLAGS"
 mkdir -p $PKG/usr/include
 make install DESTDIR=$PKG
 
+rm -rf $PKG/usr/lib${LIBDIRSUFFIX}/*.a
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 

--- a/libraries/libjwt/libjwt.SlackBuild
+++ b/libraries/libjwt/libjwt.SlackBuild
@@ -54,6 +54,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/libraries/orcania/orcania.SlackBuild
+++ b/libraries/orcania/orcania.SlackBuild
@@ -57,6 +57,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/libraries/yder/yder.SlackBuild
+++ b/libraries/yder/yder.SlackBuild
@@ -57,6 +57,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/network/dkimproxy/dkimproxy.SlackBuild
+++ b/network/dkimproxy/dkimproxy.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -129,7 +132,7 @@ for i in $( find $PKG/usr/man -type l ) ; do ln -s $( readlink $i ).gz $i.gz ; r
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \
-  AUTHORS COPYING INSTALL NEWS README TODO ChangeLog smtpprox.ChangeLog \
+  AUTHORS COPYING NEWS README TODO ChangeLog smtpprox.ChangeLog \
   smtpprox.README smtpprox.TODO \
   $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild

--- a/network/sshuttle/sshuttle.SlackBuild
+++ b/network/sshuttle/sshuttle.SlackBuild
@@ -62,6 +62,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -83,10 +86,6 @@ find -L . \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
 python3 setup.py install --root=$PKG
-
-mkdir -p $PKG/usr/man/man8
-cat $TMP/$PRGNAM-$VERSION/Documentation/$PRGNAM.8 | gzip -9c > \
-$PKG/usr/man/man8/$PRGNAM.8.gz
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \

--- a/network/thttpd/thttpd.SlackBuild
+++ b/network/thttpd/thttpd.SlackBuild
@@ -61,6 +61,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -172,7 +175,7 @@ find $PKG/usr/man -type f -exec gzip -9 {} \;
 for i in $( find $PKG/usr/man -type l ) ; do ln -s $( readlink $i ).gz $i.gz ; rm $i ; done
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a FILES INSTALL README TODO scripts $PKG/usr/doc/$PRGNAM-$VERSION
+cp -a FILES README TODO scripts $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install

--- a/office/focuswriter-qt6/focuswriter-qt6.SlackBuild
+++ b/office/focuswriter-qt6/focuswriter-qt6.SlackBuild
@@ -63,6 +63,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -83,12 +86,12 @@ find -L . \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
 cmake \
-	-B build \
-	-S . \
-    -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
-    -DCMAKE_INSTALL_PREFIX=/usr \
-	-DENABLE_STRIP=ON \
-    -DCMAKE_BUILD_TYPE=Release
+  -B build \
+  -S . \
+  -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DENABLE_STRIP=ON \
+  -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 DESTDIR=$PKG cmake --install build
 
@@ -96,8 +99,10 @@ find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | gr
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a COPYING INSTALL README ChangeLog $PKG/usr/doc/$PRGNAM-$VERSION
+cp -a COPYING README ChangeLog $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
+
+sed -i 's#SingleMainWindow#X-SingleMainWindow#' $PKG/usr/share/applications/focuswriter.desktop
 
 mv $PKG/usr/share/man $PKG/usr
 find $PKG/usr/man -type f -exec gzip -9 {} \;

--- a/office/focuswriter/focuswriter.SlackBuild
+++ b/office/focuswriter/focuswriter.SlackBuild
@@ -62,6 +62,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -89,7 +92,7 @@ find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | gr
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a COPYING INSTALL README ChangeLog $PKG/usr/doc/$PRGNAM-$VERSION
+cp -a COPYING README ChangeLog $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mv $PKG/usr/share/man $PKG/usr

--- a/python/click-plugins/click-plugins.SlackBuild
+++ b/python/click-plugins/click-plugins.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python2-attrs/python2-attrs.SlackBuild
+++ b/python/python2-attrs/python2-attrs.SlackBuild
@@ -61,6 +61,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python2-pyasn1-modules/python2-pyasn1-modules.SlackBuild
+++ b/python/python2-pyasn1-modules/python2-pyasn1-modules.SlackBuild
@@ -61,6 +61,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python2-pyasn1/python2-pyasn1.SlackBuild
+++ b/python/python2-pyasn1/python2-pyasn1.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python3-asn1crypto/python3-asn1crypto.SlackBuild
+++ b/python/python3-asn1crypto/python3-asn1crypto.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python3-automat/python3-automat.SlackBuild
+++ b/python/python3-automat/python3-automat.SlackBuild
@@ -62,6 +62,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python3-parso/python3-parso.SlackBuild
+++ b/python/python3-parso/python3-parso.SlackBuild
@@ -61,6 +61,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python3-pyasn1-modules/python3-pyasn1-modules.SlackBuild
+++ b/python/python3-pyasn1-modules/python3-pyasn1-modules.SlackBuild
@@ -61,6 +61,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python3-pyjwt/python3-pyjwt.SlackBuild
+++ b/python/python3-pyjwt/python3-pyjwt.SlackBuild
@@ -53,6 +53,8 @@ OUTPUT=${OUTPUT:-/tmp}
 
 if [ "$ARCH" = "x86_64" ]; then
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  LIBDIRSUFFIX="64"
 else
   LIBDIRSUFFIX=""
 fi

--- a/python/python3-python-editor/python3-python-editor.SlackBuild
+++ b/python/python3-python-editor/python3-python-editor.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -87,7 +90,6 @@ find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | gr
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a README.md LICENSE PKG-INFO $PKG/usr/doc/$PRGNAM-$VERSION
-# dw: Mon, 24 Oct 8:28 PM BST 2022:
 find $PKG/usr/doc/$PRGNAM-$VERSION -type f -execdir chmod -c 644 '{}' \+
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 

--- a/python/python3-tubes/python3-tubes.SlackBuild
+++ b/python/python3-tubes/python3-tubes.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python3-txaio/python3-txaio.SlackBuild
+++ b/python/python3-txaio/python3-txaio.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python3-waitress/python3-waitress.SlackBuild
+++ b/python/python3-waitress/python3-waitress.SlackBuild
@@ -61,6 +61,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python3-webencodings/python3-webencodings.SlackBuild
+++ b/python/python3-webencodings/python3-webencodings.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/python/python3-webob/python3-webob.SlackBuild
+++ b/python/python3-webob/python3-webob.SlackBuild
@@ -61,6 +61,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/system/dosbox/dosbox.SlackBuild
+++ b/system/dosbox/dosbox.SlackBuild
@@ -27,10 +27,6 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# 20220406 bkw: Modified by SlackBuilds.org, BUILD=2:
-# - do not try to use a .ico icon in the .desktop file (png instead).
-# - remove useless INSTALL from doc dir.
-
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=dosbox
@@ -66,6 +62,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
     SLKCFLAGS="-O2 -fPIC"
     LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
     SLKCFLAGS="-O2"
     LIBDIRSUFFIX=""
@@ -107,7 +106,6 @@ for i in $(find $PKG/usr/man -type l) ; do ln -s $(readlink $i).gz $i.gz ; rm $i
 install -D -m 0644 $CWD/dosbox.desktop \
   $PKG/usr/share/applications/dosbox.desktop
 
-# 20220406 bkw: convert the .ico icon to a .png.
 mkdir -p $PKG/usr/share/pixmaps
 convert 'src/dosbox.ico[1]' $PKG/usr/share/pixmaps/dosbox.png
 

--- a/system/jdupes/jdupes.SlackBuild
+++ b/system/jdupes/jdupes.SlackBuild
@@ -57,12 +57,15 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
 fi
 
-DOCFILES="*.txt *.md README*"
+DOCFILES="CHANGES.txt LICENSE.txt README*"
 
 set -e
 

--- a/system/redis-py/redis-py.SlackBuild
+++ b/system/redis-py/redis-py.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""

--- a/system/sqldiff/sqldiff.SlackBuild
+++ b/system/sqldiff/sqldiff.SlackBuild
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""


### PR DESCRIPTION
Adding the aarch64 SLCKFLAGS and LIBDIRSUFFIX section.
Sometimes fixing docs, removing INSTALL instructions, when sbopkglint complains.
Also, and only for SDL2_sound and libjodycode, removes lib/*.a, which are unneeded by other packages requiring those ones (namely ags and jdupes only).
They've been kept for dumb, as they are used.
Also fixed an old man page for sshuttle, that disappeared some time ago but was still generating a gzip of an empty file...
And the .desktop file of focuswriter-qt6 now checks with sbopkglint also.

Nothing here should warrant a change in build numbers.

Hoping that this quite huge PR will be ok, and not too much work with the CI. It's quite easy to review by eye though.