### PR TITLE
Revert "multimedia/spot: Updated for version 0.4.0."

### DIFF
--- a/multimedia/spot/spot.SlackBuild
+++ b/multimedia/spot/spot.SlackBuild
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=spot
-VERSION=${VERSION:-0.4.0}
+VERSION=${VERSION:-0.3.3}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/multimedia/spot/spot.info
+++ b/multimedia/spot/spot.info
@@ -1,742 +1,700 @@
 PRGNAM="spot"
-VERSION="0.4.0"
+VERSION="0.3.3"
 HOMEPAGE="https://github.com/xou816/spot"
-DOWNLOAD="https://github.com/xou816/spot/archive/refs/tags/0.4.0/spot-0.4.0.tar.gz \
-          https://static.crates.io/crates/addr2line/addr2line-0.19.0.crate \
-          https://static.crates.io/crates/adler/adler-1.0.2.crate \
+DOWNLOAD="https://github.com/xou816/spot/archive/refs/tags/0.3.3/spot-0.3.3.tar.gz \
+          https://static.crates.io/crates/kernel32-sys/kernel32-sys-0.2.2.crate \
           https://static.crates.io/crates/aes/aes-0.6.0.crate \
-          https://static.crates.io/crates/aes/aes-0.7.5.crate \
           https://static.crates.io/crates/aes-ctr/aes-ctr-0.6.0.crate \
           https://static.crates.io/crates/aes-soft/aes-soft-0.6.4.crate \
           https://static.crates.io/crates/aesni/aesni-0.10.0.crate \
-          https://static.crates.io/crates/aho-corasick/aho-corasick-0.7.20.crate \
+          https://static.crates.io/crates/aho-corasick/aho-corasick-0.7.18.crate \
+          https://static.crates.io/crates/alsa/alsa-0.5.0.crate \
           https://static.crates.io/crates/alsa/alsa-0.6.0.crate \
           https://static.crates.io/crates/alsa-sys/alsa-sys-0.3.1.crate \
-          https://static.crates.io/crates/android_system_properties/android_system_properties-0.1.5.crate \
-          https://static.crates.io/crates/anyhow/anyhow-1.0.69.crate \
-          https://static.crates.io/crates/async-broadcast/async-broadcast-0.5.0.crate \
-          https://static.crates.io/crates/async-channel/async-channel-1.8.0.crate \
-          https://static.crates.io/crates/async-executor/async-executor-1.5.0.crate \
-          https://static.crates.io/crates/async-global-executor/async-global-executor-2.3.1.crate \
-          https://static.crates.io/crates/async-io/async-io-1.12.0.crate \
-          https://static.crates.io/crates/async-lock/async-lock-2.6.0.crate \
-          https://static.crates.io/crates/async-recursion/async-recursion-1.0.2.crate \
-          https://static.crates.io/crates/async-std/async-std-1.12.0.crate \
-          https://static.crates.io/crates/async-task/async-task-4.3.0.crate \
-          https://static.crates.io/crates/async-trait/async-trait-0.1.64.crate \
-          https://static.crates.io/crates/atomic-waker/atomic-waker-1.1.0.crate \
+          https://static.crates.io/crates/anyhow/anyhow-1.0.53.crate \
+          https://static.crates.io/crates/async-broadcast/async-broadcast-0.3.4.crate \
+          https://static.crates.io/crates/async-channel/async-channel-1.6.1.crate \
+          https://static.crates.io/crates/async-executor/async-executor-1.4.1.crate \
+          https://static.crates.io/crates/async-global-executor/async-global-executor-2.0.2.crate \
+          https://static.crates.io/crates/async-io/async-io-1.6.0.crate \
+          https://static.crates.io/crates/async-lock/async-lock-2.4.0.crate \
+          https://static.crates.io/crates/async-mutex/async-mutex-1.4.0.crate \
+          https://static.crates.io/crates/async-recursion/async-recursion-0.3.2.crate \
+          https://static.crates.io/crates/async-std/async-std-1.10.0.crate \
+          https://static.crates.io/crates/async-task/async-task-4.1.0.crate \
+          https://static.crates.io/crates/async-trait/async-trait-0.1.52.crate \
+          https://static.crates.io/crates/atomic-waker/atomic-waker-1.0.0.crate \
           https://static.crates.io/crates/atty/atty-0.2.14.crate \
           https://static.crates.io/crates/autocfg/autocfg-1.1.0.crate \
-          https://static.crates.io/crates/backtrace/backtrace-0.3.67.crate \
-          https://static.crates.io/crates/base64/base64-0.13.1.crate \
-          https://static.crates.io/crates/bindgen/bindgen-0.61.0.crate \
+          https://static.crates.io/crates/base64/base64-0.13.0.crate \
+          https://static.crates.io/crates/bindgen/bindgen-0.56.0.crate \
           https://static.crates.io/crates/bitflags/bitflags-1.3.2.crate \
           https://static.crates.io/crates/block/block-0.1.6.crate \
           https://static.crates.io/crates/block-buffer/block-buffer-0.9.0.crate \
-          https://static.crates.io/crates/block-buffer/block-buffer-0.10.3.crate \
-          https://static.crates.io/crates/block-modes/block-modes-0.8.1.crate \
+          https://static.crates.io/crates/block-modes/block-modes-0.7.0.crate \
           https://static.crates.io/crates/block-padding/block-padding-0.2.1.crate \
-          https://static.crates.io/crates/blocking/blocking-1.3.0.crate \
-          https://static.crates.io/crates/bumpalo/bumpalo-3.12.0.crate \
+          https://static.crates.io/crates/blocking/blocking-1.1.0.crate \
+          https://static.crates.io/crates/bumpalo/bumpalo-3.9.1.crate \
           https://static.crates.io/crates/byteorder/byteorder-1.4.3.crate \
-          https://static.crates.io/crates/bytes/bytes-1.4.0.crate \
-          https://static.crates.io/crates/cairo-rs/cairo-rs-0.17.0.crate \
-          https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.17.0.crate \
+          https://static.crates.io/crates/bytes/bytes-1.1.0.crate \
+          https://static.crates.io/crates/cache-padded/cache-padded-1.2.0.crate \
+          https://static.crates.io/crates/cairo-rs/cairo-rs-0.15.1.crate \
+          https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.15.1.crate \
           https://static.crates.io/crates/castaway/castaway-0.1.2.crate \
-          https://static.crates.io/crates/cc/cc-1.0.79.crate \
+          https://static.crates.io/crates/cc/cc-1.0.72.crate \
           https://static.crates.io/crates/cesu8/cesu8-1.1.0.crate \
-          https://static.crates.io/crates/cexpr/cexpr-0.6.0.crate \
-          https://static.crates.io/crates/cfg-expr/cfg-expr-0.11.0.crate \
+          https://static.crates.io/crates/cexpr/cexpr-0.4.0.crate \
+          https://static.crates.io/crates/cfg-expr/cfg-expr-0.9.1.crate \
+          https://static.crates.io/crates/cfg-if/cfg-if-0.1.10.crate \
           https://static.crates.io/crates/cfg-if/cfg-if-1.0.0.crate \
-          https://static.crates.io/crates/chrono/chrono-0.4.23.crate \
+          https://static.crates.io/crates/chrono/chrono-0.4.19.crate \
           https://static.crates.io/crates/cipher/cipher-0.2.5.crate \
-          https://static.crates.io/crates/cipher/cipher-0.3.0.crate \
-          https://static.crates.io/crates/clang-sys/clang-sys-1.4.0.crate \
-          https://static.crates.io/crates/codespan-reporting/codespan-reporting-0.11.1.crate \
-          https://static.crates.io/crates/combine/combine-4.6.6.crate \
-          https://static.crates.io/crates/concurrent-queue/concurrent-queue-2.1.0.crate \
+          https://static.crates.io/crates/clang-sys/clang-sys-1.3.1.crate \
+          https://static.crates.io/crates/combine/combine-4.6.3.crate \
+          https://static.crates.io/crates/concurrent-queue/concurrent-queue-1.2.2.crate \
           https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.3.crate \
           https://static.crates.io/crates/coreaudio-rs/coreaudio-rs-0.10.0.crate \
-          https://static.crates.io/crates/coreaudio-sys/coreaudio-sys-0.2.11.crate \
+          https://static.crates.io/crates/coreaudio-sys/coreaudio-sys-0.2.9.crate \
           https://static.crates.io/crates/cpal/cpal-0.13.5.crate \
-          https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.5.crate \
-          https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.14.crate \
-          https://static.crates.io/crates/crypto-common/crypto-common-0.1.6.crate \
+          https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.1.crate \
+          https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.7.crate \
+          https://static.crates.io/crates/crypto-mac/crypto-mac-0.10.1.crate \
           https://static.crates.io/crates/crypto-mac/crypto-mac-0.11.1.crate \
-          https://static.crates.io/crates/ctor/ctor-0.1.26.crate \
+          https://static.crates.io/crates/ctor/ctor-0.1.21.crate \
           https://static.crates.io/crates/ctr/ctr-0.6.0.crate \
-          https://static.crates.io/crates/curl/curl-0.4.44.crate \
-          https://static.crates.io/crates/curl-sys/curl-sys-0.4.59+curl-7.86.0.crate \
-          https://static.crates.io/crates/cxx/cxx-1.0.90.crate \
-          https://static.crates.io/crates/cxx-build/cxx-build-1.0.90.crate \
-          https://static.crates.io/crates/cxxbridge-flags/cxxbridge-flags-1.0.90.crate \
-          https://static.crates.io/crates/cxxbridge-macro/cxxbridge-macro-1.0.90.crate \
-          https://static.crates.io/crates/darling/darling-0.13.4.crate \
-          https://static.crates.io/crates/darling_core/darling_core-0.13.4.crate \
-          https://static.crates.io/crates/darling_macro/darling_macro-0.13.4.crate \
+          https://static.crates.io/crates/curl/curl-0.4.42.crate \
+          https://static.crates.io/crates/curl-sys/curl-sys-0.4.52+curl-7.81.0.crate \
+          https://static.crates.io/crates/darling/darling-0.13.1.crate \
+          https://static.crates.io/crates/darling_core/darling_core-0.13.1.crate \
+          https://static.crates.io/crates/darling_macro/darling_macro-0.13.1.crate \
           https://static.crates.io/crates/derivative/derivative-2.2.0.crate \
           https://static.crates.io/crates/digest/digest-0.9.0.crate \
