### PR TITLE
graphics/veles: Require updated rust for 32bit build.

### DIFF
--- a/graphics/veles/README
+++ b/graphics/veles/README
@@ -10,3 +10,5 @@ binary data - all at a glance.
 Warning: This SlackBuild requires network access when it runs, meaning
 it downloads files from the Internet with root access. YMMV on whether
 this is a good idea.
+
+NOTE: Upstream project is now archived

--- a/graphics/veles/veles.SlackBuild
+++ b/graphics/veles/veles.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=veles
 VERSION=${VERSION:-2018.05.0.TIF}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -78,6 +78,13 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+export PATH="/opt/rust16/bin:$PATH"
+if [ -z "$LD_LIBRARY_PATH" ]; then
+  export LD_LIBRARY_PATH="/opt/rust16/lib$LIBDIRSUFFIX"
+else
+  export LD_LIBRARY_PATH="/opt/rust16/lib$LIBDIRSUFFIX:$LD_LIBRARY_PATH"
+fi
 
 mkdir -p build
 cd build

--- a/graphics/veles/veles.info
+++ b/graphics/veles/veles.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/codilime/veles/archive/2018.05.0.TIF/veles-2018.05.
 MD5SUM="f10259c5d85700f45e36b629090efed7"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="msgpack-c"
+REQUIRES="msgpack-c rust16"
 MAINTAINER="Fernando Lopez Jr."
 EMAIL="fernando.lopezjr@gmail.com"


### PR DESCRIPTION
This build requires network access and currently when building on
32bit it pulls a version of python cryptography that requires a
newer rust than the one included in 15.0.