### PR TITLE
development/rust16: Updated for version 1.78.0.

### DIFF
--- a/development/rust16/rust16.SlackBuild
+++ b/development/rust16/rust16.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust16
 SRCNAM=rust
-VERSION=${VERSION:-1.77.2}
+VERSION=${VERSION:-1.78.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -103,7 +103,8 @@ rust-demangler-preview,\
 rustfmt-preview
 
 find $PKG/opt/$PRGNAM/lib -type f -name "*.so" -exec chmod +x {} \; 2> /dev/null || true
-# As of 1.77.2, stripping the libraries causes memory faults on Slackware64-15.0.
+find $PKG/opt/$PRGNAM/lib -type f -name "*.so*stable" -exec chmod +x {} \; 2> /dev/null || true
+# As of 1.78.0, stripping the libraries causes memory faults on Slackware64-15.0.
 if [ $ARCH = "x86_64" ]; then
   find $PKG -print0 | xargs -0 file | grep "executable" | grep ELF \
     | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true

--- a/development/rust16/rust16.info
+++ b/development/rust16/rust16.info
@@ -1,12 +1,12 @@
 PRGNAM="rust16"
-VERSION="1.77.2"
+VERSION="1.78.0"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2024-04-09/rust-1.77.2-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2024-04-09/rust-1.77.2-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="279c9bda8f7406629c5c7e1bb66cf365 \
-        454dd1e89f14825dd6279d4f5a1a24a2"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2024-04-09/rust-1.77.2-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="5df06513e998f33b00ed5d8920dc0cfc"
+DOWNLOAD="https://static.rust-lang.org/dist/2024-05-02/rust-1.78.0-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2024-05-02/rust-1.78.0-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="b5563989498e9db2b910de1e70f940cc \
+        c4e256bec2b46f609afea9f7ccd48fd0"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2024-05-02/rust-1.78.0-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="73118081f69aff0622ce96c9202ef4e0"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"


### PR DESCRIPTION
Reverse dependencies were tested in VM for ARM, x86_64 and i686.

Shared objects in the x86_64 package still need to be left unstripped, so there will be one sbopkglint failure.