### PR TITLE
Update afdko.info

### DIFF
--- a/system/afdko/afdko.info
+++ b/system/afdko/afdko.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/adobe-type-tools/afdko/releases/download/3.8.3/afdk
 MD5SUM="5aa7305cf8ac232fc6c01da3fb621319"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-fonttools scikit-build python3-lxml tqdm"
+REQUIRES="python3-fonttools scikit-build python3-lxml tqdm python3-ufonormalizer python3-fontPens python3-fontParts"
 MAINTAINER="Duncan Roe"
 EMAIL="duncan_roe@optusnet.com.au"


### PR DESCRIPTION
checkoutlinesufo tool in afdko needs 
python3-ufonormalizer, python3-fontParts and 
Python3-fontPens for it to work.