### PR TITLE
system/lxqt-config: Remove lxqt-themes dependency

### DIFF
--- a/system/lxqt-config/lxqt-config.info
+++ b/system/lxqt-config/lxqt-config.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/lxqt/lxqt-config/releases/download/1.3.0/lxqt-confi
 MD5SUM="c925164e691dd8da4f44511f42ef5b4f"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="liblxqt lxqt-menu-data lxqt-themes"
+REQUIRES="liblxqt lxqt-menu-data"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
I built lxqt-config without lxqt-themes successfully.

lxqt-config does not require lxqt-themes (as a build or runtime dependency) - however, lxqt-themes is useful for the LXQt desktop environment.