### PR TITLE
libraries/libkml: fixed outdated libkml build

### DIFF
--- a/libraries/libkml/libkml.SlackBuild
+++ b/libraries/libkml/libkml.SlackBuild
@@ -81,6 +81,8 @@ find -L . \
 
 sed -i -e "s#set(DEF_INSTALL_CMAKE_DIR lib/cmake/libkml)#set(DEF_INSTALL_CMAKE_DIR lib$LIBDIRSUFFIX/cmake/libkml)#" CMakeLists.txt
 
+patch -p0 < $CWD/patches/p1.patch
+
 mkdir -p build
 cd build
   cmake \

--- a/libraries/libkml/patches/p1.patch
+++ b/libraries/libkml/patches/p1.patch
@@ -1,0 +1,21 @@
+--- cmake/External_uriparser.cmake.modif	2015-12-21 19:23:05.000000000 +0200
++++ cmake/External_uriparser.cmake	2024-02-24 11:04:25.349773553 +0200
+@@ -1,16 +1,14 @@
+ ExternalProject_Add(URIPARSER
+   PREFIX URIPARSER
+-  URL "http://sourceforge.net/projects/uriparser/files/Sources/0.7.5/uriparser-0.7.5.tar.bz2/download"
+-  URL_MD5 4f4349085fe5de33bcae8d0f26649593
++  URL "http://sourceforge.net/projects/uriparser/files/Sources/0.9.7/uriparser-0.9.7.tar.bz2/download"
++  URL_MD5 db4de4763071e993be2621249a96afac
+   BINARY_DIR ${CMAKE_BINARY_DIR}/URIPARSER/build
+   DOWNLOAD_DIR ${DOWNLOAD_LOCATION}
+-  PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/cmake/UriParser_cmake_lists_txt ${CMAKE_BINARY_DIR}/URIPARSER/src/URIPARSER/CMakeLists.txt
+   CMAKE_CACHE_ARGS
+   -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
+   -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+   -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS} )
+ 
+-
+ if(MSVC)
+ include_project_vars(URIPARSER "uriparser")
+ else()


### PR DESCRIPTION
Prior to this PR, the libkml package was not building correctly.
It was trying to pull a tarball that has been marked vulnerable [1] and because the url for it was renamed, it wasn't able to fetch it.

The fix was to patch the CMake file for libkml to use a newer version of uriparser.
Tested locally on a Slackware 15 instance and everything went well.

Please advise regarding the version bump if one is required.
Maybe we should use 1.3.0-1, not sure.

[1] https://sourceforge.net/projects/uriparser/files/Sources/0.7.5/