### PR TITLE
development/rust16: Updated for version 1.76.0.

### DIFF
--- a/development/rust16/README
+++ b/development/rust16/README
@@ -1,6 +1,6 @@
-rust16 installs a limited set of rust binaries to /opt/rust16. This is
-to allow rust-based SlackBuilds to build more recent versions than
-would be possible with system rust.
+rust16 installs a limited set of Rust stable binaries to /opt/rust16.
+This is to allow Rust-based SlackBuilds to build more recent versions
+than would be possible with system Rust.
 
 To use the rust16 binaries in a SlackBuild, make the following export
 statements:
@@ -16,7 +16,6 @@ If your SlackBuild experiences build failures on 64-bit systems, please
 ensure that the LIBDIRSUFFIX variable is set.
 
 rust16 is not intended as a substitute for rustup or for the Slackware
-rust package in terms of rust development purposes.
+Rust package in terms of Rust development purposes.
 
-Separate downloads are available for i686 and x86_64. -current users may
-be able to ignore rust16 as a dependency for some packages.
+Separate downloads are available for i686 and x86_64.

--- a/development/rust16/rust16.SlackBuild
+++ b/development/rust16/rust16.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for rust16
 
-# Copyright 2023 K. Eugene Carlson  Tsukuba, Japan
+# Copyright 2023-2024 K. Eugene Carlson  Tsukuba, Japan
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust16
 SRCNAM=rust
-VERSION=${VERSION:-1.70.0}
+VERSION=${VERSION:-1.76.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -103,7 +103,7 @@ rust-demangler-preview,\
 rustfmt-preview
 
 find $PKG/opt/$PRGNAM/lib -type f -name "*.so" -exec chmod +x {} \; 2> /dev/null || true
-# As of 1.70.0, stripping the libraries causes memory faults on Slackware64-15.0.
+# As of 1.76.0, stripping the libraries causes memory faults on Slackware64-15.0.
 if [ $ARCH = "x86_64" ]; then
   find $PKG -print0 | xargs -0 file | grep "executable" | grep ELF \
     | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true

--- a/development/rust16/rust16.info
+++ b/development/rust16/rust16.info
@@ -1,12 +1,12 @@
 PRGNAM="rust16"
-VERSION="1.70.0"
+VERSION="1.76.0"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2023-06-01/rust-1.70.0-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2023-06-01/rust-1.70.0-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="b56197499321c7b5e43812787e5dbe65 \
-        8e9fa4750ea9e33be9c1a96f6cfb1035"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2023-06-01/rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="b893174d8c961d426390292aebeec149"
+DOWNLOAD="https://static.rust-lang.org/dist/2024-02-08/rust-1.76.0-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2024-02-08/rust-1.76.0-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="9d8fb8d9d18987d3c65e781fd916adfa \
+        3f27044b6d18155a3849ae3d3958faf5"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2024-02-08/rust-1.76.0-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="3d00cf0861b0eb28e7010663dc59b2ed"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"

--- a/development/rust16/slack-desc
+++ b/development/rust16/slack-desc
@@ -8,7 +8,7 @@
       |-----handy-ruler------------------------------------------------------|
 rust16: rust16 (Rust: a safe, concurrent, practical language)
 rust16:
-rust16: rust16 installs a limited set of up-to-date stable rust binaries to
+rust16: rust16 installs a limited set of up-to-date Rust stable binaries to
 rust16: /opt/rust16 for use in SlackBuilds.
 rust16:
 rust16:


### PR DESCRIPTION
I've decided to bump `rust16` to ensure that it can continue to be used to build the latest versions of packages on SBo.

Reverse dependency testing has been carried out. A slight tweak is needed to build `cargo-vendor-filterer` on ARM (`--target` should not be used), but everything else appears to be fine.