### PR TITLE
system/openzfs: Remove unnecessary configure arguments.

### DIFF
--- a/system/openzfs/openzfs.SlackBuild
+++ b/system/openzfs/openzfs.SlackBuild
@@ -33,7 +33,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=openzfs
 SRCNAM=zfs
 VERSION=${VERSION:-2.2.3}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -110,8 +110,6 @@ CFLAGS="$SLKCFLAGS" \
   --includedir=/usr/include \
   --mandir=/usr/man \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
-  --with-linux="/lib/modules/${KERNEL}/source" \
-  --with-linux-obj="/lib/modules/${KERNEL}/source" \
   --with-udevdir=/lib/udev \
   --enable-static=no \
   $DRACUTLIBDIR \


### PR DESCRIPTION
Removed configure arguments that pointed to the "/lib/modules/${KERNEL}/source" symlink. These are not necessary to compile openzfs on -15.0, and cause the compile to fail on -current. As far as I can tell, the kernel-modules package from 15.0 creates this symlink, but the current version does not.