### PR TITLE
perl/perl-http-message: Updated dependencies.

### DIFF
--- a/perl/perl-http-message/perl-http-message.SlackBuild
+++ b/perl/perl-http-message/perl-http-message.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=perl-http-message
 VERSION=${VERSION:-6.45}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 

--- a/perl/perl-http-message/perl-http-message.info
+++ b/perl/perl-http-message/perl-http-message.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Message-6.45.ta
 MD5SUM="86c386bcc85a63c8908e6ae9967b34ee"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="perl-encode-locale perl-html-parser perl-http-date perl-lwp-mediatypes perl-IO-HTML perl-Clone perl-Try-Tiny perl-Test-Needs"
+REQUIRES="perl-encode-locale perl-http-date perl-lwp-mediatypes perl-IO-HTML perl-Clone perl-Try-Tiny perl-Test-Needs"
 MAINTAINER="LukenShiro"
 EMAIL="lukenshiro@ngi.it"


### PR DESCRIPTION
Bumped the revision number, even though the package itself is not changed in any way, but only the metadata in `.info`.