### PR TITLE
python/python3-lsp-server: Fix flake8 version constraints

### DIFF
--- a/python/python3-lsp-server/python3-lsp-server.SlackBuild
+++ b/python/python3-lsp-server/python3-lsp-server.SlackBuild
@@ -66,7 +66,7 @@ find -L . \
 
 # Workarounds for spyder
 sed -i "s|autopep8>=1.6.0,<1.7.0|autopep8>=1.6.0|" -i pyproject.toml
-sed -i "s|flake8>=5.0.0,<5.1.0|flake8>=5.1.0|" -i pyproject.toml
+sed -i "s|flake8>=5.0.0,<5.1.0|flake8>=5.0.0|" -i pyproject.toml
 sed -i "s|jedi>=0.17.2,<0.19.0|jedi>=0.17.2|" -i pyproject.toml
 sed -i "s|pycodestyle>=2.9.0,<2.10.0|pycodestyle>=2.9.0|" -i pyproject.toml
 sed -i "s|pyflakes>=2.5.0,<2.6.0|pyflakes>=2.5.0|" -i pyproject.toml


### PR DESCRIPTION
The flake8 version requirement should be listed as >=5.0.0, not >=5.1.0.

I am only making typo fixes.