### PR TITLE
games/pioneer: Remove lua52 as an optional dependency.

### DIFF
--- a/games/pioneer/README
+++ b/games/pioneer/README
@@ -16,5 +16,3 @@ OpenGL core profile version 3.1 or newer is a runtime dependency. To
 determine what version of OpenGL is installed, use:
 
   glxinfo | grep "core profile version"
-
-lua52 is an optional dependency.

--- a/games/pioneer/pioneer.SlackBuild
+++ b/games/pioneer/pioneer.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=pioneer
 VERSION=${VERSION:-20240710}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -84,10 +84,7 @@ else
 fi
 
 GLEW=OFF
-LUA=OFF
-
 pkg-config --exists glew && GLEW=ON
-pkg-config --exists lua5.2 && LUA=ON
 
 # 20210214 bkw: prevent the build from writing to /root/, without
 # breaking ccache if it's in use.
@@ -111,7 +108,6 @@ cd build
     -DCMAKE_INSTALL_BINDIR=games \
     -DCMAKE_INSTALL_DATADIR=share/games \
     -DUSE_SYSTEM_LIBGLEW=$GLEW \
-    -DUSE_SYSTEM_LIBLUA=$LUA \
     -DPROJECT_VERSION_INFO="$INFOSTRING" \
     -DCMAKE_BUILD_TYPE=$RELEASE ..
   make


### PR DESCRIPTION
RE #8379

Although the upstream default build uses bundled `lua-5.2`, I figured there wasn't any harm leaving `lua52` in place as an optional dependency so long as it was in the repo. Now that it won't be for much longer, it's time to drop it.