### PR TITLE
python/python3-pykeepass: Fix missing kdbx_parsing submodule [+use built-in isoformat support]

### DIFF
--- a/python/python3-pykeepass/fix_missing_pykeepass_kdbx_parsing.patch
+++ b/python/python3-pykeepass/fix_missing_pykeepass_kdbx_parsing.patch
@@ -1,0 +1,13 @@
+This patch was taken from Arch Linux's gitlab repo:
+https://gitlab.archlinux.org/archlinux/packaging/packages/python-pykeepass/-/blob/main/0001-fix_missing_pykeepass_kdbx_parsing.patch
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -37,7 +37,7 @@
+ Changelog = "https://github.com/libkeepass/pykeepass/blob/master/CHANGELOG.rst"
+ 
+ [tool.setuptools]
+-packages = ["pykeepass"]
++packages = ["pykeepass", "pykeepass.kdbx_parsing"]
+ include-package-data = true
+ 
+ [build-system]

--- a/python/python3-pykeepass/python3-pykeepass.SlackBuild
+++ b/python/python3-pykeepass/python3-pykeepass.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-pykeepass
 VERSION=${VERSION:-4.0.7}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -63,6 +63,14 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# Fix missing pykeepass.kdbx_parsing when built with modern tools
+# https://github.com/libkeepass/pykeepass/pull/378
+patch -p1 < $CWD/fix_missing_pykeepass_kdbx_parsing.patch
+
+# Use built-in isoformat support
+# https://github.com/libkeepass/pykeepass/pull/383
+patch -p1 < $CWD/use_built_in_isoformat_support.patch
 
 export PYTHONPATH=/opt/python3.9/site-packages/
 

--- a/python/python3-pykeepass/use_built_in_isoformat_support.patch
+++ b/python/python3-pykeepass/use_built_in_isoformat_support.patch
@@ -1,0 +1,33 @@
+This patch was taken from Arch Linux's gitlab repo:
+https://gitlab.archlinux.org/archlinux/packaging/packages/python-pykeepass/-/blob/main/0002-Use_built_in_isoformat_support.patch
+--- a/pykeepass/pykeepass.py
++++ b/pykeepass/pykeepass.py
+@@ -28,7 +28,6 @@
+ BLANK_DATABASE_FILENAME = "blank_database.kdbx"
+ BLANK_DATABASE_LOCATION = os.path.join(os.path.dirname(os.path.realpath(__file__)), BLANK_DATABASE_FILENAME)
+ BLANK_DATABASE_PASSWORD = "password"
+-DT_ISOFORMAT = "%Y-%m-%dT%H:%M:%S%fZ"
+ 
+ class PyKeePass():
+     """Open a KeePass database
+@@ -804,7 +803,7 @@ def _encode_time(self, value):
+                 struct.pack('<Q', diff_seconds)
+             ).decode('utf-8')
+         else:
+-            return value.strftime(DT_ISOFORMAT)
++            return value.isoformat()
+ 
+     def _decode_time(self, text):
+         """datetime.datetime: Convert base64 time or plaintext time to datetime"""
+@@ -819,9 +818,9 @@ def _decode_time(self, text):
+                     )
+                 )
+             except BinasciiError:
+-                return datetime.strptime(text, DT_ISOFORMAT).replace(tzinfo=timezone.utc)
++                return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+         else:
+-            return datetime.strptime(text, DT_ISOFORMAT).replace(tzinfo=timezone.utc)
++            return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+ 
+ def create_database(
+         filename, password=None, keyfile=None, transformed_key=None


### PR DESCRIPTION
kdbx_parsing submodule is missing.
This patch follows the one from the Arch Linux's repo:
https://gitlab.archlinux.org/archlinux/packaging/packages/python-pykeepass/-/blob/main/python-pykeepass-fix-install.patch

I previously faced problems importing from a Keepass database to [pass](https://www.passwordstore.org/) (the standard password manager) - the command being, for example: `pass import keepassxc filename.kdbx`

That issue with importing passwords is why I am adding this pull request.

**EDIT:** Sorry for the inconvenience - but Arch Linux just included another patch:
https://gitlab.archlinux.org/archlinux/packaging/packages/python-pykeepass/-/blob/main/0002-Use_built_in_isoformat_support.patch

I have rebased this pull request to add in this second patch.
This patch instead fixes an issue with GNOME's password manager ([Secrets](https://apps.gnome.org/Secrets)). That being said, this second patch is more for completeness - Secrets is not available at SlackBuilds.org.
I also renamed "python3-pykeepass-fix-install.patch" to "fix_missing_pykeepass_kdbx_parsing.patch" (in accordance to the Arch repo).