### PR TITLE
multimedia/kodi uses local spdlog, fmt, and rapidjson & version bump multimedia/inputstream-adaptive to 21.4.6

### DIFF
--- a/multimedia/inputstream.adaptive/inputstream.adaptive.SlackBuild
+++ b/multimedia/inputstream.adaptive/inputstream.adaptive.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=inputstream.adaptive
 CODNAM=Omega
-VERSION=${VERSION:-21.4.4}
+VERSION=${VERSION:-21.4.6}
 BENTO4VER=${BENTO4VER:-1.6.0-641}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}

--- a/multimedia/inputstream.adaptive/inputstream.adaptive.info
+++ b/multimedia/inputstream.adaptive/inputstream.adaptive.info
@@ -1,9 +1,9 @@
 PRGNAM="inputstream.adaptive"
-VERSION="21.4.4"
+VERSION="21.4.6"
 HOMEPAGE="https://github.com/xbmc/inputstream.adaptive/"
-DOWNLOAD="https://github.com/xbmc/inputstream.adaptive/archive/21.4.4-Omega/inputstream.adaptive-21.4.4-Omega.tar.gz \
+DOWNLOAD="https://github.com/xbmc/inputstream.adaptive/archive/21.4.6-Omega/inputstream.adaptive-21.4.6-Omega.tar.gz \
           https://github.com/xbmc/Bento4/archive/refs/tags/1.6.0-641-Omega/Bento4-1.6.0-641-Omega.tar.gz"
-MD5SUM="ac05307397df43eb6cc77c8379275056 \
+MD5SUM="e30913a661b9e98f56c21c734d20812c \
         77b1246f0d738ee4f2006c27eb48d3c8"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""

--- a/multimedia/kodi/kodi.SlackBuild
+++ b/multimedia/kodi/kodi.SlackBuild
@@ -35,12 +35,9 @@ PKGTYPE=${PKGTYPE:-tgz}
 
 # Versions used below
 crossguidVER=${crossguiVER:-ca1bf4b810e2d188d04cb6286f957008ee1b7681}
-fmtVER=${fmtVER:-9.1.0}
 libdvdcssVER=${libdvdcssVER:-1.4.3-Next-Nexus-Alpha2-2}
 libdvdnavVER=${libdvdnavVER:-6.1.1-Next-Nexus-Alpha2-2}
 libdvdreadVER=${libdvdreadVER:-6.1.3-Next-Nexus-Alpha2-2}
-rapidjsonVER=${rapidjsonVER:-1.1.0}
-spdlogVER=${spdlogVER:-1.10.0}
 groovyVER=${groovyVER:-4.0.16}
 comLangVER=${comLangVER:-3.14.0}
 comTextVER=${comTextVER:-1.11.0}
@@ -133,10 +130,9 @@ cp -a $CWD/apache-groovy-binary-$groovyVER.zip \
 # Reasons for internal programs
 # (so I can remember in the future why we're using them)
 
-# Internal crossguid & rapidjson is recommended by upstream
+# Internal crossguid is recommended by upstream
+# Internal libdvd{css,nav,read} are required by kodi due to patches
 # Internal ffmpeg since 15.0's is too old
-# Internal fmt & spdlog to prevent issues if spdlog was built without
-# optional fmt dependency
 
   cmake \
     -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
@@ -146,9 +142,6 @@ cp -a $CWD/apache-groovy-binary-$groovyVER.zip \
     -DAPP_RENDER_SYSTEM=gl \
     -DCORE_PLATFORM_NAME="$PLATFORM" \
     -DENABLE_INTERNAL_CROSSGUID=ON \
-    -DENABLE_INTERNAL_RapidJSON=ON \
-    -DENABLE_INTERNAL_FMT=ON \
-    -DENABLE_INTERNAL_SPDLOG=ON \
     -DENABLE_INTERNAL_FFMPEG=$FFMPEG \
     -DENABLE_AIRTUNES=$AIRPLAY \
     -DENABLE_AVAHI=$AVAHI \
