### PR TITLE
system/pcp: Use a single build job on 32bit.

### DIFF
--- a/system/pcp/pcp.SlackBuild
+++ b/system/pcp/pcp.SlackBuild
@@ -99,8 +99,16 @@ CXXFLAGS="$SLKCFLAGS" \
   --with-qt \
   --build=$ARCH-slackware-linux
 
-make
-make DIST_ROOT="$PKG" NO_CHOWN=true install_pcp
+if [ "$ARCH" = "i586" ] || [ "$ARCH" = "i686" ] ; then
+  # seems building with multiple jobs can cause flaky builds on 32bit
+  # https://github.com/SlackBuildsOrg/slackbuilds/issues/6944
+  make -j1
+  make -j1 DIST_ROOT="$PKG" NO_CHOWN=true install_pcp
+else
+  make
+  make DIST_ROOT="$PKG" NO_CHOWN=true install_pcp
+fi
+
 
 mkdir -p "$PKG"/usr/doc/$PRGNAM-$VERSION
 mv "$PKG"/usr/share/doc/* "$PKG"/usr/doc/$PRGNAM-$VERSION/


### PR DESCRIPTION
This causes random errors on 32bit. We have not seen the issue on
64bit so we will not force a single job there since this package
takes a while to build.

Related to #6944