### PR TITLE
python/python3-pykeepass: Remove python3-setuptools-opt dependency mention

### DIFF
--- a/python/python3-pykeepass/python3-pykeepass.info
+++ b/python/python3-pykeepass/python3-pykeepass.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/libkeepass/pykeepass/archive/v4.1.1.post1/pykeepass
 MD5SUM="4bf91018e9fb9cfb00e6bdbd8eb2fe9e"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-argon2-cffi python3-construct python3-lxml python3-setuptools-opt python3-pycryptodomex"
+REQUIRES="python3-argon2-cffi python3-construct python3-lxml python3-pycryptodomex"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
The python3-setuptools-opt dependency mention in .info is redundant.
python3-argon2-cffi and python3-lxml already depend on python3-setuptools-opt.