### PR TITLE
Buildbot

### DIFF
--- a/python/buildbot/README
+++ b/python/buildbot/README
@@ -12,3 +12,7 @@ tracked over time, are more visible, and are therefore easier to
 improve.
 
 See also buildbot-worker (the worker component of BuildBot).
+
+Note on SQLAlchemy: buildbot requires SQLAlchemy-legacy and won't work
+with SQLAlchemy, but python3-alembic works with both. So disregard
+REQUIRES for python3-alembic and install only SQLAlchemy-legacy.

--- a/python/buildbot/buildbot.SlackBuild
+++ b/python/buildbot/buildbot.SlackBuild
@@ -29,7 +29,7 @@ SRCNAM=${PRGNAM#python-*}
 # "pkg" stays first
 PACKAGES="pkg www console-view grid-view waterfall-view wsgi-dashboards"
 VERSION=${VERSION:-3.11.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 

--- a/python/buildbot/buildbot.info
+++ b/python/buildbot/buildbot.info
@@ -17,6 +17,6 @@ MD5SUM="b6fa75f861b66f17356afff7b120fba2 \
         9f4baaa452b81cf7c4f02a26736303d0"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-twisted python3-autobahn python3-alembic python3-pyjwt python3-dateutil msgpack-python"
+REQUIRES="SQLAlchemy-legacy python3-twisted python3-autobahn python3-alembic python3-pyjwt python3-dateutil msgpack-python"
 MAINTAINER="Yth - Arnaud"
 EMAIL="yth@ythogtha.org"

--- a/python/python3-alembic/README
+++ b/python/python3-alembic/README
@@ -5,3 +5,4 @@ This package can be used to create databases for use with the Asterisk
 project.
 
 Optional dependencies: psycopg2
+And SQLAlchemy-legacy instead of SQLAlchemy


### PR DESCRIPTION
To allow for updating SQLAlchemy to version 2.x, buildbot needs a legacy version.
This is it: requiring the approbation of the newly submitted SQLAlchemy-legacy package.

To be noted : SQLAlchemy was a requirement of buildbot through python3-alembic, but is really used directly by buildbot.
python3-alembic can work with both SQLAlchemy versions.
But in the requirement tree, there'll be that :
buildbot
 |- python3-alembic
 |\-SQLAlchemy
 \- SQLAlchemy-legacy

And both SQLAlchemy and SQLAlchemy-legacy are incompatible with each other.
People will have to read the READMEs.