### PR TITLE
Fix Flameshot installation slackbuild script

### DIFF
--- a/graphics/flameshot/flameshot.SlackBuild
+++ b/graphics/flameshot/flameshot.SlackBuild
@@ -93,7 +93,7 @@ find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | gr
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp LICENSE README.md docs/ $PKG/usr/doc/$PRGNAM-$VERSION
+cp -r LICENSE README.md docs/ $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install


### PR DESCRIPTION
When slackbuild script tries to install flameshot files, it will fail because 'cp' tries to copy folder 'docs' and for that it needs '-r' (recursive) option.