### PR TITLE
system/jq: Fix build test failures associated with non-English modules

### DIFF
--- a/system/jq/jq.SlackBuild
+++ b/system/jq/jq.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=jq
 VERSION=${VERSION:-1.7.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -76,6 +76,9 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# Fix build test failures if LANG is not C or en_US.UTF-8
+patch -p1 < $CWD/run_tests_in_C_locale.patch
 
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \

--- a/system/jq/run_tests_in_C_locale.patch
+++ b/system/jq/run_tests_in_C_locale.patch
@@ -1,0 +1,15 @@
+The following patch is taken from this pull request:
+https://github.com/jqlang/jq/pull/3039
+--- a/tests/setup
++++ b/tests/setup
+@@ -12,6 +12,10 @@
+ JQBASEDIR=$JQTESTDIR/..
+ JQ=${JQ:-$JQBASEDIR/jq}
+ 
++# Some tests have locale-dependent output; use C locale.  Fixes #3038
++LC_ALL=C
++export LC_ALL
++
+ if [ -z "${NO_VALGRIND-}" ] && which valgrind > /dev/null; then
+     VALGRIND="valgrind --error-exitcode=1 --leak-check=full \
+                        --suppressions=$JQTESTDIR/onig.supp \


### PR DESCRIPTION
I took a look at the SlackBuilds mailing list.
Thanks to Tonus for mentioning build failures when setting a non-english LANG (ex. fr_FR.UTF-8).
Also, thanks to nnb (nomnombtc) for linking to https://github.com/jqlang/jq/issues/3038.