-          https://static.crates.io/crates/digest/digest-0.10.6.crate \
-          https://static.crates.io/crates/dirs/dirs-4.0.0.crate \
-          https://static.crates.io/crates/dirs-sys/dirs-sys-0.3.7.crate \
-          https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.32.crate \
-          https://static.crates.io/crates/enumflags2/enumflags2-0.7.5.crate \
-          https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.7.4.crate \
-          https://static.crates.io/crates/env_logger/env_logger-0.9.3.crate \
-          https://static.crates.io/crates/event-listener/event-listener-2.5.3.crate \
-          https://static.crates.io/crates/fastrand/fastrand-1.8.0.crate \
+          https://static.crates.io/crates/easy-parallel/easy-parallel-3.2.0.crate \
+          https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.30.crate \
+          https://static.crates.io/crates/enumflags2/enumflags2-0.6.4.crate \
+          https://static.crates.io/crates/enumflags2/enumflags2-0.7.3.crate \
+          https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.6.4.crate \
+          https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.7.3.crate \
+          https://static.crates.io/crates/env_logger/env_logger-0.8.4.crate \
+          https://static.crates.io/crates/env_logger/env_logger-0.9.0.crate \
+          https://static.crates.io/crates/event-listener/event-listener-2.5.2.crate \
+          https://static.crates.io/crates/fastrand/fastrand-1.7.0.crate \
           https://static.crates.io/crates/field-offset/field-offset-0.3.4.crate \
-          https://static.crates.io/crates/fixedbitset/fixedbitset-0.4.2.crate \
           https://static.crates.io/crates/fnv/fnv-1.0.7.crate \
-          https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.1.0.crate \
-          https://static.crates.io/crates/futures/futures-0.3.26.crate \
-          https://static.crates.io/crates/futures-channel/futures-channel-0.3.26.crate \
-          https://static.crates.io/crates/futures-core/futures-core-0.3.26.crate \
-          https://static.crates.io/crates/futures-executor/futures-executor-0.3.26.crate \
-          https://static.crates.io/crates/futures-io/futures-io-0.3.26.crate \
+          https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.0.1.crate \
+          https://static.crates.io/crates/futures/futures-0.3.21.crate \
+          https://static.crates.io/crates/futures-channel/futures-channel-0.3.21.crate \
+          https://static.crates.io/crates/futures-core/futures-core-0.3.21.crate \
+          https://static.crates.io/crates/futures-executor/futures-executor-0.3.21.crate \
+          https://static.crates.io/crates/futures-io/futures-io-0.3.21.crate \
           https://static.crates.io/crates/futures-lite/futures-lite-1.12.0.crate \
-          https://static.crates.io/crates/futures-macro/futures-macro-0.3.26.crate \
-          https://static.crates.io/crates/futures-sink/futures-sink-0.3.26.crate \
-          https://static.crates.io/crates/futures-task/futures-task-0.3.26.crate \
-          https://static.crates.io/crates/futures-util/futures-util-0.3.26.crate \
-          https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.17.0.crate \
-          https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.17.0.crate \
-          https://static.crates.io/crates/gdk4/gdk4-0.6.0.crate \
-          https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.6.0.crate \
-          https://static.crates.io/crates/generic-array/generic-array-0.14.6.crate \
+          https://static.crates.io/crates/futures-macro/futures-macro-0.3.21.crate \
+          https://static.crates.io/crates/futures-sink/futures-sink-0.3.21.crate \
+          https://static.crates.io/crates/futures-task/futures-task-0.3.21.crate \
+          https://static.crates.io/crates/futures-util/futures-util-0.3.21.crate \
+          https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.15.6.crate \
+          https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.15.1.crate \
+          https://static.crates.io/crates/gdk4/gdk4-0.4.6.crate \
+          https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.4.2.crate \
+          https://static.crates.io/crates/generic-array/generic-array-0.14.5.crate \
           https://static.crates.io/crates/getopts/getopts-0.2.21.crate \
-          https://static.crates.io/crates/getrandom/getrandom-0.2.8.crate \
+          https://static.crates.io/crates/getrandom/getrandom-0.2.4.crate \
           https://static.crates.io/crates/gettext-rs/gettext-rs-0.7.0.crate \
-          https://static.crates.io/crates/gettext-sys/gettext-sys-0.21.3.crate \
-          https://static.crates.io/crates/gimli/gimli-0.27.1.crate \
-          https://static.crates.io/crates/gio/gio-0.17.0.crate \
-          https://static.crates.io/crates/gio-sys/gio-sys-0.17.0.crate \
-          https://static.crates.io/crates/glib/glib-0.17.1.crate \
-          https://static.crates.io/crates/glib-macros/glib-macros-0.17.1.crate \
-          https://static.crates.io/crates/glib-sys/glib-sys-0.17.0.crate \
-          https://static.crates.io/crates/glob/glob-0.3.1.crate \
-          https://static.crates.io/crates/gloo-timers/gloo-timers-0.2.6.crate \
-          https://static.crates.io/crates/gobject-sys/gobject-sys-0.17.0.crate \
-          https://static.crates.io/crates/graphene-rs/graphene-rs-0.17.1.crate \
-          https://static.crates.io/crates/graphene-sys/graphene-sys-0.17.0.crate \
-          https://static.crates.io/crates/gsk4/gsk4-0.6.0.crate \
-          https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.6.0.crate \
-          https://static.crates.io/crates/gtk4/gtk4-0.6.1.crate \
-          https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.6.0.crate \
-          https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.6.0.crate \
-          https://static.crates.io/crates/hashbrown/hashbrown-0.12.3.crate \
-          https://static.crates.io/crates/headers/headers-0.3.8.crate \
+          https://static.crates.io/crates/gettext-sys/gettext-sys-0.21.2.crate \
+          https://static.crates.io/crates/gio/gio-0.15.7.crate \
+          https://static.crates.io/crates/gio-sys/gio-sys-0.15.5.crate \
+          https://static.crates.io/crates/glib/glib-0.15.9.crate \
+          https://static.crates.io/crates/glib-macros/glib-macros-0.15.3.crate \
+          https://static.crates.io/crates/glib-sys/glib-sys-0.15.5.crate \
+          https://static.crates.io/crates/glob/glob-0.3.0.crate \
+          https://static.crates.io/crates/gloo-timers/gloo-timers-0.2.3.crate \
+          https://static.crates.io/crates/gobject-sys/gobject-sys-0.15.5.crate \
+          https://static.crates.io/crates/graphene-rs/graphene-rs-0.15.1.crate \
+          https://static.crates.io/crates/graphene-sys/graphene-sys-0.15.1.crate \
+          https://static.crates.io/crates/gsk4/gsk4-0.4.6.crate \
+          https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.4.2.crate \
+          https://static.crates.io/crates/gtk4/gtk4-0.4.6.crate \
+          https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.4.3.crate \
+          https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.4.5.crate \
+          https://static.crates.io/crates/hashbrown/hashbrown-0.11.2.crate \
+          https://static.crates.io/crates/headers/headers-0.3.6.crate \
           https://static.crates.io/crates/headers-core/headers-core-0.2.0.crate \
-          https://static.crates.io/crates/heck/heck-0.4.1.crate \
+          https://static.crates.io/crates/heck/heck-0.4.0.crate \
           https://static.crates.io/crates/hermit-abi/hermit-abi-0.1.19.crate \
-          https://static.crates.io/crates/hermit-abi/hermit-abi-0.2.6.crate \
           https://static.crates.io/crates/hex/hex-0.4.3.crate \
-          https://static.crates.io/crates/hkdf/hkdf-0.12.3.crate \
+          https://static.crates.io/crates/hkdf/hkdf-0.10.0.crate \
+          https://static.crates.io/crates/hmac/hmac-0.10.1.crate \
           https://static.crates.io/crates/hmac/hmac-0.11.0.crate \
-          https://static.crates.io/crates/hmac/hmac-0.12.1.crate \
           https://static.crates.io/crates/hostname/hostname-0.3.1.crate \
-          https://static.crates.io/crates/http/http-0.2.8.crate \
-          https://static.crates.io/crates/http-body/http-body-0.4.5.crate \
-          https://static.crates.io/crates/httparse/httparse-1.8.0.crate \
+          https://static.crates.io/crates/http/http-0.2.6.crate \
+          https://static.crates.io/crates/http-body/http-body-0.4.4.crate \
+          https://static.crates.io/crates/httparse/httparse-1.5.1.crate \
           https://static.crates.io/crates/httpdate/httpdate-1.0.2.crate \
           https://static.crates.io/crates/humantime/humantime-2.1.0.crate \
-          https://static.crates.io/crates/hyper/hyper-0.14.24.crate \
+          https://static.crates.io/crates/hyper/hyper-0.14.16.crate \
           https://static.crates.io/crates/hyper-proxy/hyper-proxy-0.9.1.crate \
-          https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.53.crate \
-          https://static.crates.io/crates/iana-time-zone-haiku/iana-time-zone-haiku-0.1.1.crate \
           https://static.crates.io/crates/ident_case/ident_case-1.0.1.crate \
-          https://static.crates.io/crates/idna/idna-0.3.0.crate \
-          https://static.crates.io/crates/if-addrs/if-addrs-0.7.0.crate \
-          https://static.crates.io/crates/indexmap/indexmap-1.9.2.crate \
+          https://static.crates.io/crates/idna/idna-0.2.3.crate \
+          https://static.crates.io/crates/if-addrs/if-addrs-0.6.7.crate \
+          https://static.crates.io/crates/if-addrs-sys/if-addrs-sys-0.3.2.crate \
+          https://static.crates.io/crates/indexmap/indexmap-1.8.0.crate \
           https://static.crates.io/crates/instant/instant-0.1.12.crate \
-          https://static.crates.io/crates/isahc/isahc-1.7.2.crate \
-          https://static.crates.io/crates/itoa/itoa-1.0.5.crate \
+          https://static.crates.io/crates/isahc/isahc-1.7.0.crate \
+          https://static.crates.io/crates/itoa/itoa-0.4.8.crate \
+          https://static.crates.io/crates/itoa/itoa-1.0.1.crate \
           https://static.crates.io/crates/jni/jni-0.19.0.crate \
           https://static.crates.io/crates/jni-sys/jni-sys-0.3.0.crate \
-          https://static.crates.io/crates/jobserver/jobserver-0.1.25.crate \
-          https://static.crates.io/crates/js-sys/js-sys-0.3.61.crate \
+          https://static.crates.io/crates/jobserver/jobserver-0.1.24.crate \
+          https://static.crates.io/crates/js-sys/js-sys-0.3.56.crate \
           https://static.crates.io/crates/kv-log-macro/kv-log-macro-1.0.7.crate \
           https://static.crates.io/crates/lazy_static/lazy_static-1.4.0.crate \
           https://static.crates.io/crates/lazycell/lazycell-1.3.0.crate \
           https://static.crates.io/crates/lewton/lewton-0.10.2.crate \
