### PR TITLE
system/OpenSnitch: Update for 1.6.8

### DIFF
--- a/system/OpenSnitch/OpenSnitch.SlackBuild
+++ b/system/OpenSnitch/OpenSnitch.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for OpenSnitch
 
-# Copyright 2024 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2024-2025 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=OpenSnitch
-VERSION=${VERSION:-1.6.6}
+VERSION=${VERSION:-1.6.8}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -110,7 +110,7 @@ make
 cd ../
 
 # Workaround for namespace conflict
-# Taken from https://github.com/pentoo/pentoo-overlay/blob/master/app-admin/opensnitch/opensnitch-1.6.6-r1.ebuild
+# Taken from https://github.com/pentoo/pentoo-overlay/blob/master/app-admin/opensnitch/opensnitch-1.6.7.ebuild
 # For more details, refer to https://github.com/evilsocket/opensnitch/issues/496
 # and https://github.com/evilsocket/opensnitch/pull/442
 sed -i 's/^import ui_pb2/from . import ui_pb2/' ui/opensnitch/ui_pb2_grpc.py

--- a/system/OpenSnitch/OpenSnitch.info
+++ b/system/OpenSnitch/OpenSnitch.info
@@ -1,7 +1,7 @@
 PRGNAM="OpenSnitch"
-VERSION="1.6.6"
+VERSION="1.6.8"
 HOMEPAGE="https://github.com/evilsocket/opensnitch"
-DOWNLOAD="https://github.com/evilsocket/opensnitch/archive/v1.6.6/opensnitch-1.6.6.tar.gz \
+DOWNLOAD="https://github.com/evilsocket/opensnitch/archive/v1.6.8/opensnitch-1.6.8.tar.gz \
           https://github.com/fsnotify/fsnotify/archive/v1.4.7/fsnotify-1.4.7.tar.gz \
           https://github.com/golang/protobuf/archive/v1.5.0/protobuf-1.5.0.tar.gz \
           https://github.com/google/gopacket/archive/v1.1.14/gopacket-1.1.14.tar.gz \
@@ -26,7 +26,7 @@ DOWNLOAD="https://github.com/evilsocket/opensnitch/archive/v1.6.6/opensnitch-1.6
           https://github.com/golang/xerrors/archive/5ec99f8/xerrors-5ec99f83aff198f5fbd629d6c8d8eb38a04218ca.tar.gz \
           https://github.com/protocolbuffers/protobuf-go/archive/v1.26.0/protobuf-go-1.26.0.tar.gz \
           https://github.com/dominikh/go-tools/archive/v0.2.2/go-tools-0.2.2.tar.gz"
-MD5SUM="95ff63a05327f6456da567604a6f40da \
+MD5SUM="02fe0265dd3197d96f03d070fbd2159f \
         e23b3240fc9e807fcffb97d12a433138 \
         7bff4630d93dc4f9081b5dbc31067899 \
         5e4827e740a060b8f97116955718de19 \

--- a/system/OpenSnitch/README
+++ b/system/OpenSnitch/README
@@ -2,7 +2,7 @@ OpenSnitch is a GNU/Linux interactive application firewall inspired by
 Little Snitch.
 
 Opensnitch requires the opensnitchd rc script to execute upon startup.
-That is, add the following line to /etc/rc.local:
+That is, add the following line to /etc/rc.d/rc.local:
 [ -x /etc/rc.d/rc.opensnitchd ] && /etc/rc.d/rc.opensnitchd start
 
 To install the eBPF process monitor module (requires kernel-source),

--- a/system/OpenSnitch/README.SLACKWARE
+++ b/system/OpenSnitch/README.SLACKWARE
@@ -48,7 +48,7 @@ make modules
 KERNEL_VER=$(uname -r)
 mv /boot/vmlinuz-generic-$KERNEL_VER /boot/vmlinuz-generic-$KERNEL_VER-old
 cp arch/x86_64/boot/bzImage /boot/vmlinuz-generic-$KERNEL_VER
-mv /boot/System.map-generic-$KERNEL_VER /boot/System.map-generic-$KERNEL_VER.old
+mv /boot/System.map-generic-$KERNEL_VER /boot/System.map-generic-$KERNEL_VER-old
 cp System.map /boot/System.map-generic-$KERNEL_VER
 
 - Finally, install the kernel:

--- a/system/OpenSnitch/patches/remove-debian-path.patch
+++ b/system/OpenSnitch/patches/remove-debian-path.patch
@@ -1,8 +1,8 @@
-This patch watch taken from Arch Linux repositories:
+This patch was taken from Arch Linux repositories:
 https://gitlab.archlinux.org/archlinux/packaging/packages/opensnitch/-/blob/main/remove-debian-path.patch
 --- a/ui/bin/opensnitch-ui
 +++ b/ui/bin/opensnitch-ui
-@@ -35,10 +35,6 @@ from concurrent import futures
+@@ -34,10 +34,6 @@
  
  import grpc
  

--- a/system/OpenSnitch/patches/use-system-python-packages.patch
+++ b/system/OpenSnitch/patches/use-system-python-packages.patch
@@ -2,14 +2,14 @@ This patch was taken from Arch Linux repositories:
 https://gitlab.archlinux.org/archlinux/packaging/packages/opensnitch/-/blob/main/use-system-python-packages.patch
 --- a/ui/Makefile
 +++ b/ui/Makefile
-@@ -3,16 +3,13 @@ all: opensnitch/resources_rc.py
+@@ -3,16 +3,13 @@
  install:
  	@pip3 install --upgrade .
  
 -opensnitch/resources_rc.py: translations deps
 +opensnitch/resources_rc.py: translations
  	@pyrcc5 -o opensnitch/resources_rc.py opensnitch/res/resources.qrc
- 	sed -i 's/^import ui_pb2/from . import ui_pb2/' opensnitch/ui_pb2*
+ 	@find opensnitch/proto/ -name 'ui_pb2_grpc.py' -exec sed -i 's/^import ui_pb2/from . import ui_pb2/' {} \;
  
  translations:
  	@cd i18n ; make


### PR DESCRIPTION
So, @willysr was discussing a potential update of protobuf3 to version 30.0 (see https://github.com/SlackBuildsOrg/slackbuilds/issues/10021 for more details.)

I (along with Willy) found out that while python3-grpcio may build with this new version of protobuf3, the python3-grpcio-tools component cannot (meaning that the new version of protobuf3 indirectly breaks building OpenSnitch.)

In the meantime, I was testing changes to the OpenSnitch SlackBuild (this was inside a Slackware virtual machine on VirtualBox.) This update is derived from said testing (e.x. I updated OpenSnitch as part of testing protobuf3 30.0.)

I am still not returning to regular SlackBuilds maintenance just yet. I am only making this update due to Willy bringing up issues associated with updating protobuf3 to 30.0.