### PR TITLE
system/trash-cli: Edit (reword) README

### DIFF
--- a/system/trash-cli/README
+++ b/system/trash-cli/README
@@ -10,5 +10,5 @@ trash-list    : list trashed files.
 trash-restore : restore a trashed file.
 trash-rm      : remove individual files from trash can.
 
-python3-shtab is additionally required for installing trash-cli with
+python3-shtab is an optional dependency for building trash-cli with
 shell completion support.


### PR DESCRIPTION
I plan on updating python3-keyring to 25.6.0.

Following the Arch Linux repo, I also plan on adding (optional) shell completion support:
https://gitlab.archlinux.org/archlinux/packaging/packages/python-keyring

Therefore, I would like to edit the trash-cli README in preparation for adding that similar feature on python3-keyring.