### PR TITLE
Fix Slackbuild Commenting

### DIFF
--- a/libraries/libminizip/libminizip.SlackBuild
+++ b/libraries/libminizip/libminizip.SlackBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Slackware build script for minizip
+# Slackware build script for libminizip
 
 # Copyright 2013 Daniil Bratashov <dn2010@gmail.com>
 # Copyright 2024 Isaac Yu <isaacyu@protonmail.com>

--- a/python/python2-atomicwrites/python2-atomicwrites.SlackBuild
+++ b/python/python2-atomicwrites/python2-atomicwrites.SlackBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Slackware build script for atomicwrites
+# Slackware build script for python2-atomicwrites
 
 # Copyright 2018-2019  Dimitris Zlatanidis  Orestiada, Greece
 # Copyright 2023 Isaac Yu <isaacyu@protonmail.com>

--- a/python/python2-pluggy/python2-pluggy.SlackBuild
+++ b/python/python2-pluggy/python2-pluggy.SlackBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Slackware build script for pluggy
+# Slackware build script for python2-pluggy
 
 # Copyright 2015-2019  Dimitris Zlatanidis  Orestiada, Greece
 # Copyright 2022 Isaac Yu <isaacyu@protonmail.com>

--- a/python/python2-soupsieve/python2-soupsieve.SlackBuild
+++ b/python/python2-soupsieve/python2-soupsieve.SlackBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Slackware build script for python-soupsieve
+# Slackware build script for python2-soupsieve
 
 # Copyright 2020 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.

--- a/python/python3-ipython_genutils/python3-ipython_genutils.SlackBuild
+++ b/python/python3-ipython_genutils/python3-ipython_genutils.SlackBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Slackware build script for ipython_genutils
+# Slackware build script for python3-ipython_genutils
 
 # Copyright 2017-2021 Benjamin Trigona-Harany <slackbuilds@jaxartes.net>
 # Copyright 2024 Isaac Yu <isaacyu@protonmail.com>

--- a/python/python3-pylint-venv/python3-pylint-venv.SlackBuild
+++ b/python/python3-pylint-venv/python3-pylint-venv.SlackBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Slackware build script for python3-pylint
+# Slackware build script for python3-pylint-venv
 
 # Copyright 2023-2024 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.

--- a/python/python3-qtawesome/python3-qtawesome.SlackBuild
+++ b/python/python3-qtawesome/python3-qtawesome.SlackBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Slackware build script for python3-QtAwesome
+# Slackware build script for python3-qtawesome
 
 # Copyright 2023-2024 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.

--- a/python/python3-watchdog/python3-watchdog.SlackBuild
+++ b/python/python3-watchdog/python3-watchdog.SlackBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SlackBuild build script for python-watchdog
+# SlackBuild build script for python3-watchdog
 
 # Copyright (c) 2000-2020 Prof. Horstmann <wmh (at) eipg.fr>
 # Copyright 2023-2024 Isaac Yu <isaacyu@protonmail.com>


### PR DESCRIPTION
Fix the beginning of the SlackBuild files (i.e. `# Slackware build script for ???`)
The '???' (i.e. the SlackBuilds' names) have some mistakes in them (ex. python-watchdog should be named python3-watchdog, etc.)