### PR TITLE
libraries/grpc: Remove trailing space within SlackBuild

### DIFF
--- a/libraries/grpc/grpc.SlackBuild
+++ b/libraries/grpc/grpc.SlackBuild
@@ -118,7 +118,7 @@ cmake -Bbuild \
   -DgRPC_BUILD_GRPC_PHP_PLUGIN=ON \
   -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=ON \
   -DgRPC_BUILD_GRPC_RUBY_PLUGIN=ON \
-  -GNinja 
+  -GNinja
 
 cd build
   cmake --build .


### PR DESCRIPTION
I was attempting to update grpc to 1.68.0, but I failed to do so. Some sample output below:
```
CMake Error at CMakeLists.txt:611 (file):
  file COPY cannot find
  "/tmp/SBo/grpc-1.68.0/third_party/envoy-api/envoy/annotations/deprecation.proto":
  No such file or directory.
Call Stack (most recent call first):
  CMakeLists.txt:893 (protobuf_generate_grpc_cpp_with_import_path_correction)
```

This means I will also not update python3-grpcio to 1.68.0 (both python3-grpcio and grpc should be at the same version).

Meanwhile, I found out this trailing space within the grpc SlackBuild.