### PR TITLE
github-desktop: Downgraded to version 3.4.1.

### DIFF
--- a/development/github-desktop/github-desktop.SlackBuild
+++ b/development/github-desktop/github-desktop.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=github-desktop
 SRCNAM=GitHubDesktop
-VERSION=${VERSION:-3.4.2}
+VERSION=${VERSION:-3.4.1}
 BUILD=${BUILD:-1}
 DEBBUILD=${DEBBUILD:-1}
 TAG=${TAG:-_SBo}

--- a/development/github-desktop/github-desktop.info
+++ b/development/github-desktop/github-desktop.info
@@ -1,12 +1,12 @@
 PRGNAM="github-desktop"
-VERSION="3.4.2"
+VERSION="3.4.1"
 HOMEPAGE="https://github.com/shiftkey/desktop/"
 DOWNLOAD="UNSUPPORTED"
 MD5SUM=""
-DOWNLOAD_x86_64="https://github.com/shiftkey/desktop/releases/download/release-3.4.2-linux1/GitHubDesktop-linux-amd64-3.4.2-linux1.deb \
-                 https://github.com/shiftkey/desktop/releases/download/release-3.4.2-linux1/GitHubDesktop-linux-arm64-3.4.2-linux1.deb"
-MD5SUM_x86_64="fb9c3ac5d457f5a3b1de1d98d0c96bb3 \
-               49f8432dcce2e7ef88bb6db9abf5409d"
+DOWNLOAD_x86_64="https://github.com/shiftkey/desktop/releases/download/release-3.4.1-linux1/GitHubDesktop-linux-amd64-3.4.1-linux1.deb \
+                 https://github.com/shiftkey/desktop/releases/download/release-3.4.1-linux1/GitHubDesktop-linux-arm64-3.4.1-linux1.deb"
+MD5SUM_x86_64="c1cfb6bc488deef917f5955f6df6f53d \
+               3036080b877ffeb16fdbdca2cda42290"
 REQUIRES=""
 MAINTAINER="Jay Lanagan"
 EMAIL="j@lngn.net"


### PR DESCRIPTION
The prior uploaded 3.4.2 has an issue doing 'git push' commands where a included helper program requires glibc 2.34 and doesn't run. Only the 'pull' operation works. This previous version doesn't include this new feature, it will be upgraded again if it's fixed.