### PR TITLE
python/python3-mistune: Update README, +remove SLKCFLAGS and LIBDIRSUFFIX

### DIFF
--- a/python/python3-mistune/README
+++ b/python/python3-mistune/README
@@ -5,7 +5,4 @@ It has the following features:
  *  Very Fast. It is the fastest in all pure Python markdown parsers.
  *  More Features. Table, footnotes, autolink, fenced code etc.
 
-This is the python3 only package (the current v2 series of mistune).
-
-For the legacy v1 series of mistune, please install the python2-mistune
-SlackBuild instead.
+This SlackBuild only installs the python3 build of mistune.

--- a/python/python3-mistune/python3-mistune.SlackBuild
+++ b/python/python3-mistune/python3-mistune.SlackBuild
@@ -49,20 +49,6 @@ TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
-if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
-else
-  SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
-fi
-
 set -e
 
 rm -rf $PKG


### PR DESCRIPTION
I am not updating python3-mistune to the latest current version (3.0.2). I don't know how such an update will affect jupyter-notebook, jupyterlab and spyder.

This is what I will do instead:
1. Update README. About a year ago, Yth has already removed python2-mistune from SlackBuilds.org. I would like to change the README accordingly.
2. Remove SLKCFLAGS and LIBDIRSUFFIX (these 2 variables are never used within the SlackBuild).