### PR TITLE
development/android-tools: Fix build with new profobuf3

### DIFF
--- a/development/android-tools/android-tools-35.0.2-fix-protobuf-30.0-compilation.patch
+++ b/development/android-tools/android-tools-35.0.2-fix-protobuf-30.0-compilation.patch
@@ -1,0 +1,13 @@
+diff --git a/libjsonpb/parse/jsonpb.cpp b/libjsonpb/parse/jsonpb.cpp
+index 6c428282b..575155709 100644
+--- a/libjsonpb/parse/jsonpb.cpp
++++ b/libjsonpb/parse/jsonpb.cpp
+@@ -33,7 +33,7 @@ using google::protobuf::util::TypeResolver;
+ static constexpr char kTypeUrlPrefix[] = "type.googleapis.com";
+ 
+ std::string GetTypeUrl(const Message& message) {
+-  return std::string(kTypeUrlPrefix) + "/" + message.GetDescriptor()->full_name();
++  return std::string(kTypeUrlPrefix) + "/" + std::string(message.GetDescriptor()->full_name());
+ }
+ 
+ ErrorOr<std::string> MessageToJsonString(const Message& message) {

--- a/development/android-tools/android-tools.SlackBuild
+++ b/development/android-tools/android-tools.SlackBuild
@@ -3,7 +3,7 @@
 # Slackware build script for android-tools
 # Thanks to the Arch linux maintainers for the makefiles
 
-# Copyright 2016, 2017, 2022-2024 Philip van der Hoeven, Almere, NL
+# Copyright 2016, 2017, 2022-2025 Philip van der Hoeven, Almere, NL
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -28,7 +28,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=android-tools
 VERSION=${VERSION:-35.0.2}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -84,6 +84,8 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# Fix building with protobuf3 version 30
+patch -p1 -d "vendor/extras" < $CWD/android-tools-35.0.2-fix-protobuf-30.0-compilation.patch
 
 mkdir -p build
 cd build


### PR DESCRIPTION
This fixes building with protobuf3 version 30. It also seems to work fine with 29.3 so it should not cause any issues in case this might get merged before the protobuf upgrade.