### PR TITLE
libraries/libdisplay-info: Remove proper source folder on rebuild

### DIFF
--- a/libraries/libdisplay-info/libdisplay-info.SlackBuild
+++ b/libraries/libdisplay-info/libdisplay-info.SlackBuild
@@ -66,7 +66,7 @@ set -e
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
-rm -rf $PRGNAM
+rm -rf $PRGNAM-$VERSION
 tar xvf $CWD/$PRGNAM-$VERSION.tar.gz || tar xvf $CWD/$VERSION.tar.gz
 cd $PRGNAM-$VERSION
 chown -R root:root .


### PR DESCRIPTION
Received permission from Damian Perticone via email to push this correction.