### PR TITLE
audio/tauonmb: Compatiblity for non-current.

### DIFF
--- a/audio/tauonmb/config/python39.diff
+++ b/audio/tauonmb/config/python39.diff
@@ -1,0 +1,134 @@
+diff --git a/t_modules/t_main.py b/t_modules/t_main.py
+index 0d0626e..2348b31 100644
+--- a/t_modules/t_main.py
++++ b/t_modules/t_main.py
+@@ -25220,75 +25220,65 @@ class SearchOverlay:
+                         go = True
+                         clear = True
+ 
+-                if extend:
+-                    match n:
+-                        case 0:
+-                            default_playlist.extend(self.click_artist(item[1], get_list=True))
+-                        case 1:
+-                            for k, pl in enumerate(pctl.multi_playlist):
+-                                if item[2] in pl[2]:
+-                                    default_playlist.extend(
+-                                        get_album_from_first_track(pl[2].index(item[2]), item[2], k))
+-                                    break
+-                        case 2:
+-                            default_playlist.append(item[2])
+-                        case 3:
+-                            default_playlist.extend(self.click_genre(item[1], get_list=True))
+-                        case 5:
+-                            default_playlist.extend(self.click_meta(item[1], get_list=True))
+-                        case 6:
+-                            default_playlist.extend(self.click_composer(item[1], get_list=True))
+-                        case 7:
+-                            default_playlist.extend(self.click_year(item[1], get_list=True))
+-                        case 8:
+-                            default_playlist.extend(pctl.multi_playlist[pl][2])
+-                        case 12:
+-                            spot_ctl.append_track(item[2])
+-                            reload_albums()
++                extend_actions = {
++                    0: lambda: default_playlist.extend(self.click_artist(item[1], get_list=True)),
++                    1: lambda: [
++                        default_playlist.extend(get_album_from_first_track(pl[2].index(item[2]), item[2], k))
++                        for k, pl in enumerate(pctl.multi_playlist)
++                        if item[2] in pl[2]
++                    ][0],
++                    2: lambda: default_playlist.append(item[2]),
++                    3: lambda: default_playlist.extend(self.click_genre(item[1], get_list=True)),
++                    5: lambda: default_playlist.extend(self.click_meta(item[1], get_list=True)),
++                    6: lambda: default_playlist.extend(self.click_composer(item[1], get_list=True)),
++                    7: lambda: default_playlist.extend(self.click_year(item[1], get_list=True)),
++                    8: lambda: default_playlist.extend(pctl.multi_playlist[pl][2]),
++                    12: lambda: [spot_ctl.append_track(item[2]), reload_albums()],
++                }
+ 
++                show_actions = {
++                    0: lambda: pctl.show_current(index=item[2], playing=False),
++                    1: lambda: pctl.show_current(index=item[2], playing=False),
++                    2: lambda: pctl.show_current(index=item[2], playing=False),
++                    3: lambda: pctl.show_current(index=item[2], playing=False),
++                    5: lambda: pctl.show_current(index=item[2], playing=False),
++                    6: lambda: pctl.show_current(index=item[2], playing=False),
++                    7: lambda: pctl.show_current(index=item[2], playing=False),
++                    10: lambda: pctl.show_current(index=item[2], playing=False),
++                    8: lambda: switch_playlist(id_to_pl(item[3])),
++                }
++
++                go_actions = {
++                    0: lambda: self.click_artist(item[1]),
++                    10: lambda: [
++                        show_message(_("Searching for albums by artist: ") + item[1], _("This may take a moment")),
++                        threading.Thread(target=spot_ctl.artist_playlist, args=([item[2]])).start()
++                    ],
++                    1: lambda: [self.click_album(item[2]), pctl.show_current(index=item[2]), setattr(pctl, 'playlist_view_position', pctl.selected_in_playlist)],
++                    2: lambda: [self.click_album(item[2]), pctl.show_current(index=item[2]), setattr(pctl, 'playlist_view_position', pctl.selected_in_playlist)],
++                    3: lambda: self.click_genre(item[1]),
++                    5: lambda: self.click_meta(item[1]),
++                    6: lambda: self.click_composer(item[1]),
++                    7: lambda: self.click_year(item[1]),
++                    8: lambda: switch_playlist(id_to_pl(item[3])),
++                    11: lambda: [spot_ctl.album_playlist(item[2]), reload_albums()],
++                    12: lambda: [spot_ctl.append_track(item[2]), reload_albums()],
++                }
++                if extend:
++                    if n in extend_actions:
++                        extend_actions[n]()
+                     gui.pl_update += 1
++
+                 elif show:
+-                    match n:
+-                        case 0 | 1 | 2 | 3 | 5 | 6 | 7 | 10:
+-                            pctl.show_current(index=item[2], playing=False)
+-                            if album_mode:
+-                                show_in_gal(0)
+-                        case 8:
+-                            pl = id_to_pl(item[3])
+-                            if pl:
+-                                switch_playlist(pl)
++                    if n in show_actions:
++                        show_actions[n]()
++                        if n != 8 and album_mode:
++                            show_in_gal(0)
+ 
+                 elif go:
+-                    match n:
+-                        case 0:
+-                            self.click_artist(item[1])
+-                        case 10:
+-                            show_message(_("Searching for albums by artist: ") + item[1], _("This may take a moment"))
+-                            shoot = threading.Thread(target=spot_ctl.artist_playlist, args=([item[2]]))
+-                            shoot.daemon = True
+-                            shoot.start()
+-                        case 1 | 2:
+-                            self.click_album(item[2])
+-                            pctl.show_current(index=item[2])
+-                            pctl.playlist_view_position = pctl.selected_in_playlist
+-                        case 3:
+-                            self.click_genre(item[1])
+-                        case 5:
+-                            self.click_meta(item[1])
+-                        case 6:
+-                            self.click_composer(item[1])
+-                        case 7:
+-                            self.click_year(item[1])
+-                        case 8:
+-                            pl = id_to_pl(item[3])
+-                            if pl:
+-                                switch_playlist(pl)
+-                        case 11:
+-                            spot_ctl.album_playlist(item[2])
+-                            reload_albums()
+-                        case 12:
+-                            spot_ctl.append_track(item[2])
+-                            reload_albums()
++                    if n in go_actions:
++                        go_actions[n]()
++                        reload_albums()
+ 
+                 if n in (2,) and keymaps.test("add-to-queue") and fade == 1:
+                     queue_object = queue_item_gen(item[2],

--- a/audio/tauonmb/tauonmb.SlackBuild
+++ b/audio/tauonmb/tauonmb.SlackBuild
@@ -29,9 +29,10 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=tauonmb
 VERSION=${VERSION:-7.8.0}
 SRCNAM=Tauon
-BUILD=${BUILD:-3}
+BUILD=${BUILD:-4}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
+SLACKVER=$(awk 'NR {print $2}' "/etc/slackware-version" | sed 's/[^+]//g')
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
@@ -107,6 +108,12 @@ mv assets extra lib locale t_modules templates theme CHANGELOG input.txt \
    LICENSE tauon.py *.md $PKG/opt/tauon-music-box
 
 cd $PKG/opt/tauon-music-box
+
+# Patch by Reza Talebi <reza.talebi.73@outlook.com>
+# - Compatiblity for python3.9 on Slackware 15
+if [[ ! "$SLACKVER" == "+"  ]]; then
+	patch -p1 < "$CWD/config/python39.diff"
+fi
 
 mkdir -p $PKG/usr/bin
 install -m 0755 extra/$PRGNAM.sh $PRGNAM.sh


### PR DESCRIPTION
SlackBuilds python is on 3.9, this issue has been reported thanks to @fourtysixand2 

Now the app should be able to run smoothly on Slackware 15.0 itself.