### PR TITLE
git/ci: Replace tj-actions/changed-files.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,40 +24,29 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Calculate clone depth.
+        run: printf "CHECKOUT_FETCH_DEPTH=%s\n" "$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           show-progress: false
-          fetch-depth: 2
+          fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Get slackbuild directories which have changes.
-        id: changed-dirs
-        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
-        with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
-          dir_names: true
-          dir_names_exclude_current_dir: true
-          dir_names_max_depth: 2
-          matrix: true
-          files_ignore: |
-            .github/**
-            .gitignore
-            .gitlab-ci.yml
-            .mailmap
-            ChangeLog.txt
-            README
-
-      - name: List all changed files
-        env:
-          CHANGED_FILES: ${{ steps.changed-dirs.outputs.all_changed_files }}
         run: |
-          printf "%s\n" "$CHANGED_FILES"
+          CHANGED_FILES="$(git diff-tree --name-only --diff-filter=d --no-commit-id -r ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | sed '/^\./d' | sed -n '/[^\/][^\/]*\/[^\/][^\/]*\//p' | xargs -I xx dirname xx | sort -u | sed '/.github/d' | sed 's/^/"/;s/$/"/g' | paste -d, -s | sed 's/^/[/;s/$/]/')"
+
+          delimiter="$(openssl rand -hex 8)"
+          printf "CHANGED_FILES<<%s\n" "$delimiter" >> "$GITHUB_ENV"
+
+          printf "%s\n" "$CHANGED_FILES" | tee -a "$GITHUB_ENV"
+
+          printf "%s\n" "$delimiter" >> "$GITHUB_ENV"
 
       - name: Get matrix output
         id: set-matrix
-        env:
-          CHANGED_FILES: ${{ steps.changed-dirs.outputs.all_changed_files }}
         run: |
           {
             printf 'matrix<<SLACKBUILDS\n'


### PR DESCRIPTION
This repo has been deleted after it was compromised. We do not have
any secrets in our repo and we had also pinned the version of the
action to sha so there is no issue for us.

But the repo is gone now. I've instead matched this code to what we
are doing in the gitlab CI runner where we did not have such an
action anyway.
