### PR TITLE
audio/yabridge: Fix info file

### DIFF
--- a/audio/yabridge/yabridge.info
+++ b/audio/yabridge/yabridge.info
@@ -7,7 +7,7 @@ DOWNLOAD="https://github.com/robbert-vdh/yabridge/archive/5.1.0/yabridge-5.1.0.t
 MD5SUM="2383d67c9089a4fda8ae311baaa8fe3b \
         f9e2185ea8cdfbdc4d99c4a5f5e4d426 \
         a58876a05ac16ada09f750a4b8564443"
-DOWNLOAD_x86_64="UNSUPPORTED"
+DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="wine-staging asio bitsery function2 ghc_filesystem tomlplusplus rust16"
 MAINTAINER="Martin Bångens"


### PR DESCRIPTION
Because it build both on 64 and 32 it should not be unsupported on "DOWNLOAD_x86_64", it should all be in "DOWNLOAD" and "MD5SUM" correct?