-          https://static.crates.io/crates/libadwaita/libadwaita-0.3.0.crate \
-          https://static.crates.io/crates/libadwaita-sys/libadwaita-sys-0.3.0.crate \
-          https://static.crates.io/crates/libc/libc-0.2.139.crate \
-          https://static.crates.io/crates/libloading/libloading-0.7.4.crate \
-          https://static.crates.io/crates/libm/libm-0.2.6.crate \
-          https://static.crates.io/crates/libmdns/libmdns-0.7.4.crate \
+          https://static.crates.io/crates/libadwaita/libadwaita-0.1.0.crate \
+          https://static.crates.io/crates/libadwaita-sys/libadwaita-sys-0.1.0.crate \
+          https://static.crates.io/crates/libc/libc-0.2.117.crate \
+          https://static.crates.io/crates/libloading/libloading-0.7.3.crate \
+          https://static.crates.io/crates/libm/libm-0.2.2.crate \
+          https://static.crates.io/crates/libmdns/libmdns-0.6.2.crate \
           https://static.crates.io/crates/libnghttp2-sys/libnghttp2-sys-0.1.7+1.45.0.crate \
-          https://static.crates.io/crates/libpulse-binding/libpulse-binding-2.27.1.crate \
-          https://static.crates.io/crates/libpulse-simple-binding/libpulse-simple-binding-2.27.1.crate \
-          https://static.crates.io/crates/libpulse-simple-sys/libpulse-simple-sys-1.20.1.crate \
-          https://static.crates.io/crates/libpulse-sys/libpulse-sys-1.20.1.crate \
-          https://static.crates.io/crates/librespot/librespot-0.4.2.crate \
-          https://static.crates.io/crates/librespot-audio/librespot-audio-0.4.2.crate \
-          https://static.crates.io/crates/librespot-connect/librespot-connect-0.4.2.crate \
-          https://static.crates.io/crates/librespot-core/librespot-core-0.4.2.crate \
-          https://static.crates.io/crates/librespot-discovery/librespot-discovery-0.4.2.crate \
-          https://static.crates.io/crates/librespot-metadata/librespot-metadata-0.4.2.crate \
-          https://static.crates.io/crates/librespot-playback/librespot-playback-0.4.2.crate \
-          https://static.crates.io/crates/librespot-protocol/librespot-protocol-0.4.2.crate \
-          https://static.crates.io/crates/libz-sys/libz-sys-1.1.8.crate \
-          https://static.crates.io/crates/link-cplusplus/link-cplusplus-1.0.8.crate \
+          https://static.crates.io/crates/libpulse-binding/libpulse-binding-2.26.0.crate \
+          https://static.crates.io/crates/libpulse-simple-binding/libpulse-simple-binding-2.25.0.crate \
+          https://static.crates.io/crates/libpulse-simple-sys/libpulse-simple-sys-1.19.2.crate \
+          https://static.crates.io/crates/libpulse-sys/libpulse-sys-1.19.3.crate \
+          https://static.crates.io/crates/librespot/librespot-0.3.1.crate \
+          https://static.crates.io/crates/librespot-audio/librespot-audio-0.3.1.crate \
+          https://static.crates.io/crates/librespot-connect/librespot-connect-0.3.1.crate \
+          https://static.crates.io/crates/librespot-core/librespot-core-0.3.1.crate \
+          https://static.crates.io/crates/librespot-discovery/librespot-discovery-0.3.1.crate \
+          https://static.crates.io/crates/librespot-metadata/librespot-metadata-0.3.1.crate \
+          https://static.crates.io/crates/librespot-playback/librespot-playback-0.3.1.crate \
+          https://static.crates.io/crates/librespot-protocol/librespot-protocol-0.3.1.crate \
+          https://static.crates.io/crates/libz-sys/libz-sys-1.1.3.crate \
           https://static.crates.io/crates/locale_config/locale_config-0.3.0.crate \
-          https://static.crates.io/crates/lock_api/lock_api-0.4.9.crate \
-          https://static.crates.io/crates/log/log-0.4.17.crate \
+          https://static.crates.io/crates/lock_api/lock_api-0.4.6.crate \
+          https://static.crates.io/crates/log/log-0.4.14.crate \
           https://static.crates.io/crates/mach/mach-0.3.2.crate \
           https://static.crates.io/crates/malloc_buf/malloc_buf-0.0.6.crate \
           https://static.crates.io/crates/match_cfg/match_cfg-0.1.0.crate \
-          https://static.crates.io/crates/memchr/memchr-2.5.0.crate \
+          https://static.crates.io/crates/matches/matches-0.1.9.crate \
+          https://static.crates.io/crates/memchr/memchr-2.4.1.crate \
           https://static.crates.io/crates/memoffset/memoffset-0.6.5.crate \
           https://static.crates.io/crates/mime/mime-0.3.16.crate \
-          https://static.crates.io/crates/minimal-lexical/minimal-lexical-0.2.1.crate \
-          https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.6.2.crate \
-          https://static.crates.io/crates/mio/mio-0.8.5.crate \
+          https://static.crates.io/crates/mio/mio-0.8.0.crate \
+          https://static.crates.io/crates/miow/miow-0.3.7.crate \
           https://static.crates.io/crates/multimap/multimap-0.8.3.crate \
+          https://static.crates.io/crates/nb-connect/nb-connect-1.2.0.crate \
           https://static.crates.io/crates/ndk/ndk-0.6.0.crate \
-          https://static.crates.io/crates/ndk-context/ndk-context-0.1.1.crate \
-          https://static.crates.io/crates/ndk-glue/ndk-glue-0.6.2.crate \
+          https://static.crates.io/crates/ndk-glue/ndk-glue-0.6.0.crate \
           https://static.crates.io/crates/ndk-macro/ndk-macro-0.3.0.crate \
           https://static.crates.io/crates/ndk-sys/ndk-sys-0.3.0.crate \
-          https://static.crates.io/crates/nix/nix-0.23.2.crate \
-          https://static.crates.io/crates/nix/nix-0.25.1.crate \
-          https://static.crates.io/crates/nom/nom-7.1.3.crate \
-          https://static.crates.io/crates/nom8/nom8-0.2.0.crate \
-          https://static.crates.io/crates/num/num-0.4.0.crate \
+          https://static.crates.io/crates/nix/nix-0.17.0.crate \
+          https://static.crates.io/crates/nix/nix-0.20.0.crate \
+          https://static.crates.io/crates/nix/nix-0.23.1.crate \
+          https://static.crates.io/crates/nom/nom-5.1.2.crate \
+          https://static.crates.io/crates/ntapi/ntapi-0.3.6.crate \
+          https://static.crates.io/crates/num/num-0.3.1.crate \
+          https://static.crates.io/crates/num-bigint/num-bigint-0.3.3.crate \
           https://static.crates.io/crates/num-bigint/num-bigint-0.4.3.crate \
-          https://static.crates.io/crates/num-complex/num-complex-0.4.3.crate \
+          https://static.crates.io/crates/num-complex/num-complex-0.3.1.crate \
           https://static.crates.io/crates/num-derive/num-derive-0.3.3.crate \
-          https://static.crates.io/crates/num-integer/num-integer-0.1.45.crate \
-          https://static.crates.io/crates/num-iter/num-iter-0.1.43.crate \
-          https://static.crates.io/crates/num-rational/num-rational-0.4.1.crate \
-          https://static.crates.io/crates/num-traits/num-traits-0.2.15.crate \
-          https://static.crates.io/crates/num_cpus/num_cpus-1.15.0.crate \
-          https://static.crates.io/crates/num_enum/num_enum-0.5.9.crate \
-          https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.5.9.crate \
+          https://static.crates.io/crates/num-integer/num-integer-0.1.44.crate \
+          https://static.crates.io/crates/num-iter/num-iter-0.1.42.crate \
+          https://static.crates.io/crates/num-rational/num-rational-0.3.2.crate \
+          https://static.crates.io/crates/num-traits/num-traits-0.2.14.crate \
+          https://static.crates.io/crates/num_cpus/num_cpus-1.13.1.crate \
+          https://static.crates.io/crates/num_enum/num_enum-0.5.6.crate \
+          https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.5.6.crate \
           https://static.crates.io/crates/objc/objc-0.2.7.crate \
           https://static.crates.io/crates/objc-foundation/objc-foundation-0.1.1.crate \
           https://static.crates.io/crates/objc_id/objc_id-0.1.1.crate \
-          https://static.crates.io/crates/object/object-0.30.3.crate \
-          https://static.crates.io/crates/oboe/oboe-0.4.6.crate \
+          https://static.crates.io/crates/oboe/oboe-0.4.5.crate \
           https://static.crates.io/crates/oboe-sys/oboe-sys-0.4.5.crate \
           https://static.crates.io/crates/ogg/ogg-0.8.0.crate \
-          https://static.crates.io/crates/once_cell/once_cell-1.17.0.crate \
+          https://static.crates.io/crates/once_cell/once_cell-1.9.0.crate \
           https://static.crates.io/crates/opaque-debug/opaque-debug-0.3.0.crate \
           https://static.crates.io/crates/openssl-probe/openssl-probe-0.1.5.crate \
-          https://static.crates.io/crates/openssl-sys/openssl-sys-0.9.80.crate \
-          https://static.crates.io/crates/ordered-stream/ordered-stream-0.2.0.crate \
-          https://static.crates.io/crates/pango/pango-0.17.0.crate \
-          https://static.crates.io/crates/pango-sys/pango-sys-0.17.0.crate \
+          https://static.crates.io/crates/openssl-sys/openssl-sys-0.9.72.crate \
+          https://static.crates.io/crates/ordered-stream/ordered-stream-0.0.1.crate \
+          https://static.crates.io/crates/pango/pango-0.15.2.crate \
+          https://static.crates.io/crates/pango-sys/pango-sys-0.15.1.crate \
           https://static.crates.io/crates/parking/parking-2.0.0.crate \
           https://static.crates.io/crates/parking_lot/parking_lot-0.11.2.crate \
-          https://static.crates.io/crates/parking_lot/parking_lot-0.12.1.crate \
-          https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.8.6.crate \
-          https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.7.crate \
+          https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.8.5.crate \
           https://static.crates.io/crates/pbkdf2/pbkdf2-0.8.0.crate \
           https://static.crates.io/crates/peeking_take_while/peeking_take_while-0.1.2.crate \
-          https://static.crates.io/crates/percent-encoding/percent-encoding-2.2.0.crate \
-          https://static.crates.io/crates/pest/pest-2.5.5.crate \
-          https://static.crates.io/crates/petgraph/petgraph-0.6.3.crate \
-          https://static.crates.io/crates/pin-project/pin-project-1.0.12.crate \
-          https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.0.12.crate \
-          https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.9.crate \
+          https://static.crates.io/crates/percent-encoding/percent-encoding-2.1.0.crate \
+          https://static.crates.io/crates/pest/pest-2.1.3.crate \
+          https://static.crates.io/crates/pin-project/pin-project-1.0.10.crate \
+          https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.0.10.crate \
+          https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.8.crate \
           https://static.crates.io/crates/pin-utils/pin-utils-0.1.0.crate \
