### PR TITLE
development/spyder: Edit README

### DIFF
--- a/development/spyder/README
+++ b/development/spyder/README
@@ -3,4 +3,4 @@ development environment for the Python language with advanced editing,
 interactive testing, debugging and introspection features.
 
 spyder 5.4.0 is the last available version in Slackware 15.0. Newer
-versions require a newer python3-lsp-server.
+versions require python3-lsp-server >= 1.7.0.


### PR DESCRIPTION
More specifically specify that newer versions of spyder require python3-lsp-server >= 1.7.0.

Other users/maintainers do not know that python3-lsp-server v1.6.0 is the reason why spyder is being held back at v5.4.0.