### PR TITLE
development/spyder: Clarify commenting on python3-spyder-kernels version restriction

### DIFF
--- a/development/spyder/spyder.SlackBuild
+++ b/development/spyder/spyder.SlackBuild
@@ -73,7 +73,7 @@ for FILE in $(find . -type f \( ! -iname "*\.*o" ! -iname "*\.png" \) \
 done
 
 # Allow SlackBuilds python libraries versions
-# Note that while python3-spyder-kernels 3.0.0 can still be built and installed, it causes Spyder 5.4.0 to crash
+# Note that while python3-spyder-kernels >= 3.0.0 can still be built and installed, it causes Spyder 5.4.0 to crash
 sed 's|IPYTHON_REQVER = ">=7.31.1;<8.0.0"|IPYTHON_REQVER = ">=7.31.1"|' -i spyder/dependencies.py
 sed "s|JEDI_REQVER = '>=0.17.2;<0.19.0'|JEDI_REQVER = '>=0.17.2'|" -i spyder/dependencies.py
 sed "s|PYLINT_REQVER = '>=2.5.0;<3.0'|PYLINT_REQVER = '>=2.5.0'|" -i spyder/dependencies.py


### PR DESCRIPTION
python3-spyder-kernels has versions later than 3.0.0.
I would like to slightly change the documentation to reflect this.

It's python3-spyder-kernels >= 3.0.0 (not only version 3.0.0 itself) that cannot run with spyder 5.4.0.