### PR TITLE
development/spyder: Fix requirements typo

### DIFF
--- a/development/spyder/spyder.SlackBuild
+++ b/development/spyder/spyder.SlackBuild
@@ -84,7 +84,7 @@ sed "s|ipython>=7.31.1,<8.0.0|ipython>=7.31.1|" -i setup.py
 sed "s|jedi>=0.17.2,<0.19.0|jedi>=0.17.2|" -i setup.py
 sed "s|pylint>=2.5.0,<3.0|pylint>=2.5.0|" -i setup.py
 sed "s|qdarkstyle>=3.0.2,<3.1.0|qdarkstyle>=3.0.2|" -i setup.py
-sed "s|qtconsole>=5.4.0,<5.5.0|qtconsole>=5.5.0|" -i setup.py
+sed "s|qtconsole>=5.4.0,<5.5.0|qtconsole>=5.4.0|" -i setup.py
 sed "s|spyder-kernels>=2.4.0,<2.5.0|spyder-kernels>=2.4.0,<=2.5.2|" -i setup.py
 
 python3 setup.py install --root=$PKG


### PR DESCRIPTION
spyder 5.4.0 by default sets the qtconsole version requirement to be >=5.4.0, <5.5.0.

In line 87 of the spyder SlackBuild, I currently have that requirement changed to qtconsole >=5.5.0.
This is a typo.
Instead, that requirement is supposed to be: qtconsole >=5.4.0.
