### PR TITLE
python/python3-incremental: Fixed, again

### DIFF
--- a/python/python3-incremental/python3-incremental.SlackBuild
+++ b/python/python3-incremental/python3-incremental.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=python3-incremental
 SRCNAM=${PRGNAM#python3-*}
 VERSION=${VERSION:-24.7.2}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -68,6 +68,9 @@ export PYTHONPATH=/opt/python$PYVER/site-packages
 
 python3 -m build --no-isolation
 python3 -m installer -d "$PKG" dist/*.whl
+
+# Prevent incremental from messing up Slackware setuptools
+head -6 $PKG/usr/lib*/python$PYVER/site-packages/incremental-24.7.2.dist-info/entry_points.txt > $PKG/usr/lib*/python$PYVER/site-packages/incremental-24.7.2.dist-info/entry_points.txt
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true


### PR DESCRIPTION
Remove the hook from incremental onto setuptools.
Because moving incremental to /opt breaks twisted.

This fix let twisted work, while not preventing other packages from using stock setuptools.
Yay ?