### PR TITLE
gis/geopy: Edit README

### DIFF
--- a/gis/geopy/README
+++ b/gis/geopy/README
@@ -1,9 +1,9 @@
-geopy makes it easy for developers to locate the coordinates of 
-addresses, cities, countries, and landmarks across the globe using 
+geopy makes it easy for developers to locate the coordinates of
+addresses, cities, countries, and landmarks across the globe using
 third-party geocoders and other data sources.
 
-geopy currently includes support for several geocoders, including 
+geopy currently includes support for several geocoders, including
 OpenStreetMap Nominatim, ESRI ArcGIS, Google Geocoding API and more.
 
-pytz and python3-aiohttp are optional dependencies that 
+python3-pytz and python3-aiohttp are optional dependencies that
 will be used if available.


### PR DESCRIPTION
"pytz" is currently not available at SlackBuilds.org, as it has been split into python2-pytz and python3-pytz.
I would like to update the README in accordance with this.

EDIT: Also, remove trailing whitespace from README.