### PR TITLE
development/jupyterlab: Add .desktop file

### DIFF
--- a/development/jupyterlab/doinst.sh
+++ b/development/jupyterlab/doinst.sh
@@ -1,0 +1,9 @@
+if [ -x /usr/bin/update-desktop-database ]; then
+  /usr/bin/update-desktop-database -q usr/share/applications >/dev/null 2>&1
+fi
+
+if [ -e usr/share/icons/hicolor/icon-theme.cache ]; then
+  if [ -x /usr/bin/gtk-update-icon-cache ]; then
+    /usr/bin/gtk-update-icon-cache -f usr/share/icons/hicolor >/dev/null 2>&1
+  fi
+fi

--- a/development/jupyterlab/jupyterlab.SlackBuild
+++ b/development/jupyterlab/jupyterlab.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for jupyterlab
 
-# Copyright 2022-2023 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2022-2024 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=jupyterlab
 VERSION=${VERSION:-3.5.3}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -46,20 +46,6 @@ fi
 TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
-
-if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
-else
-  SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
-fi
 
 set -e
 
@@ -88,6 +74,9 @@ sed 's|etc|/etc|' -i setup.py
 
 python3 setup.py install --root=$PKG
 
+# Install desktop file
+install -Dm644 $CWD/jupyterlab.desktop $PKG/usr/share/applications/jupyterlab.desktop
+
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
@@ -97,6 +86,7 @@ cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc
+cat $CWD/doinst.sh > $PKG/install/doinst.sh
 
 cd $PKG
 /sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE

--- a/development/jupyterlab/jupyterlab.desktop
+++ b/development/jupyterlab/jupyterlab.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=JupyterLab
+Comment=Run JupyterLab
+Exec=jupyter-lab %f
+Terminal=true
+Type=Application
+Icon=jupyterlab
+StartupNotify=true
+MimeType=application/x-ipynb+json;
+Categories=Development;Education;
+Keywords=python;


### PR DESCRIPTION
jupyterlab 4 has a .desktop file installed by default.

I think it would be a good idea for jupyterlab 3 to have this as well.

Anyway, I am not updating jupyterlab until Slackware 15.1 (or whatever comes after 15.0) gets released.
Any later version of jupyterlab requires python-requests > 2.26.