### PR TITLE
desktop/xsecurelock: Update build - make pandoc-bin an optional dependency

### DIFF
--- a/desktop/xsecurelock/README
+++ b/desktop/xsecurelock/README
@@ -9,7 +9,8 @@ may appear on top of the screen saver), or sometimes even worse.
 In XSecureLock, security is achieved using a modular design to avoid the
 usual pitfalls of screen locking utility design on X11.
 
-pandoc-bin (listed in REQUIRES) is required for generating man pages.
+If pandoc (or pandoc-bin) is installed, then the SlackBuild will build
+man pages as well.
 
-mpv is additionally required for building (and running) the saver_mpv
-module (which plays video clips in $HOME/Videos).
+In addition, mpv provides support for the saver_mpv module (which plays
+video clips in $HOME/Videos).

--- a/desktop/xsecurelock/xsecurelock.SlackBuild
+++ b/desktop/xsecurelock/xsecurelock.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=xsecurelock
 VERSION=${VERSION:-1.9.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -76,6 +76,9 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# If pandoc is installed, build the manpage 
+pandoc --version >/dev/null 2&>1 && PANDOC=yes || PANDOC=no
+
 sh autogen.sh
 
 CFLAGS="$SLKCFLAGS" \
@@ -89,7 +92,8 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --disable-static \
   --build=$ARCH-slackware-linux \
-  --with-pam-service-name=system-auth
+  --with-pam-service-name=system-auth \
+  --with-pandoc=$PANDOC
 
 make GIT_VERSION=$VERSION
 make install DESTDIR=$PKG
@@ -98,7 +102,7 @@ find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | gr
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 # compress man page
-gzip -9 $PKG/usr/man/man1/$PRGNAM.1
+[ ${PANDOC:-no} = yes ] && gzip -9 $PKG/usr/man/man1/$PRGNAM.1
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a CONTRIBUTING LICENSE README.md $PKG/usr/doc/$PRGNAM-$VERSION

--- a/desktop/xsecurelock/xsecurelock.info
+++ b/desktop/xsecurelock/xsecurelock.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/google/xsecurelock/releases/download/v1.9.0/xsecure
 MD5SUM="ccd6ec5ad9ee89a96020f1f9f5d642ea"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="pandoc-bin"
+REQUIRES=""
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
pandoc-bin (or pandoc) is only required at build-time for building man pages.
I have now made pandoc-bin an optional dependency.

This SlackBuild now autodetects whether pandoc is installed:
`pandoc --version >/dev/null 2&>1`

I also have made additional changes to the README (ex. description of mpv as an optional requirement for the saver_mpv module).