### PR TITLE
network/pound: Fix permissions on /etc files.

### DIFF
--- a/network/pound/pound.SlackBuild
+++ b/network/pound/pound.SlackBuild
@@ -102,6 +102,9 @@ find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | gr
 find $PKG/usr/man -type f -exec gzip -9 {} \;
 for i in $( find $PKG/usr/man -type l ) ; do ln -s $( readlink $i ).gz $i.gz ; rm $i ; done
 
+rm -f $PKG/usr/info/dir
+gzip -9 $PKG/usr/info/*.info*
+
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \
   AUTHORS COPYING ChangeLog NEWS README THANKS \
@@ -109,8 +112,8 @@ cp -a \
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/etc $PKG/etc/rc.d
-cp $CWD/pound.cfg $PKG/etc/pound.cfg.new
-cp $CWD/rc.pound $PKG/etc/rc.d/rc.pound.new
+install -D -m 0644 -o root -g root $CWD/pound.cfg $PKG/etc/pound.cfg.new
+install -D -m 0644 -o root -g root $CWD/rc.pound $PKG/etc/rc.d/rc.pound.new
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc


### PR DESCRIPTION
Files from `$CWD` should not be installed with `cp`, but rather `install` so that have correct ownership and permissions.