### PR TITLE
development/zope.interface: Fix build when python-opt are present

### DIFF
--- a/development/zope.interface/zope.interface.SlackBuild
+++ b/development/zope.interface/zope.interface.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=zope.interface
 VERSION=${VERSION:-7.2}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -65,6 +65,9 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+export PYTHONPATH=/opt/python$PYVER/site-packages
 
 python3 setup.py install --root=$PKG
 


### PR DESCRIPTION
If various python-opt packages are installed, zope.interface can only build if they are used.
I don't know precisely where lies the conflict, but with this modification it builds alone on a stock Slackware, or alongside lots of python builds.

This is required for things like python3-tubes which requires -opt packages for other dependencies, and will prevent zope.interface from building if other requirements are present...