### PR TITLE
development/spyder: Add further commenting

### DIFF
--- a/development/spyder/spyder.SlackBuild
+++ b/development/spyder/spyder.SlackBuild
@@ -48,20 +48,6 @@ TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
-if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
-else
-  SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
-fi
-
 set -e
 
 rm -rf $PKG
@@ -87,7 +73,7 @@ for FILE in $(find . -type f \( ! -iname "*\.*o" ! -iname "*\.png" \) \
 done
 
 # Allow SlackBuilds python libraries versions
-# Note that while python3-spyder-kernels 3.0.0 can still be built and installed, it causes Spyder to crash
+# Note that while python3-spyder-kernels 3.0.0 can still be built and installed, it causes Spyder 5.4.0 to crash
 sed 's|IPYTHON_REQVER = ">=7.31.1;<8.0.0"|IPYTHON_REQVER = ">=7.31.1"|' -i spyder/dependencies.py
 sed "s|JEDI_REQVER = '>=0.17.2;<0.19.0'|JEDI_REQVER = '>=0.17.2'|" -i spyder/dependencies.py
 sed "s|PYLINT_REQVER = '>=2.5.0;<3.0'|PYLINT_REQVER = '>=2.5.0'|" -i spyder/dependencies.py


### PR DESCRIPTION
I mentioned beforehand that python3-spyder-kernels 3.0.0 causes Spyder to crash.
I need to add that this applies to Spyder 5.4.0 (the version at SlackBuilds.org) specifically.

The crash might not happen with later versions of Spyder (but I have not tried said later versions yet).

Also, remove SLKCFLAGS and LIBDIRSUFFIX (these variables are not used in the SlackBuild).
