### PR TITLE
graphics/vimiv-qt: Update vimiv-qt.SlackBuild

### DIFF
--- a/graphics/vimiv-qt/doinst.sh
+++ b/graphics/vimiv-qt/doinst.sh
@@ -1,0 +1,9 @@
+if [ -x /usr/bin/update-desktop-database ]; then
+  /usr/bin/update-desktop-database -q usr/share/applications >/dev/null 2>&1
+fi
+
+if [ -e usr/share/icons/hicolor/icon-theme.cache ]; then
+  if [ -x /usr/bin/gtk-update-icon-cache ]; then
+    /usr/bin/gtk-update-icon-cache -f usr/share/icons/hicolor >/dev/null 2>&1
+  fi
+fi

--- a/graphics/vimiv-qt/vimiv-qt.SlackBuild
+++ b/graphics/vimiv-qt/vimiv-qt.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=vimiv-qt
 VERSION=${VERSION:-0.9.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -76,7 +76,13 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-python3 setup.py install --root=$PKG
+# Install man files to /usr/man, rather than /usr/share/man 
+sed -i "s/\$(DATADIR)\\/man/\$(DESTDIR)\\/\$(PREFIX)\\/man/g" misc/Makefile
+
+# Do not install license files to /usr/share/licenses
+sed -i "/LICENSEDIR/d" misc/Makefile
+
+make -f misc/Makefile DESTDIR=$PKG install
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
@@ -87,6 +93,7 @@ cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc
+cat $CWD/doinst.sh > $PKG/install/doinst.sh
 
 cd $PKG
 /sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE


### PR DESCRIPTION
The SlackBuild should have used make install rather than python3 setup.py install.

python3 setup.py install alone does not install man files, desktkop entry, etc.