### PR TITLE
ci: Show reverse deps as a tasklist.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,9 +74,7 @@ pr-checks:
         if [[ "$response" == "" ]] ; then
           printf 'None\n'
         else
-          printf '```\n'
-          printf '%s' "$response"
-          printf '```\n'
+          printf '%s\n' "$response" | sort | sed 's/^/- [ ] /'
         fi
       } > comment-output
 


### PR DESCRIPTION
This syncs the output for gitlab MRs to also be a tasklist like we
do for github PRs.