### PR TITLE
development/sysprof: Update meson options.

### DIFF
--- a/development/sysprof/sysprof.SlackBuild
+++ b/development/sysprof/sysprof.SlackBuild
@@ -21,6 +21,8 @@
 #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# 2025-02-06 - Updated meson options to fix building on Slackware-current
 
 cd $(dirname $0) ; CWD=$(pwd)
 
@@ -79,11 +81,9 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-mkdir build
-cd build
-  CFLAGS="$SLKCFLAGS" \
-  CXXFLAGS="$SLKCFLAGS" \
-  meson .. \
+CFLAGS="$SLKCFLAGS" \
+CXXFLAGS="$SLKCFLAGS" \
+meson setup \
   --buildtype=release \
   --infodir=/usr/info \
   --libdir=/usr/lib${LIBDIRSUFFIX} \
@@ -92,18 +92,16 @@ cd build
   --prefix=/usr \
   --sysconfdir=/etc \
   -Dstrip=true \
-  -Dgtk=true \
+  -Denable_gtk=true \
   -Dlibsysprof=true \
-  -Dinstall-static=false \
   -Dsystemdunitdir='/tmp' \
   -Dhelp=true \
   -Dlibunwind=false \
-  -Dtools=true \
-  -Dexamples=false \
-  -Dagent=true
-  "${NINJA:=ninja}"
-  DESTDIR=$PKG $NINJA install
-cd ..
+  -Denable_tools=true \
+  -Denable_examples=false \
+  build/
+"${NINJA:=ninja}" -C build/
+DESTDIR=$PKG "$NINJA" -C build/ install
 
 rm -f $PKG/{,usr/}lib${LIBDIRSUFFIX}/*.la
 rm -rf $PKG/tmp # Remove systemd service files.


### PR DESCRIPTION
This commit adjusts meson build options to fix building sysprof on Slackware-current, while leaving Slackware-15.0 build unaffected.