### PR TITLE
Update xdg-utils-cxx.SlackBuild

### DIFF
--- a/system/xdg-utils-cxx/xdg-utils-cxx.SlackBuild
+++ b/system/xdg-utils-cxx/xdg-utils-cxx.SlackBuild
@@ -53,13 +53,13 @@ PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
 if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
+  SLKCFLAGS="-march=i586 -mtune=i686 -pipe -O2 -fPIC"
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
+  SLKCFLAGS="-march=i686 -mtune=i686 -pipe -O2 -fPIC"
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
+  SLKCFLAGS="-march=x86-64 -mtune=generic -pipe -O2 -fPIC"
   LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
@@ -93,11 +93,6 @@ cmake -B build -S $TMP/$PRGNAM-$VERSION \
 
 cmake --build build
 DESTDIR=$PKG cmake --install build
-
-install -D -m755 $TMP/$PRGNAM-$VERSION/build/tests/BaseDir/TestXdgUtilsBaseDir -t "$PKG/usr/bin"
-install -D -m755 $TMP/$PRGNAM-$VERSION/build/tests/DesktopEntry/TestXdgUtilsDesktopEntry -t "/$PKG/usr/bin"
-install -D -m755 $TMP/$PRGNAM-$VERSION/build/tests/DesktopEntry/Reader/TestXdgUtilsDesktopEntryReader -t "$PKG/usr/bin"
-install -D -m755 $TMP/$PRGNAM-$VERSION/build/tests/DesktopEntry/AST/TestXdgUtilsDesktopAST -t "$PKG/usr/bin"
 
 # Don't ship .la files:
 rm -f $PKG/{,usr/}lib${LIBDIRSUFFIX}/*.la


### PR DESCRIPTION
Installing test binaries need to be removed in slackbuild if we are to  turn tests off, otherwise it will cause build problems.