-          https://static.crates.io/crates/pkg-config/pkg-config-0.3.26.crate \
-          https://static.crates.io/crates/polling/polling-2.5.2.crate \
-          https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.17.crate \
-          https://static.crates.io/crates/priority-queue/priority-queue-1.3.1.crate \
-          https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-1.3.0.crate \
+          https://static.crates.io/crates/pkg-config/pkg-config-0.3.24.crate \
+          https://static.crates.io/crates/polling/polling-2.2.0.crate \
+          https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.16.crate \
+          https://static.crates.io/crates/priority-queue/priority-queue-1.2.1.crate \
+          https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-0.1.5.crate \
+          https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-1.1.0.crate \
           https://static.crates.io/crates/proc-macro-error/proc-macro-error-1.0.4.crate \
           https://static.crates.io/crates/proc-macro-error-attr/proc-macro-error-attr-1.0.4.crate \
-          https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.51.crate \
-          https://static.crates.io/crates/protobuf/protobuf-2.28.0.crate \
-          https://static.crates.io/crates/protobuf-codegen/protobuf-codegen-2.28.0.crate \
-          https://static.crates.io/crates/protobuf-codegen-pure/protobuf-codegen-pure-2.28.0.crate \
-          https://static.crates.io/crates/quote/quote-1.0.23.crate \
+          https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.36.crate \
+          https://static.crates.io/crates/protobuf/protobuf-2.27.1.crate \
+          https://static.crates.io/crates/protobuf-codegen/protobuf-codegen-2.27.1.crate \
+          https://static.crates.io/crates/protobuf-codegen-pure/protobuf-codegen-pure-2.27.1.crate \
+          https://static.crates.io/crates/quote/quote-1.0.15.crate \
           https://static.crates.io/crates/rand/rand-0.8.5.crate \
           https://static.crates.io/crates/rand_chacha/rand_chacha-0.3.1.crate \
-          https://static.crates.io/crates/rand_core/rand_core-0.6.4.crate \
+          https://static.crates.io/crates/rand_core/rand_core-0.6.3.crate \
           https://static.crates.io/crates/rand_distr/rand_distr-0.4.3.crate \
-          https://static.crates.io/crates/redox_syscall/redox_syscall-0.2.16.crate \
-          https://static.crates.io/crates/redox_users/redox_users-0.4.3.crate \
+          https://static.crates.io/crates/redox_syscall/redox_syscall-0.2.10.crate \
           https://static.crates.io/crates/ref_filter_map/ref_filter_map-1.0.1.crate \
-          https://static.crates.io/crates/regex/regex-1.7.1.crate \
-          https://static.crates.io/crates/regex-syntax/regex-syntax-0.6.28.crate \
+          https://static.crates.io/crates/regex/regex-1.5.5.crate \
+          https://static.crates.io/crates/regex-syntax/regex-syntax-0.6.25.crate \
           https://static.crates.io/crates/remove_dir_all/remove_dir_all-0.5.3.crate \
-          https://static.crates.io/crates/rodio/rodio-0.15.0.crate \
-          https://static.crates.io/crates/rpassword/rpassword-6.0.1.crate \
-          https://static.crates.io/crates/rustc-demangle/rustc-demangle-0.1.21.crate \
+          https://static.crates.io/crates/rodio/rodio-0.14.0.crate \
+          https://static.crates.io/crates/rpassword/rpassword-5.0.1.crate \
           https://static.crates.io/crates/rustc-hash/rustc-hash-1.1.0.crate \
           https://static.crates.io/crates/rustc_version/rustc_version-0.3.3.crate \
           https://static.crates.io/crates/rustc_version/rustc_version-0.4.0.crate \
-          https://static.crates.io/crates/ryu/ryu-1.0.12.crate \
+          https://static.crates.io/crates/ryu/ryu-1.0.9.crate \
           https://static.crates.io/crates/same-file/same-file-1.0.6.crate \
-          https://static.crates.io/crates/schannel/schannel-0.1.21.crate \
+          https://static.crates.io/crates/schannel/schannel-0.1.19.crate \
+          https://static.crates.io/crates/scoped-tls/scoped-tls-1.0.0.crate \
           https://static.crates.io/crates/scopeguard/scopeguard-1.1.0.crate \
-          https://static.crates.io/crates/scratch/scratch-1.0.3.crate \
-          https://static.crates.io/crates/secret-service/secret-service-3.0.1.crate \
+          https://static.crates.io/crates/secret-service/secret-service-2.0.1.crate \
           https://static.crates.io/crates/semver/semver-0.11.0.crate \
-          https://static.crates.io/crates/semver/semver-1.0.16.crate \
+          https://static.crates.io/crates/semver/semver-1.0.5.crate \
           https://static.crates.io/crates/semver-parser/semver-parser-0.10.2.crate \
-          https://static.crates.io/crates/serde/serde-1.0.152.crate \
-          https://static.crates.io/crates/serde_derive/serde_derive-1.0.152.crate \
-          https://static.crates.io/crates/serde_json/serde_json-1.0.93.crate \
-          https://static.crates.io/crates/serde_repr/serde_repr-0.1.10.crate \
+          https://static.crates.io/crates/serde/serde-1.0.136.crate \
+          https://static.crates.io/crates/serde_derive/serde_derive-1.0.136.crate \
+          https://static.crates.io/crates/serde_json/serde_json-1.0.79.crate \
+          https://static.crates.io/crates/serde_repr/serde_repr-0.1.7.crate \
           https://static.crates.io/crates/sha-1/sha-1-0.9.8.crate \
-          https://static.crates.io/crates/sha1/sha1-0.10.5.crate \
-          https://static.crates.io/crates/sha2/sha2-0.10.6.crate \
+          https://static.crates.io/crates/sha1/sha1-0.6.1.crate \
+          https://static.crates.io/crates/sha1_smol/sha1_smol-1.0.0.crate \
+          https://static.crates.io/crates/sha2/sha2-0.9.9.crate \
           https://static.crates.io/crates/shannon/shannon-0.2.0.crate \
           https://static.crates.io/crates/shell-words/shell-words-1.1.0.crate \
-          https://static.crates.io/crates/shlex/shlex-1.1.0.crate \
-          https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.1.crate \
-          https://static.crates.io/crates/slab/slab-0.4.7.crate \
+          https://static.crates.io/crates/shlex/shlex-0.1.1.crate \
+          https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.0.crate \
+          https://static.crates.io/crates/slab/slab-0.4.5.crate \
           https://static.crates.io/crates/sluice/sluice-0.5.5.crate \
-          https://static.crates.io/crates/smallvec/smallvec-1.10.0.crate \
-          https://static.crates.io/crates/socket2/socket2-0.4.7.crate \
+          https://static.crates.io/crates/smallvec/smallvec-1.8.0.crate \
+          https://static.crates.io/crates/socket2/socket2-0.4.4.crate \
           https://static.crates.io/crates/static_assertions/static_assertions-1.1.0.crate \
           https://static.crates.io/crates/stdweb/stdweb-0.1.3.crate \
           https://static.crates.io/crates/strsim/strsim-0.10.0.crate \
           https://static.crates.io/crates/subtle/subtle-2.4.1.crate \
-          https://static.crates.io/crates/syn/syn-1.0.107.crate \
-          https://static.crates.io/crates/system-deps/system-deps-6.0.3.crate \
+          https://static.crates.io/crates/syn/syn-1.0.86.crate \
+          https://static.crates.io/crates/synstructure/synstructure-0.12.6.crate \
+          https://static.crates.io/crates/system-deps/system-deps-6.0.1.crate \
           https://static.crates.io/crates/temp-dir/temp-dir-0.1.11.crate \
           https://static.crates.io/crates/tempfile/tempfile-3.3.0.crate \
-          https://static.crates.io/crates/termcolor/termcolor-1.2.0.crate \
-          https://static.crates.io/crates/thiserror/thiserror-1.0.38.crate \
-          https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.38.crate \
-          https://static.crates.io/crates/thread-id/thread-id-4.0.0.crate \
-          https://static.crates.io/crates/time/time-0.1.45.crate \
-          https://static.crates.io/crates/tinyvec/tinyvec-1.6.0.crate \
-          https://static.crates.io/crates/tinyvec_macros/tinyvec_macros-0.1.1.crate \
-          https://static.crates.io/crates/tokio/tokio-1.25.0.crate \
-          https://static.crates.io/crates/tokio-macros/tokio-macros-1.8.2.crate \
-          https://static.crates.io/crates/tokio-stream/tokio-stream-0.1.11.crate \
-          https://static.crates.io/crates/tokio-util/tokio-util-0.7.7.crate \
-          https://static.crates.io/crates/toml/toml-0.5.11.crate \
-          https://static.crates.io/crates/toml_datetime/toml_datetime-0.5.1.crate \
-          https://static.crates.io/crates/toml_edit/toml_edit-0.18.1.crate \
-          https://static.crates.io/crates/tower-service/tower-service-0.3.2.crate \
-          https://static.crates.io/crates/tracing/tracing-0.1.37.crate \
-          https://static.crates.io/crates/tracing-attributes/tracing-attributes-0.1.23.crate \
-          https://static.crates.io/crates/tracing-core/tracing-core-0.1.30.crate \
+          https://static.crates.io/crates/termcolor/termcolor-1.1.2.crate \
+          https://static.crates.io/crates/thiserror/thiserror-1.0.30.crate \
+          https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.30.crate \
+          https://static.crates.io/crates/time/time-0.1.43.crate \
+          https://static.crates.io/crates/tinyvec/tinyvec-1.5.1.crate \
+          https://static.crates.io/crates/tinyvec_macros/tinyvec_macros-0.1.0.crate \
+          https://static.crates.io/crates/tokio/tokio-1.17.0.crate \
+          https://static.crates.io/crates/tokio-macros/tokio-macros-1.7.0.crate \
+          https://static.crates.io/crates/tokio-stream/tokio-stream-0.1.8.crate \
+          https://static.crates.io/crates/tokio-util/tokio-util-0.6.9.crate \
+          https://static.crates.io/crates/toml/toml-0.5.8.crate \
+          https://static.crates.io/crates/tower-service/tower-service-0.3.1.crate \
+          https://static.crates.io/crates/tracing/tracing-0.1.30.crate \
+          https://static.crates.io/crates/tracing-attributes/tracing-attributes-0.1.19.crate \
+          https://static.crates.io/crates/tracing-core/tracing-core-0.1.22.crate \
           https://static.crates.io/crates/tracing-futures/tracing-futures-0.2.5.crate \
