### PR TITLE
python/python3-grpcio: Re-enable python3-grpcio-tools module [revised PR 1]

### DIFF
--- a/python/python3-grpcio/python3-grpcio.SlackBuild
+++ b/python/python3-grpcio/python3-grpcio.SlackBuild
@@ -16,7 +16,7 @@
 #  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
 #  EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 #  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
 #  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
@@ -26,11 +26,12 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-grpcio
 VERSION=${VERSION:-1.71.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
 SRCNAM=grpc
+PROTOVER=${PROTOVER:-30.1}
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
@@ -57,6 +58,10 @@ cd $TMP
 rm -rf $SRCNAM-$VERSION
 tar xvf $CWD/$SRCNAM-$VERSION.tar.gz
 cd $SRCNAM-$VERSION
+
+# Extract protobuf tarball
+tar xvf $CWD/protobuf-$PROTOVER.tar.gz
+
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
@@ -87,11 +92,11 @@ sed -r -i \
     tools/distrib/python/grpcio_tools/protoc_lib_deps.py
 ln -s ../../../.. tools/distrib/python/grpcio_tools/grpc_root
 
-# Build python3-grcpio_tools
-#cd tools/distrib/python/grpcio_tools
-#GRPC_PYTHON_CFLAGS="-fno-wrapv -frtti $(pkg-config --cflags protobuf)" \
-#  GRPC_PYTHON_LDFLAGS="$(pkg-config --libs protobuf) -lprotoc" \
-#  python3 setup.py install --root=$PKG
+# Build python3-grcpio-tools
+cd tools/distrib/python/grpcio_tools
+GRPC_PYTHON_CFLAGS="-fno-wrapv -frtti $(pkg-config --cflags protobuf)" \
+  GRPC_PYTHON_LDFLAGS="$(pkg-config --libs protobuf) -lprotoc -I$TMP/$SRCNAM-$VERSION/protobuf-$PROTOVER/src" \
+  python3 setup.py install --root=$PKG
 cd $TMP/$SRCNAM-$VERSION
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/python/python3-grpcio/python3-grpcio.info
+++ b/python/python3-grpcio/python3-grpcio.info
@@ -1,8 +1,10 @@
 PRGNAM="python3-grpcio"
 VERSION="1.71.0"
 HOMEPAGE="https://grpc.io/"
-DOWNLOAD="https://github.com/grpc/grpc/archive/v1.71.0/grpc-1.71.0.tar.gz"
-MD5SUM="89ad442e1b174bc5d55c554aec583fa0"
+DOWNLOAD="https://github.com/grpc/grpc/archive/v1.71.0/grpc-1.71.0.tar.gz \
+          https://github.com/google/protobuf/archive/v30.1/protobuf-30.1.tar.gz"
+MD5SUM="89ad442e1b174bc5d55c554aec583fa0 \
+        3f3792f866d8dc5820ce9fdc10b33bf8"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="protobuf3 re2"


### PR DESCRIPTION
See https://github.com/SlackBuildsOrg/slackbuilds/issues/10021 and https://github.com/SlackBuildsOrg/slackbuilds/pull/10020 for more details.

1. Can the python3-grpcio SlackBuild simply link to a prior protobuf v30.0 source tarball within the $TMP directory (that is, /tmp/SBo)? Or does the python3-grpcio SlackBuild itself have to download and extract another protobuf v30.0 tarball? (i.e. python3-grpcio's .info would additionally contain a link to the protobuf v30.0 source tarball.)

2. Regarding the protobuf version (the $PROTOVER variable):
Since @willysr prefers to keep updating protobuf, I am more inclined to remove the $PROTOVER variable entirely. Instead, the new build flag will be something like -I$TMP/protobuf-*/src

@willysr, please advise.

Update:
I'm trying this PR again.
This time, the python3-grpcio SlackBuild will download the protobuf v30.1 tarball and then extract it inside the grpc source folder (i.e. inside /tmp/SBo/grpc-1.71.0).