### PR TITLE
git/ci: Update CI dependencies.

### DIFF
--- a/.github/workflows/auto-create-build-check-issue.yml
+++ b/.github/workflows/auto-create-build-check-issue.yml
@@ -9,6 +9,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     permissions: write-all
+    if: contains('["SlackBuildsOrg/slackbuilds"]', github.repository)
     steps:
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=loose
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.3-15.0@sha256:75a5d705957ef4e5ae69dbe403abea8b79f3d99da07ba646176268179e1122a8
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.3-15.0@sha256:e617db2c7de01f7a5778b7139439fc99a69715ba5ea573a7b0e2add34155f455
 
 jobs:
   changes:
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get slackbuild directories which have changes.
         id: changed-dirs
-        uses: tj-actions/changed-files@bab30c2299617f6615ec02a68b9a40d10bd21366 # v45.0.5
+        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           dir_names: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,18 @@
 variables:
   FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: "true"
   # renovate: datasource=gitlab-releases depName=gitlab-org/cli
-  GLAB_VERSION: 1.51.0
+  GLAB_VERSION: 1.53.0
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=loose
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.3-15.0@sha256:75a5d705957ef4e5ae69dbe403abea8b79f3d99da07ba646176268179e1122a8
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.3-15.0@sha256:e617db2c7de01f7a5778b7139439fc99a69715ba5ea573a7b0e2add34155f455
 
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
 
 default:
-  image: docker:27.4.1@sha256:d33ffba5909705d375ef1a99bb69fe6e21d80482134283226b119acf18bb08b4
+  image: docker:27.5.1@sha256:baade57b9dc1c2e915fa6d5fabe2b600a4b1e1323aa52c5eca53170739b0db8d
   services:
-    - docker:27.4.1-dind@sha256:d33ffba5909705d375ef1a99bb69fe6e21d80482134283226b119acf18bb08b4
+    - docker:27.5.1-dind@sha256:baade57b9dc1c2e915fa6d5fabe2b600a4b1e1323aa52c5eca53170739b0db8d
 
 pr-checks:
   script: |


### PR DESCRIPTION
Updates:

- gitlab ci build images
- gitlab cli version bump
- bump actions
- bump sbo-maintainer-tools docker image
- don't create weekly build issue in forks
  - avoids creating an issue in ponce's repo weekly