### PR TITLE
development/rstudio-desktop-legacy: Update HOMEPAGE

### DIFF
--- a/development/rstudio-desktop-legacy/rstudio-desktop-legacy.SlackBuild
+++ b/development/rstudio-desktop-legacy/rstudio-desktop-legacy.SlackBuild
@@ -40,9 +40,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0

--- a/development/rstudio-desktop-legacy/rstudio-desktop-legacy.info
+++ b/development/rstudio-desktop-legacy/rstudio-desktop-legacy.info
@@ -1,6 +1,6 @@
 PRGNAM="rstudio-desktop-legacy"
 VERSION="1.1.463"
-HOMEPAGE="http://rstudio.com"
+HOMEPAGE="https://posit.co"
 DOWNLOAD="https://download1.rstudio.org/rstudio-1.1.463-i386.deb"
 MD5SUM="8a6755fa9fae2bafce289df3358aaf63"
 DOWNLOAD_x86_64="https://download1.rstudio.org/rstudio-1.1.463-amd64.deb"

--- a/development/rstudio-desktop-legacy/slack-desc
+++ b/development/rstudio-desktop-legacy/slack-desc
@@ -14,6 +14,6 @@ rstudio-desktop-legacy: This is the Linux desktop version.
 rstudio-desktop-legacy:
 rstudio-desktop-legacy: This package is the last supported version for 32-bit systems.
 rstudio-desktop-legacy:
-rstudio-desktop-legacy: See http://www.rstudio.com
+rstudio-desktop-legacy: https://posit.co
 rstudio-desktop-legacy:
 rstudio-desktop-legacy:


### PR DESCRIPTION
RStudio's homepage is now posit.co.

Also, remove PRINT_PACKAGE_NAME commenting.