### PR TITLE
ci: Update CI dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=docker
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.0-15.0@sha256:a857eeb783622430a77ffdc0e9be0fa7d38b4d30696f362454eb990614a5ade8
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.1-15.0@sha256:7a961b60a487ecd3e6171f4e7e7ee7c8f659fdc6a37aac26ae2dcd5a3cb8414f
 
 jobs:
   changes:
@@ -24,7 +24,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           show-progress: false
           fetch-depth: 2
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get slackbuild directories which have changes.
         id: changed-dirs
-        uses: tj-actions/changed-files@90a06d6ba9543371ab4df8eeca0be07ca6054959 # v42.0.2
+        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c # v44.5.7
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           dir_names: true
@@ -41,7 +41,13 @@ jobs:
           dir_names_max_depth: 2
           json: true
           quotepath: false
-          files_ignore: .github/**
+          files_ignore: |
+            .github/**
+            .gitignore
+            .gitlab-ci.yml
+            .mailmap
+            ChangeLog.txt
+            README
 
       - name: List all changed files
         run: echo '${{ steps.changed-dirs.outputs.all_changed_files }}'
@@ -66,7 +72,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           show-progress: false
           ref: ${{ github.head_ref }}
@@ -100,11 +106,21 @@ jobs:
         shell:
           bash
 
+      - name: Find Comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "sbolint - ${{ matrix.dir }}"
+
       - name: Comment with sbolint results
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body-path: comment-output
+          edit-mode: replace
 
   dependencies:
     name: Compute reverse dependencies
@@ -117,7 +133,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           show-progress: false
           ref: ${{ github.head_ref }}
@@ -128,7 +144,7 @@ jobs:
 
       - name: Look up dependencies
         id: get_deps
-        uses: fjogeleit/http-request-action@8af28031091191b8e41afb287e0e56fce753c7b4 # v1.15.4
+        uses: fjogeleit/http-request-action@44816be1eabb9c1122d8d775923f39bbe55c67a3 # v1.16.1
         with:
           url: 'https://slackbuilds.org/revdeps.php?q=${{ env.PACKAGE_NAME }}'
           method: 'GET'
@@ -147,8 +163,18 @@ jobs:
         shell:
           bash
 
-      - name: Comment with dependeny results
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      - name: Find Comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        id: fc
         with:
           issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "reverse dependencies - ${{ matrix.dir }}"
+
+      - name: Comment with dependency results
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.number }}
           body-path: comment-output
+          edit-mode: replace

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,18 @@
 variables:
   FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: "true"
   # renovate: datasource=gitlab-releases depName=gitlab-org/cli
-  GLAB_VERSION: 1.36.0
+  GLAB_VERSION: 1.45.0
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=docker
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.0-15.0@sha256:a857eeb783622430a77ffdc0e9be0fa7d38b4d30696f362454eb990614a5ade8
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.1-15.0@sha256:7a961b60a487ecd3e6171f4e7e7ee7c8f659fdc6a37aac26ae2dcd5a3cb8414f
 
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
 
 default:
-  image: docker:25.0.2@sha256:c5353bc15e6746f7dec07a61346e9bbd2a19291d1e4306d15b745cb343dd84b5
+  image: docker:27.1.1@sha256:a690693976550aba640859bb3c3c29eb323a4f53f684c99b2a8282b14a22308b
   services:
-    - docker:25.0.2-dind@sha256:c5353bc15e6746f7dec07a61346e9bbd2a19291d1e4306d15b745cb343dd84b5
+    - docker:27.1.1-dind@sha256:a690693976550aba640859bb3c3c29eb323a4f53f684c99b2a8282b14a22308b
 
 pr-checks:
   script: |


### PR DESCRIPTION
Updates:

- all github actions
- sbo-maintainer-tools
- gitlab cli
- gitlab ci build images
- update sbolint comments in place
- update reverse dependency comments in place