### PR TITLE
development/rust16: Updated for version 1.79.0.

### DIFF
--- a/development/rust16/rust16.SlackBuild
+++ b/development/rust16/rust16.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust16
 SRCNAM=rust
-VERSION=${VERSION:-1.78.0}
+VERSION=${VERSION:-1.79.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -97,6 +97,7 @@ rust-docs,\
 clippy-preview,\
 rls-preview,\
 llvm-tools-preview,\
+llvm-bitcode-linker-preview,\
 rust-analysis-$TRIPLET,\
 rust-analyzer-preview,\
 rust-demangler-preview,\
@@ -104,7 +105,7 @@ rustfmt-preview
 
 find $PKG/opt/$PRGNAM/lib -type f -name "*.so" -exec chmod +x {} \; 2> /dev/null || true
 find $PKG/opt/$PRGNAM/lib -type f -name "*.so*stable" -exec chmod +x {} \; 2> /dev/null || true
-# As of 1.78.0, stripping the libraries causes memory faults on Slackware64-15.0.
+# Stripping the libraries causes memory faults on Slackware64-15.0.
 if [ $ARCH = "x86_64" ]; then
   find $PKG -print0 | xargs -0 file | grep "executable" | grep ELF \
     | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true

--- a/development/rust16/rust16.info
+++ b/development/rust16/rust16.info
@@ -1,12 +1,12 @@
 PRGNAM="rust16"
-VERSION="1.78.0"
+VERSION="1.79.0"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2024-05-02/rust-1.78.0-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2024-05-02/rust-1.78.0-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="b5563989498e9db2b910de1e70f940cc \
-        c4e256bec2b46f609afea9f7ccd48fd0"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2024-05-02/rust-1.78.0-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="73118081f69aff0622ce96c9202ef4e0"
+DOWNLOAD="https://static.rust-lang.org/dist/2024-06-13/rust-1.79.0-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2024-06-13/rust-1.79.0-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="14d04dfa5b8db0e4c60b3ca510413154 \
+        b935f3d193c8618d9bfe3ab97ad99d4e"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2024-06-13/rust-1.79.0-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="6f2d7072b8bcd817f9effa0c504e31e9"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"


### PR DESCRIPTION
Reverse dependencies (except for multilib `yabridge`) have been build-tested on x86_64, i686 and ARM.

Shared objects still need to go unstripped on x86_64, so there will be a handful of `sbopkglint` test failures for that architecture only.