### PR TITLE
network/rtl8188fu: Build for $KERNEL.

### DIFF
--- a/network/rtl8188fu/doinst.sh
+++ b/network/rtl8188fu/doinst.sh
@@ -1,3 +1,3 @@
 if [ -x sbin/depmod ]; then
-  chroot . /sbin/depmod -a 1> /dev/null 2> /dev/null
+  chroot . /sbin/depmod -a @KERNEL@ 1> /dev/null 2> /dev/null
 fi

--- a/network/rtl8188fu/rtl8188fu.SlackBuild
+++ b/network/rtl8188fu/rtl8188fu.SlackBuild
@@ -10,11 +10,12 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=rtl8188fu
 VERSION=${VERSION:-1.0+20231018_68ced40}
 COMMIT=68ced40d862d13663294496bac2e9a91ffa0e5c7
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
 KERNEL=${KERNEL:-$(uname -r)}
+KERNELPATH=${KERNELPATH:-/lib/modules/$KERNEL/build}
 PKGVER=${VERSION}_$(echo $KERNEL | tr - _)
 
 if [ -z "$ARCH" ]; then
@@ -46,7 +47,7 @@ chown -R root:root .
 find -L .  -perm /111 -a \! -perm 755 -a -exec chmod 755 {} \+ -o \
      \! -perm /111 -a \! -perm 644 -a -exec chmod 644 {} \+
 
-make
+env -u ARCH make KVER=$KERNEL KDIR=$KERNELPATH
 
 install -D -m0644 rtl8188fu.ko \
         $PKG/lib/modules/$KERNEL/kernel/drivers/net/wireless/rtl8188fu.ko
@@ -74,7 +75,7 @@ cat $CWD/$PRGNAM.SlackBuild > $PKGDOC/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc
-cat $CWD/doinst.sh > $PKG/install/doinst.sh
+sed "s%@KERNEL@%$KERNEL%" $CWD/doinst.sh > $PKG/install/doinst.sh
 
 cd $PKG
 /sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$PKGVER-$ARCH-$BUILD$TAG.$PKGTYPE


### PR DESCRIPTION
The slackbuild was setting checking $KERNEL, but was not passing it through to make. I've adjusted this and you can now build the kernel module after installing a new kernel, even if it is not the running kernel.