### PR TITLE
Python3 incremental

### DIFF
--- a/python/python3-incremental/README
+++ b/python/python3-incremental/README
@@ -1,7 +1,7 @@
 Incremental is a small library that versions your Python projects.
 
-Beware, since 24.7 release, this packages interferes with some*
-other builds, which were fine with stock setuptools.
-You can either remove python3-incremental before building, or
+Beware, since 24.7 release, this packages interferes with stock
+python builds, hence it has been moved to /opt.
+Tu use it :
 export PYTHONPATH=/opt/python$PYVER/site-packages
 with PYVER set to your python3 version.

--- a/python/python3-incremental/python3-incremental.SlackBuild
+++ b/python/python3-incremental/python3-incremental.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=python3-incremental
 SRCNAM=${PRGNAM#python3-*}
 VERSION=${VERSION:-24.7.2}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -67,7 +67,10 @@ PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 export PYTHONPATH=/opt/python$PYVER/site-packages
 
 python3 -m build --no-isolation
-python3 -m installer -d "$PKG" dist/*.whl
+python3 -m installer -d "$PKG" -p "opt" dist/*.whl
+
+mv $PKG/opt/lib*/python$PYVER $PKG/opt/
+rmdir $PKG/opt/lib*
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true


### PR DESCRIPTION
The new incremental disturbs stock slackware python build.
If it is installed, no package can still use the stock setuptools, and all of them will require the new setuptools on /opt.

So I've moved this incremental to /opt :

Since incremental is *only* required by Twisted, which already requires the new setuptools in /opt, this is OK for twisted.
And for that matter it is OK for anything that uses /opt, because the new setuptools will therefore be available in /opt, because it is required by incremental.

I've added CICD build of python/buildbot-badges because I have seen it not working here, because it pulls up a lot of Python packages, including python3-incremental through python3-twisted.