### PR TITLE
network/radicale: Simplify extracting tarball

### DIFF
--- a/network/radicale/radicale.SlackBuild
+++ b/network/radicale/radicale.SlackBuild
@@ -25,6 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=radicale
+SRCNAM=Radicale
 VERSION=${VERSION:-3.1.8}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
@@ -89,9 +90,9 @@ fi
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
-rm -rf $PRGNAM-$VERSION
-tar xvf $CWD/$PRGNAM-$VERSION.tar.gz || tar xvf $CWD/Radicale-$VERSION.tar.gz || tar xvf v$VERSION.tar.gz
-cd Radicale-$VERSION
+rm -rf $SRCNAM-$VERSION
+tar xvf $CWD/$SRCNAM-$VERSION.tar.gz
+cd $SRCNAM-$VERSION
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \

--- a/network/radicale/radicale.info
+++ b/network/radicale/radicale.info
@@ -1,7 +1,7 @@
 PRGNAM="radicale"
 VERSION="3.1.8"
 HOMEPAGE="https://radicale.org/"
-DOWNLOAD="https://github.com/Kozea/Radicale/archive/refs/tags/v3.1.8/radicale-3.1.8.tar.gz"
+DOWNLOAD="https://github.com/Kozea/Radicale/archive/refs/tags/v3.1.8/Radicale-3.1.8.tar.gz"
 MD5SUM="4c886b54c6926c5c463bbb80cf555998"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""


### PR DESCRIPTION
Downloaded tarball will always be named correctly even if it's
downloaded using wget or curl without using extra options.

Signed-off-by: Arkadiusz Drabczyk <arkadiusz@drabczyk.org>
