### PR TITLE
system/OpenSnitch: Edit commenting

### DIFF
--- a/system/OpenSnitch/OpenSnitch.SlackBuild
+++ b/system/OpenSnitch/OpenSnitch.SlackBuild
@@ -110,7 +110,7 @@ make
 cd ../
 
 # Workaround for namespace conflict
-# Taken from https://github.com/pentoo/pentoo-overlay/blob/master/app-admin/opensnitch/opensnitch-1.6.4.ebuild
+# Taken from https://github.com/pentoo/pentoo-overlay/blob/master/app-admin/opensnitch/opensnitch-1.6.6-r1.ebuild
 # For more details, refer to https://github.com/evilsocket/opensnitch/issues/496
 # and https://github.com/evilsocket/opensnitch/pull/442
 sed -i 's/^import ui_pb2/from . import ui_pb2/' ui/opensnitch/ui_pb2_grpc.py


### PR DESCRIPTION
The link to pentoo's ebuild no longer works (it's for OpenSnitch 1.6.4).
I would like that link changed to refer to pentoo's ebuild for OpenSnitch 1.6.6-r1.