### PR TITLE
python/python3-lsp-server: Edit README

### DIFF
--- a/python/python3-lsp-server/README
+++ b/python/python3-lsp-server/README
@@ -2,4 +2,4 @@ Python LSP Server is a Python 3.7+ implementation of the Language
 Server Protocol.
 
 python3-lsp-server 1.6.0 is the last available version for Slackware
-15.0. Newer versions require a newer python3-rope.
+15.0. Newer versions require python3-rope > 1.2.0.

--- a/python/python3-lsp-server/python3-lsp-server.SlackBuild
+++ b/python/python3-lsp-server/python3-lsp-server.SlackBuild
@@ -49,20 +49,6 @@ TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
-if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
-else
-  SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
-fi
-
 set -e
 
 rm -rf $PKG


### PR DESCRIPTION
More specifically specify that newer versions of python3-lsp-server require python3-rope > 1.2.0.

Currently, python3-rope is being held back at version < 1.2.0.
Edit README to better reflect this context.