### PR TITLE
development/spyder: Add python3-spyder-kernels version restriction

### DIFF
--- a/development/spyder/spyder.SlackBuild
+++ b/development/spyder/spyder.SlackBuild
@@ -87,18 +87,19 @@ for FILE in $(find . -type f \( ! -iname "*\.*o" ! -iname "*\.png" \) \
 done
 
 # Allow SlackBuilds python libraries versions
+# Note that while python3-spyder-kernels 3.0.0 can still be built and installed, it causes Spyder to crash
 sed 's|IPYTHON_REQVER = ">=7.31.1;<8.0.0"|IPYTHON_REQVER = ">=7.31.1"|' -i spyder/dependencies.py
 sed "s|JEDI_REQVER = '>=0.17.2;<0.19.0'|JEDI_REQVER = '>=0.17.2'|" -i spyder/dependencies.py
 sed "s|PYLINT_REQVER = '>=2.5.0;<3.0'|PYLINT_REQVER = '>=2.5.0'|" -i spyder/dependencies.py
 sed "s|QDARKSTYLE_REQVER = '>=3.0.2;<3.1.0'|QDARKSTYLE_REQVER = '>=3.0.2'|" -i spyder/dependencies.py
 sed "s|QTCONSOLE_REQVER = '>=5.4.0;<5.5.0'|QTCONSOLE_REQVER = '>=5.4.0'|" -i spyder/dependencies.py
-sed "s|SPYDER_KERNELS_REQVER = '>=2.4.0;<2.5.0'|SPYDER_KERNELS_REQVER = '>=2.4.0'|" -i spyder/dependencies.py
+sed "s|SPYDER_KERNELS_REQVER = '>=2.4.0;<2.5.0'|SPYDER_KERNELS_REQVER = '>=2.4.0,<=2.5.2'|" -i spyder/dependencies.py
 sed "s|ipython>=7.31.1,<8.0.0|ipython>=7.31.1|" -i setup.py
 sed "s|jedi>=0.17.2,<0.19.0|jedi>=0.17.2|" -i setup.py
 sed "s|pylint>=2.5.0,<3.0|pylint>=2.5.0|" -i setup.py
 sed "s|qdarkstyle>=3.0.2,<3.1.0|qdarkstyle>=3.0.2|" -i setup.py
 sed "s|qtconsole>=5.4.0,<5.5.0|qtconsole>=5.5.0|" -i setup.py
-sed "s|spyder-kernels>=2.4.0,<2.5.0|spyder-kernels>=2.4.0|" -i setup.py
+sed "s|spyder-kernels>=2.4.0,<2.5.0|spyder-kernels>=2.4.0,<=2.5.2|" -i setup.py
 
 python3 setup.py install --root=$PKG
 


### PR DESCRIPTION
I was able to update python3-spyder-kernels to 3.0.0.

However, in doing so, I received the following error upon running Spyder:
```
Traceback (most recent call last):
  File "/usr/bin/spyder", line 33, in <module>
    sys.exit(load_entry_point('spyder==5.4.0', 'gui_scripts', 'spyder')())
  File "/usr/lib64/python3.9/site-packages/spyder/app/start.py", line 252, in main
    mainwindow.main(options, args)
  File "/usr/lib64/python3.9/site-packages/spyder/app/mainwindow.py", line 1956, in main
    mainwindow = create_window(MainWindow, app, splash, options, args)
  File "/usr/lib64/python3.9/site-packages/spyder/app/utils.py", line 300, in create_window
    main.post_visible_setup()
  File "/usr/lib64/python3.9/site-packages/spyder/app/mainwindow.py", line 1049, in post_visible_setup
    plugin.on_mainwindow_visible()
  File "/usr/lib64/python3.9/site-packages/spyder/plugins/ipythonconsole/plugin.py", line 396, in on_mainwindow_visible
    self.create_new_client(give_focus=False)
  File "/usr/lib64/python3.9/site-packages/spyder/plugins/ipythonconsole/plugin.py", line 533, in create_new_client
    self.get_widget().create_new_client(
  File "/usr/lib64/python3.9/site-packages/spyder/plugins/ipythonconsole/widgets/main_widget.py", line 1484, in create_new_client
    self.register_client(client, give_focus=give_focus)
  File "/usr/lib64/python3.9/site-packages/spyder/plugins/ipythonconsole/widgets/main_widget.py", line 1810, in register_client
    client.configure_shellwidget(give_focus=give_focus)
  File "/usr/lib64/python3.9/site-packages/spyder/plugins/ipythonconsole/widgets/client.py", line 473, in configure_shellwidget
    self.shellwidget.call_kernel()._send_comm_config()
  File "/usr/lib64/python3.9/site-packages/spyder_kernels/comms/commbase.py", line 611, in __call__
    return self._comms_wrapper._get_call_return_value(
TypeError: _get_call_return_value() missing 1 required positional argument: 'comm_id'
```

I currently do not understand why this error is happening.
Therefore, for now, I will keep python3-spyder-kernels at 2.5.2.