### PR TITLE
python/python3-incremental: reverted to version 22.10.0 - breaks builds

### DIFF
--- a/python/python3-incremental/README
+++ b/python/python3-incremental/README
@@ -1,1 +1,7 @@
 Incremental is a small library that versions your Python projects.
+
+Beware, since 24.7 release, this packages interferes with some*
+other builds, which were fine with stock setuptools.
+You can either remove python3-incremental before building, or
+export PYTHONPATH=/opt/python$PYVER/site-packages
+with PYVER set to your python3 version.


### PR DESCRIPTION
Newer version will break a lot of builds, which would start complaining about a too old setuptools.
Reverting to avoid breakages, or lots of updates.

/!\ edit /!\ But breaks Twisted...