### PR TITLE
development/jupyter_server: Remove python3-hatch_jupyter_builder dependency

### DIFF
--- a/development/jupyter_server/jupyter_server.SlackBuild
+++ b/development/jupyter_server/jupyter_server.SlackBuild
@@ -47,20 +47,6 @@ TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
-if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
-else
-  SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
-fi
-
 set -e
 
 rm -rf $PKG

--- a/development/jupyter_server/jupyter_server.info
+++ b/development/jupyter_server/jupyter_server.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/j/jupyter_server/jupyte
 MD5SUM="322b630244d4dddf3db54e5c2d7a58de"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-argon2-cffi jupyter_events jupyter-nbconvert jupyter_server_terminals python3-anyio python3-hatch_jupyter_builder python3-prometheus_client send2trash python3-overrides python3-websocket-client"
+REQUIRES="python3-argon2-cffi jupyter_events jupyter-nbconvert jupyter_server_terminals python3-anyio python3-prometheus_client send2trash python3-overrides python3-websocket-client"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
Now that jupyterlab_pygments 0.3.0 is ready to be updated for next week:
Remove python3-hatch_jupyter_builder from jupyter_server's list of dependencies.