### PR TITLE
python/python3-grpcio: Revert workaround for building the python3-grpcio-tools module

### DIFF
--- a/python/python3-grpcio/python3-grpcio.SlackBuild
+++ b/python/python3-grpcio/python3-grpcio.SlackBuild
@@ -26,12 +26,11 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-grpcio
 VERSION=${VERSION:-1.71.0}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
 SRCNAM=grpc
-PROTOVER=${PROTOVER:-30.1}
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
@@ -58,12 +57,6 @@ cd $TMP
 rm -rf $SRCNAM-$VERSION
 tar xvf $CWD/$SRCNAM-$VERSION.tar.gz
 cd $SRCNAM-$VERSION
-
-# Extract protobuf tarball
-tar xvf $CWD/protobuf-$PROTOVER.tar.gz
-cd protobuf-$PROTOVER
-patch -p1 < $CWD/protobuf-reenable-private-headers.patch
-cd ..
 
 chown -R root:root .
 find -L . \
@@ -97,7 +90,7 @@ ln -s ../../../.. tools/distrib/python/grpcio_tools/grpc_root
 
 # Build python3-grcpio-tools
 cd tools/distrib/python/grpcio_tools
-GRPC_PYTHON_CFLAGS="-fno-wrapv -frtti $(pkg-config --cflags protobuf) -I$TMP/$SRCNAM-$VERSION/protobuf-$PROTOVER/src" \
+GRPC_PYTHON_CFLAGS="-fno-wrapv -frtti $(pkg-config --cflags protobuf)" \
   GRPC_PYTHON_LDFLAGS="$(pkg-config --libs protobuf) -lprotoc" \
   python3 setup.py install --root=$PKG
 cd $TMP/$SRCNAM-$VERSION

--- a/python/python3-grpcio/python3-grpcio.info
+++ b/python/python3-grpcio/python3-grpcio.info
@@ -1,10 +1,8 @@
 PRGNAM="python3-grpcio"
 VERSION="1.71.0"
 HOMEPAGE="https://grpc.io/"
-DOWNLOAD="https://github.com/grpc/grpc/archive/v1.71.0/grpc-1.71.0.tar.gz \
-          https://github.com/google/protobuf/archive/v30.1/protobuf-30.1.tar.gz"
-MD5SUM="89ad442e1b174bc5d55c554aec583fa0 \
-        3f3792f866d8dc5820ce9fdc10b33bf8"
+DOWNLOAD="https://github.com/grpc/grpc/archive/v1.71.0/grpc-1.71.0.tar.gz"
+MD5SUM="89ad442e1b174bc5d55c554aec583fa0"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="protobuf3 re2"


### PR DESCRIPTION
@willysr has already prepared an update of protobuf to 30.2 for next week.

Therefore, the protobuf-reenable-private-headers.patch is no longer necessary for building the python3-grpcio-tools module.

I would like sbo-bot to build python3-grpcio against protobuf 30.2 rather than 30.1.