### PR TITLE
system/trash-cli: Add shell completions

### DIFF
--- a/system/trash-cli/README
+++ b/system/trash-cli/README
@@ -9,3 +9,6 @@ trash-empty   : empty the trashcan(s).
 trash-list    : list trashed files.
 trash-restore : restore a trashed file.
 trash-rm      : remove individual files from trash can.
+
+python3-shtab is additionally required for installing trash-cli with
+shell completion support.

--- a/system/trash-cli/trash-cli.SlackBuild
+++ b/system/trash-cli/trash-cli.SlackBuild
@@ -70,6 +70,17 @@ sed 's|share/man/|man/|' -i setup.cfg
 
 python3 setup.py install --root=$PKG
 
+# Add trash-cli shell completions (requires python3-shtab)
+# Reference: https://github.com/zsh-users/zsh-completions/pull/895
+if $(python3 -c 'import pkgutil; exit(not pkgutil.find_loader("shtab"))'); then
+  mkdir -p $PKG/usr/share/bash-completion/completions
+  mkdir -p $PKG/usr/share/zsh/site-functions
+  for CMD in trash-empty trash-list trash-restore trash-put trash; do
+    $CMD --print-completion bash > "$PKG/usr/share/bash-completion/completions/$CMD"
+    $CMD --print-completion zsh >  "$PKG/usr/share/zsh/site-functions/_$CMD"
+  done
+fi
+
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 


### PR DESCRIPTION
See the comments within https://github.com/SlackBuildsOrg/slackbuilds/pull/4306 for more details (that was when I orphaned python3-shtab).

It would be better if I could trigger a re-installation of trash-cli immediately after getting python3-shtab installed.

To get around the issue of shell completion support having to be added at compile-time (that is, running the SlackBuild with python3-shtab installed beforehand), rather than immediately after installing python3-shtab on a system with trash-cli, I worded the README the best I could.