### PR TITLE
audio/clementine: Fix for compiling with newer protobuf3

### DIFF
--- a/audio/clementine/clementine.SlackBuild
+++ b/audio/clementine/clementine.SlackBuild
@@ -3,7 +3,7 @@
 # Slackware build script for clementine
 
 # Copyright 2010  David Woodfall <dave@slackbuilds.org>
-# Copyright 2023  Jeremy Hansen <jebrhansen+SBo@gmail.com>
+# Copyright 2023-2024  Jeremy Hansen <jebrhansen+SBo@gmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -30,7 +30,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=clementine
 SRCNAM=Clementine
 VERSION=${VERSION:-1.4.0rc2}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -85,6 +85,7 @@ cd build
   cmake \
     -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
     -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
+    -DCMAKE_CXX_STANDARD=17 \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_BUILD_TYPE=Release \
     ..


### PR DESCRIPTION
@willysr This commit works with the current and updated protobuf3. It can be added at either point.