### PR TITLE
development/jupyter-nbconvert: Edit SlackBuild

### DIFF
--- a/development/jupyter-nbconvert/jupyter-nbconvert.SlackBuild
+++ b/development/jupyter-nbconvert/jupyter-nbconvert.SlackBuild
@@ -65,11 +65,6 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-# Build jupyter-nbconvert offline
-# Code taken from Gentoo science project:
-# https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-python/nbconvert/nbconvert-7.16.1.ebuild
-sed -e 's:css = .*:raise PermissionError("You shall not fetch!"):' -i hatch_build.py
-
 PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 export PYTHONPATH=/opt/python$PYVER/site-packages
 


### PR DESCRIPTION
jupyter-nbconvert's default behaviour is to download the .css files if they're not already available in the source tarball.

The sed command to prevent downloading of .css files was only necessary for earlier versions of jupyter-nbconvert (as back then, the .css files were not provided in the tarball).

However, in later versions of jupyter-nbconvert (ex. jupyter-nbconvert 7.16.4), the .css files are already in the source tarball.

Therefore, I can remove the code section.
In fact, gentoo's ebuilds (for jupyter-nbconvert) have not listed this sed command since version 7.14.1.