### PR TITLE
system/OpenSnitch: Edit README

### DIFF
--- a/system/OpenSnitch/README
+++ b/system/OpenSnitch/README
@@ -2,7 +2,12 @@ OpenSnitch is a GNU/Linux interactive application firewall inspired by
 Little Snitch.
 
 Opensnitch requires the opensnitchd rc script to execute upon startup.
-That is, add the following line to /etc/rc.d/rc.local:
+That is:
+
+1. Make /etc/rc.d/rc.opensnitchd executable:
+chmod +x /etc/rc.d/rc.opensnitchd
+
+2. Add the following line to /etc/rc.d/rc.local:
 [ -x /etc/rc.d/rc.opensnitchd ] && /etc/rc.d/rc.opensnitchd start
 
 To install the eBPF process monitor module (requires kernel-source),


### PR DESCRIPTION
I just found out from installing OpenSnitch on my Slackware system (in VirtualBox) that I need to make /etc/rc.d/rc.opensnitchd executable (so that OpenSnitch actually filters outgoing connections.)

I would like the README edited accordingly.