### PR TITLE
python/python3-statsmodels: Edit README (+update homepage)

### DIFF
--- a/python/python3-statsmodels/README
+++ b/python/python3-statsmodels/README
@@ -6,6 +6,3 @@ plotting functions, and result statistics are available for
 different types of data and each estimator. Researchers across
 fields may find that statsmodels fully meets their needs for
 statistical computing and data analysis in Python.
-
-python3-statsmodels 0.14.1 is the last available version for Slackware
-15.0. Newer versions would require Cython >= 3.0.10.

--- a/python/python3-statsmodels/python3-statsmodels.info
+++ b/python/python3-statsmodels/python3-statsmodels.info
@@ -1,6 +1,6 @@
 PRGNAM="python3-statsmodels"
 VERSION="0.14.1"
-HOMEPAGE="http://statsmodels.sourceforge.net/"
+HOMEPAGE="https://www.statsmodels.org"
 DOWNLOAD="https://pypi.python.org/packages/source/s/statsmodels/statsmodels-0.14.1.tar.gz"
 MD5SUM="4e0f1ecd898349d9f23ee496bb6ba7ba"
 DOWNLOAD_x86_64=""


### PR DESCRIPTION
1. https://statsmodels.sourceforge.net is outdated as a homepage (therefore, update it to https://www.statsmodels.org instead.)
2. Since fourtysixandtwo has uploaded python3-cython-opt to SlackBuilds.org, python3-statsmodels can now be updated to v0.14.4. However, this would require prerequisite SlackBuilds to be updated - for example, python3-numpy to be updated to 2.0.0 and python3-scipy to be updated to 1.15.2. I have not asked the maintainers (i.e. Christoph Willing and Jeremy Hansen) to update those packages. I am not interested in updating python3-statsmodels at this time.