### PR TITLE
libraries/allegro: updated REQUIRES

### DIFF
--- a/libraries/allegro/README
+++ b/libraries/allegro/README
@@ -14,3 +14,7 @@ of its key features include:
     * Open Source - anyone can contribute, including you!
     * Free - it won't cost you a dime, and there are no restrictions on
       its usage
+
+physfs is optional, but allegro needs to be built against it to use it,
+and some programs using allegro, like opensurge, requires physfs built
+into it.

--- a/libraries/allegro/allegro.SlackBuild
+++ b/libraries/allegro/allegro.SlackBuild
@@ -28,7 +28,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=allegro
 SRCNAM=allegro5
 VERSION=${VERSION:-5.2.9.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 

--- a/libraries/allegro/allegro.info
+++ b/libraries/allegro/allegro.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/liballeg/allegro5/archive/5.2.9.1/allegro5-5.2.9.1.
 MD5SUM="94b189f2b138891b5f068e9a0915b5eb"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES=""
+REQUIRES="physfs"
 MAINTAINER="Yth - Arnaud"
 EMAIL="yth@ythogtha.org"


### PR DESCRIPTION
It seems easier, here, to set physfs as REQUIRES instead of optional.
If physfs is present, allegro is automatically built against it, and one of the only three slackbuilds using allegro, namely opensurge, will require allegro to be built against physfs.

It feels like this is better to set physfs as a REQUIRES than to expect people to read the README of opensurge and then rebuild allegro from scratch after having installed physfs.