### PR TITLE
git/ci: Update CI dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=loose
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.2.1-15.0@sha256:189ed00ee0cfc66b5b2c03bf512c02b881519feacd16e0c8d24afd9db4fb9faf
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.3-15.0@sha256:570ccd359aafa3df56d3316dc1f8206a1902c1e53829cf2e70dde9e8b6fc93d3
 
 jobs:
   changes:
@@ -24,7 +24,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           show-progress: false
           fetch-depth: 2
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get slackbuild directories which have changes.
         id: changed-dirs
-        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c # v44.5.7
+        uses: tj-actions/changed-files@c3a1bb2c992d77180ae65be6ae6c166cf40f857c # v45.0.3
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           dir_names: true
@@ -72,7 +72,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           show-progress: false
           ref: ${{ github.head_ref }}
@@ -133,7 +133,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           show-progress: false
           ref: ${{ github.head_ref }}
@@ -144,7 +144,7 @@ jobs:
 
       - name: Look up dependencies
         id: get_deps
-        uses: fjogeleit/http-request-action@44816be1eabb9c1122d8d775923f39bbe55c67a3 # v1.16.1
+        uses: fjogeleit/http-request-action@bf78da14118941f7e940279dd58f67e863cbeff6 # v1.16.3
         with:
           url: 'https://slackbuilds.org/revdeps.php?q=${{ env.PACKAGE_NAME }}'
           method: 'GET'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,18 @@
 variables:
   FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: "true"
   # renovate: datasource=gitlab-releases depName=gitlab-org/cli
-  GLAB_VERSION: 1.45.0
-  # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=docker
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.1-15.0@sha256:7a961b60a487ecd3e6171f4e7e7ee7c8f659fdc6a37aac26ae2dcd5a3cb8414f
+  GLAB_VERSION: 1.47.0
+  # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=loose
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.3-15.0@sha256:570ccd359aafa3df56d3316dc1f8206a1902c1e53829cf2e70dde9e8b6fc93d3
 
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
 
 default:
-  image: docker:27.2.0@sha256:f9f72ad901a78f27be922b2d320bbc263174f12919c1b37e6a01f828fa904565
+  image: docker:27.3.1@sha256:8d5039800a368057d99fc0a75167d80f345ac8650850509adc7fe25c64cba9dd
   services:
-    - docker:27.2.0-dind@sha256:f9f72ad901a78f27be922b2d320bbc263174f12919c1b37e6a01f828fa904565
+    - docker:27.3.1-dind@sha256:8d5039800a368057d99fc0a75167d80f345ac8650850509adc7fe25c64cba9dd
 
 pr-checks:
   script: |


### PR DESCRIPTION
Updates:

- all github actions
- sbo-maintainer-tools
- gitlab cli
- gitlab ci build images