-          https://static.crates.io/crates/try-lock/try-lock-0.2.4.crate \
-          https://static.crates.io/crates/typenum/typenum-1.16.0.crate \
-          https://static.crates.io/crates/ucd-trie/ucd-trie-0.1.5.crate \
-          https://static.crates.io/crates/uds_windows/uds_windows-1.0.2.crate \
-          https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.10.crate \
-          https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.6.crate \
-          https://static.crates.io/crates/unicode-normalization/unicode-normalization-0.1.22.crate \
-          https://static.crates.io/crates/unicode-width/unicode-width-0.1.10.crate \
-          https://static.crates.io/crates/url/url-2.3.1.crate \
-          https://static.crates.io/crates/uuid/uuid-1.3.0.crate \
-          https://static.crates.io/crates/value-bag/value-bag-1.0.0-alpha.9.crate \
+          https://static.crates.io/crates/try-lock/try-lock-0.2.3.crate \
+          https://static.crates.io/crates/typenum/typenum-1.15.0.crate \
+          https://static.crates.io/crates/ucd-trie/ucd-trie-0.1.3.crate \
+          https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.7.crate \
+          https://static.crates.io/crates/unicode-normalization/unicode-normalization-0.1.19.crate \
+          https://static.crates.io/crates/unicode-width/unicode-width-0.1.9.crate \
+          https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.2.crate \
+          https://static.crates.io/crates/url/url-2.2.2.crate \
+          https://static.crates.io/crates/uuid/uuid-0.8.2.crate \
+          https://static.crates.io/crates/value-bag/value-bag-1.0.0-alpha.8.crate \
           https://static.crates.io/crates/vcpkg/vcpkg-0.2.15.crate \
           https://static.crates.io/crates/vergen/vergen-3.2.0.crate \
-          https://static.crates.io/crates/version-compare/version-compare-0.1.1.crate \
+          https://static.crates.io/crates/version-compare/version-compare-0.1.0.crate \
           https://static.crates.io/crates/version_check/version_check-0.9.4.crate \
+          https://static.crates.io/crates/void/void-1.0.2.crate \
           https://static.crates.io/crates/waker-fn/waker-fn-1.1.0.crate \
           https://static.crates.io/crates/walkdir/walkdir-2.3.2.crate \
           https://static.crates.io/crates/want/want-0.3.0.crate \
-          https://static.crates.io/crates/wasi/wasi-0.10.0+wasi-snapshot-preview1.crate \
-          https://static.crates.io/crates/wasi/wasi-0.11.0+wasi-snapshot-preview1.crate \
-          https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.84.crate \
-          https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.84.crate \
-          https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.34.crate \
-          https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.84.crate \
-          https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.84.crate \
-          https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.84.crate \
-          https://static.crates.io/crates/web-sys/web-sys-0.3.61.crate \
+          https://static.crates.io/crates/wasi/wasi-0.10.2+wasi-snapshot-preview1.crate \
+          https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.79.crate \
+          https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.79.crate \
+          https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.29.crate \
+          https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.79.crate \
+          https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.79.crate \
+          https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.79.crate \
+          https://static.crates.io/crates/web-sys/web-sys-0.3.56.crate \
           https://static.crates.io/crates/wepoll-ffi/wepoll-ffi-0.1.2.crate \
           https://static.crates.io/crates/winapi/winapi-0.3.9.crate \
           https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate \
           https://static.crates.io/crates/winapi-util/winapi-util-0.1.5.crate \
           https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate \
