### PR TITLE
python/python3-statsmodels: Update SlackBuild and README

### DIFF
--- a/python/python3-statsmodels/README
+++ b/python/python3-statsmodels/README
@@ -6,3 +6,6 @@ plotting functions, and result statistics are available for
 different types of data and each estimator. Researchers across
 fields may find that statsmodels fully meets their needs for
 statistical computing and data analysis in Python.
+
+python3-statsmodels 0.14.1 is the last available version for Slackware
+15.0. Newer versions would require Cython >= 3.0.10.

--- a/python/python3-statsmodels/python3-statsmodels.SlackBuild
+++ b/python/python3-statsmodels/python3-statsmodels.SlackBuild
@@ -71,9 +71,6 @@ find -L . \
 # remove requirement
 sed -i '/oldest-supported-numpy/d' pyproject.toml
 
-# convert to minimum req'd instead of pinned
-sed -i 's/\(setuptools_scm.*\)~=/\1>=/' pyproject.toml
-
 PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 export PYTHONPATH=/opt/python$PYVER/site-packages/
 


### PR DESCRIPTION
1. In python3-statsmodels 0.14.1, the line below "convert to minimum req'd instead of pinned" does not actually change anything within pyproject.toml.
2. I cannot update python3-statsmodels to 0.14.2. Such an update requires Cython >= 3.0.10 (Slackware 15.0 only has Cython 0.29.36).