@@ -160,12 +153,9 @@ cp -a $CWD/apache-groovy-binary-$groovyVER.zip \
     -DENABLE_NFS=$NFS \
     -DENABLE_UDFREAD=$UDFREAD \
     -DCROSSGUID_URL=$CWD/crossguid-$crossguidVER.tar.gz \
-    -DFMT_URL=$CWD/fmt-$fmtVER.tar.gz \
     -Dlibdvdcss_URL=$CWD/libdvdcss-$libdvdcssVER.tar.gz \
     -Dlibdvdnav_URL=$CWD/libdvdnav-$libdvdnavVER.tar.gz \
     -Dlibdvdread_URL=$CWD/libdvdread-$libdvdreadVER.tar.gz \
-    -DRAPIDJSON_URL=$CWD/rapidjson-$rapidjsonVER.tar.gz \
-    -DSPDLOG_URL=$CWD/spdlog-$spdlogVER.tar.gz \
     $FFMPEGURL \
     -DCMAKE_BUILD_TYPE=Release ../$SRCNAM-$VERSION-$CODNAM
   make

--- a/multimedia/kodi/kodi.info
+++ b/multimedia/kodi/kodi.info
@@ -6,9 +6,6 @@ DOWNLOAD="https://github.com/xbmc/xbmc/archive/21.0-Omega/xbmc-21.0-Omega.tar.gz
           https://github.com/xbmc/libdvdcss/archive/refs/tags/1.4.3-Next-Nexus-Alpha2-2/libdvdcss-1.4.3-Next-Nexus-Alpha2-2.tar.gz \
           https://github.com/xbmc/libdvdnav/archive/refs/tags/6.1.1-Next-Nexus-Alpha2-2/libdvdnav-6.1.1-Next-Nexus-Alpha2-2.tar.gz \
           https://github.com/xbmc/libdvdread/archive/refs/tags/6.1.3-Next-Nexus-Alpha2-2/libdvdread-6.1.3-Next-Nexus-Alpha2-2.tar.gz \
-          https://github.com/fmtlib/fmt/archive/refs/tags/9.1.0/fmt-9.1.0.tar.gz \
-          https://github.com/gabime/spdlog/archive/refs/tags/v1.10.0/spdlog-1.10.0.tar.gz \
-          https://github.com/miloyip/rapidjson/archive/v1.1.0/rapidjson-1.1.0.tar.gz \
           http://mirrors.kodi.tv/build-deps/sources/apache-groovy-binary-4.0.16.zip \
           http://mirrors.kodi.tv/build-deps/sources/commons-lang3-3.14.0-bin.tar.gz \
           http://mirrors.kodi.tv/build-deps/sources/commons-text-1.11.0-bin.tar.gz \
@@ -18,15 +15,12 @@ MD5SUM="74501a89f0ea23d2908a9b983ab3d6f8 \
         42dc3770ae928103e8033a18b007e79d \
         2349cde54d950af21fa4936371ad3349 \
         0d24c950abfef9dc02e231dda56912ac \
-        21fac48cae8f3b4a5783ae06b443973a \
-        effea813cd81cfb5588806c5754e14f1 \
-        badd12c511e081fec6c89c43a7027bce \
         bd9eb761a11372dd659da8c2cf1ae692 \
         88c83b3fa007ae35d4f82a2466cad423 \
         ae1f7607159b192e12f9c8eaaaf3d927 \
         ab9c27629c2a43689c63ff55fd7cbf67"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="zulu-openjdk11 libass flatbuffers tinyxml gtest fstrcmp spdlog tinyxml2 libdisplay-info"
+REQUIRES="zulu-openjdk11 libass flatbuffers tinyxml gtest fstrcmp spdlog tinyxml2 libdisplay-info rapidjson"
 MAINTAINER="Jeremy Hansen"
 EMAIL="jebrhansen+SBo@gmail.com"


### PR DESCRIPTION
multimedia/inputstream-adaptive requires the inclusion of external rapidjson dependency to kodi, and kodi also switches to external spdlog and fmt since spdlog now requires fmt.