-          https://static.crates.io/crates/windows-sys/windows-sys-0.42.0.crate \
-          https://static.crates.io/crates/windows-sys/windows-sys-0.45.0.crate \
-          https://static.crates.io/crates/windows-targets/windows-targets-0.42.1.crate \
-          https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.42.1.crate \
-          https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.42.1.crate \
-          https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.42.1.crate \
-          https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.42.1.crate \
-          https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.42.1.crate \
-          https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.42.1.crate \
-          https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.42.1.crate \
-          https://static.crates.io/crates/zbus/zbus-3.10.0.crate \
-          https://static.crates.io/crates/zbus_macros/zbus_macros-3.10.0.crate \
-          https://static.crates.io/crates/zbus_names/zbus_names-2.5.0.crate \
-          https://static.crates.io/crates/zerocopy/zerocopy-0.6.1.crate \
-          https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.3.2.crate \
-          https://static.crates.io/crates/zvariant/zvariant-3.11.0.crate \
-          https://static.crates.io/crates/zvariant_derive/zvariant_derive-3.11.0.crate"
-MD5SUM="baecd514a5312ce09063632318d74b09 \
-        b8e7ee27350aad1efd1cbe7a6a32c551 \
-        669215548c64019c08c92b2c1afd3deb \
+          https://static.crates.io/crates/zbus/zbus-1.9.1.crate \
+          https://static.crates.io/crates/zbus/zbus-2.1.1.crate \
+          https://static.crates.io/crates/zbus_macros/zbus_macros-1.9.1.crate \
+          https://static.crates.io/crates/zbus_macros/zbus_macros-2.1.1.crate \
+          https://static.crates.io/crates/zbus_names/zbus_names-2.1.0.crate \
+          https://static.crates.io/crates/zerocopy/zerocopy-0.3.0.crate \
+          https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.2.0.crate \
+          https://static.crates.io/crates/zvariant/zvariant-2.10.0.crate \
+          https://static.crates.io/crates/zvariant/zvariant-3.1.2.crate \
+          https://static.crates.io/crates/zvariant_derive/zvariant_derive-2.10.0.crate \
+          https://static.crates.io/crates/zvariant_derive/zvariant_derive-3.1.2.crate"
+MD5SUM="1ab5f9d3e76d2e99691c6337c2657d7e \
+        9d033cc2daa6924420a4a89e6705773f \
         bd53a9f0ec43690f84e8c96bba8e538d \
-        815dfe34d3e7a3ab4fdd827fde9e3d04 \
         db6f9a586bda62de931be1b2bce9cd34 \
         b14b12cd0e866930de1993132c85705b \
         58a6326364dbe6f5168f3f3a341f360e \
-        96f06331c915195bce97c8542c0eb728 \
+        425b8fdf70df59998d9b7c89083e48d1 \
+        fce951b34a5c1b8edb8c104987637fd3 \
         bd278d96770173a5298bea9ebdba03f7 \
         730ff1a5c2f3becc07743810ad47e66e \
-        bf23cd323c33a8c283c41bb9b79e4ce4 \
-        ee4e2682a0fe87a36210b97aea8b9634 \
-        1b4533e03596b7ae7c7a3e6ab07a73ae \
-        3b66520f824a5a16dbb507acdcf897d3 \
-        8afc9ce101e88b32ebd62dedc5caf0fd \
-        791074db008026b2bae6850084353574 \
-        e0430976e568e5dea0515b49f6e8bb56 \
-        c50a8ba12ca56e1c583be8038950a0eb \
-        f3e1ce5b1080bac150445a888b32a735 \
-        1aea297795331d5e82ad16b0fca71748 \
-        2fe91c987ca3f910aad12f4913e6e631 \
-        5d2d3892ddd169a55043e2aeb96a5359 \
-        b1c7932139530dfc5c984fbba7d40b81 \
+        7814be2d45d822ba919dc9e6b70ac44e \
+        b2733911430dec241671728239f8924e \
+        218d9b779b991e39e2e3fd2f299a9864 \
+        50806ccba0af9b3fdd3e37c6b651059c \
+        44dc698c2ff129b4592c402dd9a4501a \
+        8588bed0c242a7e964ac4cf236dbccd2 \
+        ae1a5d749e1a8af706a5c9104bb0923b \
+        6a5fb43167d44652c51e3ceb9c2b8c23 \
+        c33a5eb809e9f42be5388d47c80f6eeb \
+        8b03718de9cf7106f0b77b87e1bda5fb \
+        f8e2c3f07b084e1aece1741f58ec28d1 \
+        f3bf7f61aeafc26eea205f0e05f1beea \
+        6a2f7b82f00aaf8f9124cbae817980ac \
         142cb4b9a653e56e56311f0c883b8582 \
         05d77ef52e90ad161fdd41b252420467 \
-        58637599fb4e68ecbca68939709aca1a \
-        3d192a852cb456a965c5d64db624c915 \
-        53536a7f4250f679d3aaf112874e08a2 \
+        80a2c27647a6acb1890a3a7de8fded72 \
+        bbc1b4852c4eb23effe97764def8d1ce \
         a295edb6953237ebbdfa8e731229f9a3 \
         ea2d23ceb9f98853a7dffc6c02884464 \
         c7fbaf61245dc847237ab7c72b3ee9ea \
-        7caa371ca22e7a14288920a69c081d40 \
-        9d5be2ea9722444b02b39f3e70012325 \
+        25bcf8d84152a1c93f2767715c250779 \
         3518756a1af12a80e9c872091cdec5d5 \
-        1907c0d2a97e835ad0a442415e3d4bc1 \
-        a931236e210885462e4b4b92ea47e246 \
+        b56e5ae6b74252e4d9b89a06adf510c5 \
+        79173170388e20507a241b355ef521e3 \
         1e704be5ddde9d6b5383ef1035309f91 \
-        596cab766930d487256260ab9ca55b71 \
-        899ea6bce8f704ca9d5e90878179e3a8 \
-        20bceb66cef4cc995d004267009e6a49 \
+        df3ac16302a9dd29508eda92aa402a9b \
+        ca7e295f50617a33e02283d3ef93ff99 \
+        6d0a8ceae87853ef8947455469cefda9 \
+        4b84cfa4a4822e326a5dcd8d1bdfd030 \
         6473ba7813c7756738489dbc0b6203b9 \
-        7d83f411bb22318c65fec8bbee937ece \
+        00cc3eeabff68c61e5aacdb5ea9d16ac \
         267fc4a374516caa7ab495f0c607c1b4 \
-        10b68ba1e7093d889e9198dcd0ea2a3e \
-        ea38f5bb1eaab6580d9ac0d41b230ed1 \
+        dcb58f182347515cab229f836dd8e6d1 \
+        76d8f58004ba41bc3cd6bcfa48cb229b \
+        882dbbc613a93f64c3709b0a2bd0d6dc \
         74634128440dbc3766bda76fdf0aaa05 \
-        4a9390915b209721b7a1b87e2bb5c571 \
+        1581b390d17f6e73a43ffc8a7b009e57 \
         5184822d3fd9f30dfa4bc922ffa4143c \
-        5f2578209a4d7964623462e402375ac0 \
-        7c28deaed5c3327645cffe40430aecf0 \
-        faa32da3be14130a4525bb7ba601c62e \
-        8b15d333a98fc02a34909961900246a4 \
-        f6af8b98a829bb06cffbf425e5694e5e \
+        ad93a9f51606d9d5eba5c8c057a14f14 \
+        457e008da6d6f7863eb8b037d61ec5c2 \
+        f637bf20fac185ee2687bb2a08325e59 \
         d05cbf26ed52299487a802688a1d22cb \
         092c01b71d220e9e742d1ce83040f9ba \
-        2d596b8162dae46a0c1aeb05020ae35d \
+        adb22c60d90fc92bce0e9e0cad12eab8 \
         5c0b974591c88858125a1bb4e64d7bdc \
-        ebdc1f779823eaad615501b1cd3822b1 \
-        9924872c20a6be30ea1120cd899d2c18 \
-        89e88633cab0e4b6f3d3878b84dffe8b \
+        70afc41079e42a402066ce556552a478 \
+        26a9ff1052f12176f2d168f1e41b339e \
+        f77fc9fd7b24926d6cfc9881cc0efab8 \
         ed0342f94ffebe96d5650f55c23b12a1 \
-        39cd2aade20a2eab4779f1a3db530209 \
+        10c9ec124683092e8fc0cb93ce0de640 \
         cf52970ee52905ad114b93571dd9c6c6 \
-        2055aa2a8c9da89dadfd1e9012a26a20 \
-        6c14cc803de55e30a66331bb24e626d1 \
-        d422955b622bd73be3e85d4e8fd2e2ca \
-        8dd01b9b3dadff7246c8afdc079f68ff \
-        bd7e89cd9afc8d87dfa1f59eb403ea44 \
-        aa1b8e906b7459f042f80b6574ee23e1 \
-        f28e4363b28774af3f8127ed40bcdc9f \
-        c1713950e7088b216d011fc5c2bdd661 \
-        6129e036328e2ec678c8d5d9be3c5e59 \
+        603aaa62874e458ebecb55bd8b249edb \
+        8a4686ec3b3d644f70e6780462a755b1 \
+        3391bb3a172bd8aab0c0dc61b31c459c \
+        d39ccc2276d4c0b11ee46aa82d31acb5 \
+        4c5c5dd84fee3aa2dc530702bddc85e8 \
         59978ef7bcea7bc55e24d06a2d32a32c \
         493a2f042d86baa5c6bac75202c64554 \
-        732c54e5b65b869d7301eec81c97f6a1 \
-        889fdcd1499ef5939caaafab5c09729e \
-        4c21da37e71a52f26c8c5490f3ec4837 \
-        28925d0d3649d0577f07bc9ab288999c \
-        7718afd363b2ef45c28cbe9e06b562c5 \
-        1370f13d01572cc80e4a11bfbecd73c6 \
-        c25e1a69f2d40b3f6f8dae4b4459413d \
-        65934957ea79137686ded549467e1329 \
-        d59e1fe9834d52c50e2414a34945e479 \
+        baac29564e83e3957b1976f3a1d92ba6 \
+        a6242be0e2040974cb83dc7c4c67b761 \
+        8c1bba1510c915f915a9eca6fa95f476 \
+        19070d2b1f030565e3d994df2fd9cb6c \
+        3d2977b047e366303274ab03ebef1c2b \
+        9f40837910054385d663c557f735b03a \
+        3fa75bcd254d37247ec3e97bad1dd445 \
+        33ee4fa20d181488961006de02740b50 \
+        782fd3cac41045c0d89d69b90012d8b7 \
+        e08921c68133df2e254fe723b368bae3 \
         52f1c0adc1d0fb68e8608b8c4faa3c71 \
-        a1e1c92075e77d61acf61a094a68fa61 \
         8dab3b3ec00dc56cffde0b0c410d47b5 \
-        357f2bcdc622476ad883fe9d07f874c3 \
-        316fcebbe23696d8e2ec15617d4f5cb3 \
-        33c6a65a07354886102e917783ba4e13 \
-        5329468d3efc2b43dd628f8bdb4397e5 \
-        50217439ab76fc1ee930bf4df3804799 \
-        af48680d31f067c33ef15f9a2a91c713 \
+        7ee8703970c3fa6a2e37893de742824b \
+        bece18dd831ac2ce1e26e92271e6d832 \
+        5d404b52af03b999e7fb74fbe16d3bd0 \
+        8aa040d9c661f68ebb67d5b71813473b \
+        1e0ad6e5cdab371cabd218748fee9b6d \
+        74d9ab54981e8f02e7eb683ac0a8a6b9 \
         3763e6c936b1accbd2e9a7c8118793e0 \
-        d641a02cecdf39645bef945598d49b35 \
-        1736d597947715518fb4928a67e37af3 \
-        53030efc4eb919791407c0b49790ffc3 \
-        49ccc67d2ee6e8506790f4bb551340bc \
-        e567b304bfe4a274f7e974bd4c63ec3c \
-        0d0c5c91c20090babcfe008a5c59a490 \
-        bd1291c8e5cb564d5418e874814c774e \
-        0cec39953242b532648f356dba65d0a0 \
-        e3480971fb7f7462149056fd70df74e2 \
+        750ca4b374c5cd501a612a841f7362a9 \
+        a46bd303e3155f7975b167af12435e5e \
+        1ab2952ce15d2f9cfe279821274133eb \
+        8071e8e030bee77619611dbb4e508864 \
+        32c8f5f8523fd26925e2a6495604bb93 \
+        53c91805e78e1ab2a34282be3aecbe94 \
+        324bb5f02dba12add6dc16c10bfbce6c \
+        e62727696767b6ef195e3b50e42817c1 \
+        4824dbe307f1d20e74a4ebad2b7e4d6e \
         c3ec5977ecc0f6244ef3be87f5325e72 \
-        7e3435db94bbfde52efb6e639cfff542 \
+        d3f5e27649cc6184d1bca2d065d2a092 \
         bb072f15d5e4067bea6933a4fbeb9c0a \
-        9486190bcfe1c4af6a50d265a113ac12 \
-        eff6e29698ea257ad7fb7dd1e388e2e4 \
-        8290950f13be0f28845795158c343ce7 \
-        069aa7ed2552b2623af2a8e282baffb0 \
-        73f6c15be7000350ba8970c9c6545269 \
-        93bf413572d8ae35ce16f82b533e1b8a \
-        0c938328d6424744c46943938ed6a4ee \
-        2d6d28ec311884da69bcaf320ada8ad5 \
-        606e9b910c315b6197ba83fad7dd13a0 \
-        276a77a39cba360dfb2f45df2d71be9a \
-        509f1c8b700b622dd92656b3877f3f89 \
-        e4abcad3267eb3d01687e21d46992235 \
-        acf918834a1556abdbcda627816f3ff3 \
-        dc1e00a2654c3b921658d01e1c617539 \
-        ce8b343f8221ffb572b3a5b2b0702249 \
-        b9f1f29a4012cc3c7bce83511f40c5b5 \
-        f4e9294066cbc6503b6e0ef703a6b565 \
-        1b41b97d982520b7364a87a39e2a1ed8 \
-        d7c035eba93308f73ce4f04ae2c9a674 \
+        92f23eb502ec2add616257ca9ea8823e \
+        27e0b5429881ec07a10c75803f572312 \
+        7bfceacb0504ab8f7cc961f0c81bb844 \
+        60134448c463c3e2645353f8de19f669 \
+        fe5d62a5aa97e780833348f5d9a6ec9b \
+        3d41dae1c09c54f19d224f58e98e5a89 \
+        e7c07242a95ee1df865efe9534e10a34 \
+        8d0a78969cbc0ceb1787bcd02430cefd \
+        6d39e92a8d9bac6e8613eae79b4ac637 \
+        97a0c8bef92ca2df111b6067deea1630 \
+        8dbc13bf4848e7a0f39572be8c9c319c \
+        5af6733a9e5107b2df46a32fa1e1ef7b \
+        dd838e84196263901190504f44053a5f \
+        474ea5fc0ec36be109eba41e9ff92595 \
+        799f84552a7a943a492fb3f27f1d6b1e \
+        8488e9acd924b1baf4f97cbb3ca418f6 \
+        62b3edf8c2db7fccb1a6a41134b84e62 \
+        d84097823667ed4c3f938da04a13992c \
         0372a8de508e57da4d4869f058bcb630 \
-        b92fa50f56a1e06a7f1bf665442d4a73 \
+        4fd75413081a400a1c230f0700732611 \
         0b7994d1256215201bdfb810a357ffa2 \
-        4bb3ee6be8ce77402250dd0d0f26e131 \
         1d3e530a3410fc95a6987d70f84a6332 \
-        761cd5ae202c54efba117f5d68c57756 \
+        ff7c38e023578064f54c98f7b0f7d2c2 \
+        b57599fc2bb8cfd76567e656070d0d72 \
         656eb112c9634812796a81803b04a3e6 \
-        4e0c068ba38fa8e0aa6c46bce5e9d2ab \
         d15066ccf2d33bbd8afdb9036ba47da5 \
-        5a454a33646271c81e6b2f70e8ca1b83 \
-        c21c16e3bdc619cf65a31b23136d62ce \
-        92968aee56cb2f162a55008fedddbb78 \
+        df09b038f991ff902161d83159d4871a \
+        e685b43c1f198999c125bc7bbe084ab3 \
+        e40d2efcee31e346fbc82277683422ea \
         4918da28fbc2f6888ad71c159996a9b5 \
         c01022fe0357c10ca1d48b16187f81bd \
-        2dd38d9f88feab3e6067874e535dc758 \
+        8e87a3c1697ca04a19ebde7187f15156 \
         31667fab2083c342c85bb51c2cba6d58 \
-        b6c59717dc5601672c3e73fa2258e64c \
-        1e49f16311d2a62e44c05750c0ec0dc7 \
         fe77a3f609b6fd8d5b08f3b2ef14d2ad \
-        c3425a02781d0bb3c4f8d5d025d12266 \
-        237b55fa488d3be0c5c6c0aba4dfa913 \
-        7e70355483fc2559770b4db2ff32bcde \
+        f50aaf5171cbc0327f8d18a4ec7405fb \
+        c3fe94727289a0f8f47b149810022900 \
+        df401fb6d6fe40c02ecea514716ee96a \
+        bd04a204662b00e7d773d0a753bd0928 \
         5f153f7135dceb02f88266121c836b4e \
-        bab7df9c671c07b763e33245de65336b \
-        f2ffcbe94a83f2437ffe47d7dbf4ad04 \
+        057d52b1e2b951597cc4a82876e7646b \
+        06e7dbde9932c6a9bac63d9288670678 \
+        5c98b89b530b563b6e5f6e1b631c4b35 \
         b30ef1414dde99d96e89aeea2b3fc094 \
         73272fe4aadb91d550dca8fc7ead8bf7 \
-        75e2156746dcd795a4fcfeee4ce4953f \
-        0779350c00b03603f72eef7f737686ad \
+        3aefa31e8413112958290a6ca004b096 \
+        60bcdfbbaca59d4c147f4fa11c592c68 \
         e155c3d45440413eec6db44f68a21b69 \
         fba3b040a55c01be7376d3dd5c4d4920 \
         23cc9e52c52465f5b225e62ab7cc3457 \
         d3d110551104b00b42c9920958939391 \
-        1286030c54134a42189f312a2671fa87 \
-        0f36c4a4835a1163b5c070ea94ababff \
-        2f4991ee29e75b732dbfbbe637506066 \
-        02e14c7718a87f6c90ba05b62fd5c706 \
-        5cef28504e265f32f3caec4684a5ead2 \
-        738cf4fc881596b1977847f0d393bfd2 \
+        03f9ff96b48b1a661e6804fe63d7d6a2 \
+        c34dcfcdcf62d89900e94a6a7b1ed0d7 \
+        7077d380579b979cd864756ac90e3f9c \
+        a087f8a5947ecf4e734ac9cfe695469c \
+        0764d84de2302fda8d1d72b95f31a0b8 \
+        cc9ba5bc2cc1f60765c57f5d6cc10042 \
         a63fa50b0954c349c74980347253f06e \
-        918e7eb38af0848dc112f929e73718a0 \
-        27688de4059dd10d56d79dc3db1e8786 \
-        06a6fac6e221a2496763bd255609c35e \
-        13ce2239c2c3873c6ea715c5d70a6021 \
-        7b9e2b22daa94d69a7e8515ae7ad3a1d \
-        d5619cd692cdf95bddb994fa4351e4a5 \
-        1587213d8240da87a9593fa110654c7d \
-        2ba6cd31b6ef69fdcbec450eb07fb2ed \
-        66f2e78effb16e788e09b6b2c353c26e \
-        1a9824f887b3ef3150c93c087bbb10fb \
-        067ca67cf5dc5d2eb25c03e491ceb395 \
-        bd13e165196e3470237b852d347cbb9b \
-        591b0243c421bf8e6df09e3209fce861 \
-        06356b72118cb4ea0f63177479b7575a \
+        a2db9e4d802b919606c596d7d95ef251 \
+        d07af7d3cab8ed749a8310a89be6b1ff \
+        4ba60e706b5e69a88192ff773b27a229 \
+        58d0064087bc800cf6ee10d667651491 \
+        84a3537d01f17e0e19f28000bb445c6b \
+        2721e88844fd0335095f7e99df1ebbb9 \
+        0bedbc5d1b29e4d6a7fbae0e6d1e146a \
+        e85f829193ea1afa080dcff7f77cf945 \
+        c6acde76d0fbb62b7eda3857d8a73436 \
+        9e3ea187f6e3f01e3c9590782c744b3e \
+        c000dfa6a77a58ede02be41418056bf3 \
+        9e0bf233b47424b8449a928bd31a1470 \
+        9160664d20c024783323f5b90ca74d2d \
         6fa7c4b0da26b511570845e41527bc8f \
-        426eb9e22cbb36480e13fd265be87b4c \
-        b31bf94ffe7e0f2ada93afae1076eaeb \
+        825ecc659b700477535aa5c7dea95a82 \
+        40e508baeee8cdccbc471489b0f449ff \
         7b3195612bc6090f0fa759e747a9e91c \
         7c81e7a61ec172a229d6fdbc553e883d \
         ccc5ff9ff4a431e36c0b6dd9f640ab58 \
-        94b8bf179385ff071bdc33b58bf047c0 \
+        5ac809692422b722eaded90be3c4d9c2 \
+        d75b1c734f85b007c55ca84217df4201 \
         76124c2327f642cddf19a4aa50cbcb7d \
         a362e890dd0dfe51ecd95a4a1be6e28c \
-        8b708bc4b33c5e1683467444c9ed41b0 \
-        bb21a8ff26ec16bc15758b1625bc0f46 \
-        a8a1c536701e539cdce215fd7f55de9f \
+        b0a7859b81eeead5a15800d489e07347 \
+        4604959975c2154a14f6b5e97444e2c8 \
         5a4f0e9922683867565531089e3c417f \
+        4917ff4eaed099a21ff16b96f0df49cb \
         1a6e77e2f6f916ef7a5a9481ed426b76 \
-        7e395ce2e673b7d9665751cbbe3cbcdc \
-        5f5168cd7b4aad8ae68f4d1e32a1e0e2 \
+        e01c75ca9113d2af67ae903fa39e14be \
         97b832ecaac0eee2b644fd42f2931160 \
         b235f97b3139681d61419166e7c00e3c \
-        e3bd46e4620b19864b2dd3542bb14c1c \
-        b97a98b82065343e45f160671f6ffe8e \
-        f17aecb8887cf0ecd823623160aed7db \
-        8e44066df6dc8663faaab84eddabf721 \
-        1081c01b2d9b17a33c3d0156193be592 \
+        c45800f4dfb888a928c772b081065214 \
+        2e504fc2b79dc46f983c960e30be1702 \
+        675fcfdbc94cd10b26b71965d3c3807b \
+        bd9b057de16e5b299bcda0894cfd823e \
+        420f93a43fa603c1253213bdf28983df \
+        ebe381c6ee4281c78701e79a2cf90bc8 \
+        0ce3cb22636a6b7992a2cd5b106f54ea \
         9c414752deabb69c93aa3911422a960c \
-        c71701508a4b5fa358c3efc4f0469fa2 \
+        4b8c01a755ea55d3344d9ccb07c093ca \
         56c34619687723fa3fc23213471e8545 \
-        073b4c53e303ccf2a807dfce7f5e986a \
-        44ef8a2279dadf391881a69c60d29197 \
-        00ebf3254ed74711c1f6717de3012350 \
-        a0de6eabdeb1320350abcbd7c02df6ac \
-        09adf9a15c5576d25da061a0e576d056 \
-        bee49068dd525d22d350dcd0d7543183 \
-        f1917a7199fd7217e71efa6bbcb715cb \
+        a8ec1126ef06244ac1e3773981a005f1 \
+        4b9ee6818517941de3ad6d645b77af3a \
+        d631c116041b5f68abc8680fa82feedf \
+        c0e036fd990d0c9cae11b5876a5cb572 \
+        c5e50e299295e662ad19c58428d6e085 \
+        a8bd18783d4b87808a6dad6814f297b6 \
+        2493cc854d9a4fb0a1ed78595a5b667a \
         b4dcac855af5df71f3383d86c4a96b78 \
         aecd889de42c8168e1bc97a6f2720d8f \
         fd9aa273ad560dedd00ddcf3dbe808ce \
-        e1a629a86bfa03f5c17180a8b213c74c \
-        980c225025b646fa54a9450d22688ad0 \
+        0b06dd6bef5cc7724c3daf6c900d38d0 \
         af692853d165edb9c5df23627b2f8e04 \
         e460418ee4f5508bc53c97e809331882 \
-        dc9b023a3d3833fa5a853d950b54d944 \
+        9e544fc057bf6032dd55b02f87b8dbf4 \
         653e04baa68a4484b3b839c19221e474 \
         907244c0d3791f3f981c7cc8e4cad0a3 \
-        99094dc9de392d7b233df089aaec5589 \
-        481cc7357cb8bfd6a728e7b47dee84b1 \
-        18d9fbe67f19564599ed55389e357232 \
-        6475ac2c917c96d375eb56f1761eea0a \
+        50bcf9c0d46f49e8fdbbe9ffa1a73c56 \
+        7e12f02e9742f49de13bbeacfe2906b8 \
+        f1adbc335ff6dd6692959688dedd9484 \
+        af00c723f5d3b3e4e6e388e98d6bf7f1 \
         205459def23510e8815562e73a65c898 \
         12e4ba5909e1f30b9142932571eaa4da \
-        1be45f99109d447849f4244b58c5a470 \
-        b1713fb3ae03d434680cff5fb4c14144 \
-        1dd7189bccf7a3cfb69fd1dc213f660e \
+        233dee08f26c9cbe78f29b66c0c20ccd \
         cf2f0435bd5b5111fea46e8d9dc6522d \
         7e264bc8f23a45ad680668cb5e57d9fd \
-        c7ce684666ac9c76223b1a0a5034ce99 \
-        655de4844e5024d64d6c45296ec1ba42 \
-        445f5eb8b47aa8f2ff66b5f5bca00096 \
-        ee800c5e7efc827cefe64af7d380cea5 \
-        c775911c38f984e3cacad6c3d0691618 \
-        ce6dde2ea2691fdd97632fb8c9b3e042 \
+        f490982aceabdbd515348f63e638a782 \
+        37cf6acd1c3259eefeba636e4cc9b365 \
+        228eb40a277a6dda01626b6e9287ee66 \
+        8ff78776b6140283bd558ad74554cb16 \
+        5e9fce0f8489727426f9b155cd08d8e3 \
         07c75fec267864bcbb800ca7709ceae2 \
-        57a5575d623bcbc7ba5c033c9f87744f \
-        2c7870ed53f4e906876bd7901a10164f \
-        5c69337d37e58a380e00eac9ce0373bb \
-        61d3f525a24a154550d2d307121f89dd \
-        517af3607e2042ad806635bec4b1780e \
+        42b88767a9db3d9fe6e59b5dff52abf5 \
+        1d827ececfe381f71248b88ec399f359 \
+        ae91c97885d67994a342820cf7d59fb2 \
+        d6291d0e18f55b8364b36a7f5e1af699 \
+        5ecf56203dda9419751b532d99c3601d \
+        0baac9bed3d6065b6128aa8a888e5eb9 \
         6a32bab57772c3a1146d599b65ffb0cb \
         7d76a523677de261dda1b65d29a93c4e \
-        cd9614d4d4afcfe5e26c118a42120d40 \
-        5770ccff26d6481010ab6c6006cda25a \
-        c2a8746886f9f7bcc8fb9dd539183e44 \
-        4785f3ef9f313f11aae87120112c45b6 \
-        41defdffa40e7cbcc7e17a933c5660ab \
+        5af0856196b1bb934f25a66b082c4131 \
+        256e8677308aa17acc8c82b54d8a4fae \
+        1810d970f84683a419d7b9aa6740f8a6 \
+        aca51d2a40262bfd8e69fbf6b2b01ed2 \
+        418d3ebc9610905ab514667dad302f56 \
         ee7a5f842c39bc47c474196e83b0df5f \
         e30085994bbeb4b7f4895d48216d5476 \
-        a1626b8f4d165b1b60d960862eba4cf0 \
+        ae5dab3db7dc317e16bb6f9e7eb15d14 \
         a661e92ffd6cb9f0893126e3cde3fffc \
-        16111f31a29feae4ce4a324b83dc0189 \
-        2793ed3e6807d79ff72271baec586531 \
+        4a80ab58144fc731cd12abc6d5139d7f \
         d1e5569ab3528bea44f2a7ebb1ec0a35 \
-        267efbd05da2900424b1fa6e841d1280 \
-        39cfd27d1728af99cbae763b4f81acd3 \
+        6b5c7401117316735435311bf551515b \
+        82401c70623ccc1bfc0bcb5c3b0ac8b7 \
         0538d1da369f3e3f0412aa4d735c1b61 \
-        ee620998fafcd5665f24897e37c0d57e \
-        961872666d1de352fd4936d0b18581dd \
-        6eb014e73f66bc13226e0ef6d815d375 \
+        4ac453abdecd6346f92989b4f789ac84 \
+        1e585d25db7b5bb009b060befc74e9fe \
         7b1261ea730a9314bc9bcdf4a379bf98 \
         93aeba00993f0ed8c474864e455cf584 \
         fdf3aa5e1f6c33e4f68b0f7b08e1e94e \
-        4ca29f2ce41fb9f282c527c1d8ae5cc4 \
+        7fe15f165a1812b23e5b1980aa364de2 \
         2d8d8b377d144f5e32b4f65a69eb0b24 \
-        0bf4ac47fef874d61250f4d4afe4866b \
+        f505a218806e44b2369671089d65e839 \
+        fc60e4ecd18db5e582b9e7dd19dd62e4 \
         b4a0a98a54439a5a37952c8879187ee3 \
-        a661bb863762e9f20761215a7650e6d5 \
-        4b09ca5c71f379ebcfa3c06222a082b2 \
+        f916271c81cfe339d66df629e3828392 \
         d2cc4e584ed64165fc56d2c9081eb3ee \
-        3828d2d048ce354388c0de6ba5649754 \
+        461fc1209ec16fb35a70adebd0f3c09f \
         42408be0352a76b14f1e77a6b8858a77 \
-        2d82330c9f218f42ccc9e44c2d18ff8f \
-        3338953ce1388e5ff5fef5aac76ab1f5 \
-        de68d2e964ba3b051ca2107aa12ebe4f \
-        7ade79d246bedd718a9eac604282dab2 \
+        c8ae0dd2469d51f273abdbfb24adceac \
+        7c532e05dc3b2bd295136a297260c4dc \
+        c8f9eb4d5f0173b70647e559b03e85fb \
+        e3932c56e06c7d1e780242ca5feba32f \
         82078b82ed1c52aac9552a39ead691a0 \
-        602d4f1e2fe53f870b70e83c8cee49db \
-        e3e93a5606f450c13fcad764fa1c4bed \
+        ff221db0109795b44f92352780cd1901 \
+        74d8afce717ff89fb2cb5141f121782b \
+        9420cc533b8572ae0d04750421127f80 \
         31bc883e6f9b36925f55460401197274 \
         ce622fdb8d18cd1c13ed8fadc5400c10 \
-        0bfb08b9dd5df72ba5ed7d74dd5fe6eb \
-        22e95901b912671da26457ac33e36a23 \
-        9b7ebf6b588afaad70bf48a742973a30 \
+        e4e7efe2ab7921499d5c247a349e9e1f \
+        21b43d5721b3a9c16059acb691f4314d \
+        2fcf5fe983975bbcea43129c9fb31923 \
         06ed54fefb2e737e18d586bfa7ad44fe \
-        a8014a7c865aa54f305e8cda3ef02019 \
-        362eebacce3b2c9204fdef6d1c04d757 \
+        6249245cf12427da0a4f37bc3d294ff4 \
+        f8839491f88f7a15ac8a5bdd787de442 \
         c9defe80406280bcfce4ecf31c0200b3 \
         43661dc16a38eb42bd49a11b9f00d6f4 \
         82d98dc87dc8503400aa095f5aa70f13 \
         8e053c23f1d36fbf3f276fbf501e3e35 \
-        8efa8e23cddda0540efe4ba8ff60840b \
-        f05de931658b166a05c5520720fdba07 \
+        67def8e3d7d4b26b803a2d0799ef31b9 \
+        8f6b6cc71be0473b79c65abfea592c07 \
+        10e133f0f33f0f41bc7fdad56e85a35b \
         73ff8cffc66d065488dcf50e3b8c0c1f \
         f29a1bb1b5f3f29cedb36f40f720d765 \
-        36c7197f00034ff87f3b849dd6b98b6e \
-        3d2277774414ad0f59584e7021b9be06 \
-        44e45d4d9b0904fd06d6f46107eda592 \
-        66345b13fd97229fefe61ba6457dfe66 \
-        dc9491aba5e393b587f4bbffab58ed52 \
-        5f0470696baaa4e5953bddbf196998f9 \
-        c678a7da0ee4b850ebde0474144a0415 \
-        3516a8d8c8e682ac47b252c447fcea75 \
-        d6f24a12196b2e717d4fd869f3410e7f \
-        e2d8018fa3841938e750da57b706852c \
-        b5670d9b6d6560440845d23ca563d44d \
-        b21820f2664242498beba7783b32bef4 \
-        7a55379fb7eaef176e373798441e7836 \
-        bc4ac3f5c142859e5dfeb45a31866eeb \
-        60d7c3a9f75ac64cffbb9ccda7c1c8e5 \
-        97e8197912c3d06f0b7486d07c31e182 \
-        45c1d005c5df9e62640b4bbb1f79090a \
-        e3189db1511d7f2fe59fd1b15ebac8ff \
+        ebdff467249aa3dca005a441dc824236 \
+        cc180843b3b626ede01ebd9a0d9fbdaa \
+        3e61457993a6e3fdaaf2fbe82bd7dff3 \
+        9d66208e00715217a8c1f2e40efe4a0c \
+        90a6772f747261b181e3801bf51d9379 \
+        7bfcad253aff26bc26c5e3521f3ba891 \
+        4625feab41aceeb81e268cf272a8cb43 \
+        64c940cf10c49b34761e1a4dbf2b023f \
+        97aab350fb2614818580f00d1fb284ad \
+        3b23aa9eb619cbfd68d96719db904597 \
+        db6fe956ec67f88412df3a627158a7ba \
+        519bfbdd19531f1d7b775bfa7ce4ee80 \
+        6a50f7029b3a8cc76f5f50ef9ee0b4aa \
+        610bf72284e8f22d831d2f4ab3b87809 \
+        b7bf9803f61dcdcfc0bc07dfe5c6c249 \
         f601f89fde92362c93611ef2358e1bc1 \
-        a25ff12cdf468d4a5b4bf75b7fc6d743 \
-        63ce54e1fcbbdb45c15146fd082528bb \
-        11ad59bd731103e90d688afc5f35271b \
-        39ad78aa5442d71ddece93677f24d408 \
-        19f44a64888c1c2ff5ac943b066141f1 \
-        e522898b2cb1fd23af2695324b3a5c78 \
-        c12d182417999fc365f952e701f6071f \
-        7d6d4fc9fad200d6e295f6930e97e022 \
-        41a9cb1cc86d75f991241c9c3f725556 \
-        4518a0588a916a89400a31c2064a60ce \
-        6e71c4d256f4d02355b5b722e7d481be \
+        e876964c7b83db85fb7897bee7ad0f45 \
+        7b38b145ae3f6d7d09a1a7a98396f1a2 \
+        6cae4969689ecc3b4b4c31a9fb9539a6 \
+        dfbd8371187d9453f7461825972272bb \
+        10291d9a0022076bc0827250816d3476 \
+        a42cc2834b2150027d7b427558a87803 \
+        087bfc476e9d73628cebd265590f11f7 \
+        eb721c4d9e5dba8f93e9de0a80036ec3 \
+        43f743c17293ad2404a9a4967f4e570b \
+        c9bde3bd6ba907b5319657c3b65e1191 \
         e900a384ac7dbb320fe6a7279fbfef89 \
         c4769705079e88d68739e6089e8769a3 \
-        d4e6a3f2d7286408592d08defd7de156 \
+        f15c7457b6f2e06ee2037472d2f9a0fd \
         d18d362345c4fe512ef67b738b239fb8 \
+        689203efc084fc0f1d1f74f5d354ae75 \
         274f9bcda1e4afd4a290329eff9267ad \
         580dd7d12690c726da7d5075f3442a74 \
         e334c03160b1e0989c2a71ca55f631fc \
-        a312b55a428f827a91097d1d8497b02b \
-        e972ea58ec203bfa6c79c1207852298b \
-        5ad255225437a92850eaea3cd7aa0051 \
-        a277676f11a4b8df65f0bd10cf91c34d \
-        6dedf2077979fbca816469b7685d9e28 \
-        8c58a7b08dcaaf1e6bc55616ce88582e \
-        edd96c9a12dc3e04aa4d9a345ee6dd0f \
-        eff90729cd4a439c36ff89f3ee0904d0 \
-        d04b3c91526662b97397fc1e04e007b1 \
+        a061ad1db3e0d839725b037ff8be84e7 \
+        89f443c919328fcc7b985e262823f0ab \
+        a4dca633705dd04abd9a35e0b794d3d4 \
+        e5e5a1190e8e84eda279934d60ec4d48 \
+        5909d8a50e0749f6aa8cfea853f161f0 \
+        37869fac434114d80ef4af359f0a6a12 \
+        4b9f324ed896f7e327f561e2341ac9ea \
+        812034252008acfa704cbc65c505bdf2 \
         20cfa8aba7521c8767344b06c39479f7 \
         0498c4a11448bfc35dc7bb2caa64c753 \
         db96b50050277bf05a3c68534bbb9586 \
         b9e37d5fc4ad28b612b78ad37816684d \
         09de9d01e7331ff3da11f58be8bef0df \
-        110789f2dd21a2ea820ebed976b4b1c2 \
-        b58284cb8ce52b8de07e09f4f8fb9653 \
-        25cf36fbb4f7adb02f3d9fa24ccaef4f \
-        5ac131337793334dce7adbf1116671b3 \
-        8f5702706600f24bf7332043c15aa566 \
-        dd86cb477e0b0b1411a5c92cba244b42 \
-        0f6b457ea783c088dff026ce39ce72ca \
-        23d20707b55228cb9b4328a26ddca724 \
-        62e05b432403f316d86f7af8af0839e3 \
-        8893d419a205b225e4010d7d02a15c6a \
-        1da18746ec7044fab3be0166f21975fa \
-        98c6613744636d05e6cdd64d6a74bba8 \
-        1cb886a35a22cdc6b930f58e748ca172 \
-        2af5c75a55a2e46662c060100d5c3222 \
-        b063b98a03b5b198c528b842e1530a95 \
-        19e6057d49c1b26f0cf24cd98d88553f \
-        5d6f4bdeea0e991c8b894331501a6c04"
+        57b0fdc06f3330e9cafafe88af48c0cf \
+        1736946acda05e1e94b814f3e3c0145a \
+        803148006d757487c3767bcdfffd8eb1 \
+        0fa82df5a92ae7acde1f67130935c17b \
+        53fc83d016a4a5c3d69a099eb3d10e1d \
+        7a5233ce3372d0ac3adc2c85f616e3ad \
+        338a919a7f8b6a7b1eb23272a2b7a237 \
+        0137ff709b7fe58cc99d835bb01a84bf \
+        71835a55bbab1c98313163f2fe78138e \
+        9196c9f6e81d7775d63a9444b4fdfd3d \
+        9a3b018157fc6d55b895dd429e54bcc2"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="libadwaita"


### PR DESCRIPTION
This reverts commit 0435e76f20b1c38e02ce7aa6298fecee3d004b8f.

Somehow this passed review, and it builds in -current, but in reality it requires glib2-2.72, so no choice but to revert