### PR TITLE
Typosfix

### DIFF
--- a/academic/xiphos/xiphos.SlackBuild
+++ b/academic/xiphos/xiphos.SlackBuild
@@ -85,7 +85,7 @@ find -L . \
 
 #patch to make work with newer glib
 echo "#define GLIB_VERSION_MIN_REQUIRED (GLIB_VERSION_2_26)" >>cmake/config.h.cmake.in
-if $(pkg-config --exists webkit2gtk.1); then  #patch for webkit2gtk4.1
+if $(pkg-config --exists webkit2gtk-4.1); then  #patch for webkit2gtk4.1
   sed -i 's/webkit2gtk-4.0/webkit2gtk-4.1/g' cmake/XiphosDependencies.cmake
   sed -i 's/libsoup-2.4/libsoup-3.0/g' cmake/XiphosDependencies.cmake
 fi

--- a/office/gnucash/gnucash.SlackBuild
+++ b/office/gnucash/gnucash.SlackBuild
@@ -119,7 +119,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-if $(pkg-config --exists webkit2gtk4.1); then
+if $(pkg-config --exists webkit2gtk-4.1); then
   #use webkit2gtk4.1 instead of webkit2gtk if present.
   sed -i 's/webkit2gtk-4.0/webkit2gtk-4.1/g' CMakeLists.txt
   sed -i 's/WebKit2Gtk4/WebKit2Gtk4.1/g' CMakeLists.txt


### PR DESCRIPTION
fix a couple of typos that stopped webkit2gtk4.1 detection working in xiphos and gnucash. (appologies for the original typos.)