### PR TITLE
system/OpenSnitch: Update for 1.6.5

### DIFF
--- a/system/OpenSnitch/OpenSnitch.SlackBuild
+++ b/system/OpenSnitch/OpenSnitch.SlackBuild
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=OpenSnitch
-VERSION=${VERSION:-1.6.4}
+VERSION=${VERSION:-1.6.5}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -108,9 +108,6 @@ export GOMODCACHE="${GOMODCACHE:-"$TMP/$SRCNAM-$VERSION/go"}"
 cd proto
 make
 cd ../
-
-# Fix version number
-sed -i "s/1.6.2/$VERSION/g" daemon/core/version.go
 
 # Workaround for namespace conflict
 # Taken from https://github.com/pentoo/pentoo-overlay/blob/master/app-admin/opensnitch/opensnitch-1.6.4.ebuild

--- a/system/OpenSnitch/OpenSnitch.info
+++ b/system/OpenSnitch/OpenSnitch.info
@@ -1,7 +1,7 @@
 PRGNAM="OpenSnitch"
-VERSION="1.6.4"
+VERSION="1.6.5"
 HOMEPAGE="https://github.com/evilsocket/opensnitch"
-DOWNLOAD="https://github.com/evilsocket/opensnitch/archive/v1.6.4/opensnitch-1.6.4.tar.gz \
+DOWNLOAD="https://github.com/evilsocket/opensnitch/archive/v1.6.5/opensnitch-1.6.5.tar.gz \
           https://github.com/fsnotify/fsnotify/archive/v1.4.7/fsnotify-1.4.7.tar.gz \
           https://github.com/golang/protobuf/archive/v1.5.0/protobuf-1.5.0.tar.gz \
           https://github.com/google/gopacket/archive/v1.1.14/gopacket-1.1.14.tar.gz \
@@ -20,7 +20,7 @@ DOWNLOAD="https://github.com/evilsocket/opensnitch/archive/v1.6.4/opensnitch-1.6
           https://github.com/googleapis/go-genproto/archive/24fa4b2/go-genproto-24fa4b261c55da65468f2abfdae2b024eef27dfb.tar.gz \
           https://github.com/grpc/grpc-go/archive/v1.32.0/grpc-go-1.32.0.tar.gz \
           https://github.com/protocolbuffers/protobuf-go/archive/v1.26.0/protobuf-go-1.26.0.tar.gz"
-MD5SUM="072ebb1632ada723623203a8248e1996 \
+MD5SUM="779d7696d69bc6238020b7ea48feb7c7 \
         e23b3240fc9e807fcffb97d12a433138 \
         7bff4630d93dc4f9081b5dbc31067899 \
         5e4827e740a060b8f97116955718de19 \


### PR DESCRIPTION
Also, version number in daemon/core/version.go no longer needs to be fixed.