### PR TITLE
system/virtualbox: fix error when starting

### DIFF
--- a/system/virtualbox/vboxdrv.sh-setup.diff
+++ b/system/virtualbox/vboxdrv.sh-setup.diff
@@ -1,5 +1,5 @@
---- vboxdrv.sh.orig	2024-02-28 15:40:56.680861821 +0100
-+++ vboxdrv.sh	2024-02-28 15:47:52.417842405 +0100
+--- vboxdrv.sh.orig	2024-07-31 22:02:05.602388417 +0200
++++ vboxdrv.sh	2024-07-31 22:02:22.486387635 +0200
 @@ -45,39 +45,13 @@
    MODPROBE="$MODPROBE --allow-unsupported-modules"
  fi
@@ -40,7 +40,7 @@
  if test -u "${VIRTUALBOX}"; then
      GROUP=root
      DEVICE_MODE=0600
-@@ -173,333 +147,12 @@
+@@ -173,354 +147,21 @@
      lsmod | grep -q "$1[^_-]"
  }
  
@@ -374,7 +374,18 @@
  start()
  {
      begin_msg "Starting VirtualBox services" console
-@@ -518,9 +171,6 @@
+     if [ -d /proc/xen ]; then
+         failure "Running VirtualBox in a Xen environment is not supported"
+     fi
+-    if test "$(kernel_requires_module_signature)" = "1" && test -z "$DEB_KEY_ENROLLED"; then
+-        if test -n "$HAVE_DEB_KEY"; then
+-            begin_msg "You must re-start your system to finish Debian secure boot set-up." console
+-        else
+-            begin_msg "You must sign these kernel modules before using VirtualBox:
+-  $MODULE_LIST
+-See the documentation for your Linux distribution." console
+-        fi
+-    fi
  
      if ! running vboxdrv; then
  
@@ -384,7 +395,7 @@
          if ! rm -f $DEVICE; then
              failure "Cannot remove $DEVICE"
          fi
-@@ -572,8 +222,6 @@
+@@ -572,8 +213,6 @@
          mkdir -p -m 0750 /dev/vboxusb 2>/dev/null
          chown root:vboxusers /dev/vboxusb 2>/dev/null
      fi
@@ -393,7 +404,7 @@
      succ_msg "VirtualBox services started"
  }
  
-@@ -654,153 +302,10 @@
+@@ -654,153 +293,10 @@
      fi
  }
  
@@ -548,7 +559,7 @@
  }
  
  dmnstatus()
-@@ -850,20 +355,7 @@
+@@ -850,20 +346,7 @@
      stop && start
      ;;
  setup)
@@ -570,7 +581,7 @@
      ;;
  force-reload)
      stop
-@@ -873,7 +365,7 @@
+@@ -873,7 +356,7 @@
      dmnstatus
      ;;
  *)


### PR DESCRIPTION
As reported at https://lists.slackbuilds.org/pipermail/slackbuilds-users/2024-July/029553.html.

I found that modules are loaded and `VBoxManage list vms` doesn't
return non-zero even when the error is printed so maybe at the end of
the day it didn't prevent VirtualBox from working correctly but it
should be removed nonetheless.
