### PR TITLE
system/catatonit: Updated for version 0.2.0-2.

### DIFF
--- a/system/catatonit/catatonit.SlackBuild
+++ b/system/catatonit/catatonit.SlackBuild
@@ -26,7 +26,7 @@ cd "$(dirname "$0")" ; CWD=$(pwd)
 
 PRGNAM=catatonit
 VERSION=${VERSION:-0.2.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -64,7 +64,7 @@ rm -rf "$PKG"
 mkdir -p "$TMP" "$PKG" "$OUTPUT"
 cd "$TMP"
 rm -rf "$PRGNAM-$VERSION"
-tar xvf "$CWD/$PRGNAM-$VERSION.tar.gz"
+tar xvf "$CWD/$PRGNAM-v$VERSION.tar.gz"
 cd "$PRGNAM-$VERSION"
 chown -R root:root .
 chmod -R u+w,go+r-w,a-s .


### PR DESCRIPTION
Fix wrong filename for `tar` command.