### PR TITLE
development/rstudio-desktop: Update README (last available version for Slackware 15.0)

### DIFF
--- a/development/rstudio-desktop/README
+++ b/development/rstudio-desktop/README
@@ -21,6 +21,11 @@ version, featuring:
 At the moment, the script just repackages the Fedora/Redhat binaries,
 provided by upstream.
 
-NOTE
+NOTE 1:
 RStudio currently only supports 64-bit systems. The last 32-bit version
 is 1.1.463, provided by "rstudio-desktop-legacy", available at SBo.
+
+NOTE 2:
+RStudio 2024.12.1+563 is the last available version for Slackware 15.0.
+Newer versions require openssl >= 3 (for context, Slackware 15.0 has
+openssl 1.1.1.)


### PR DESCRIPTION
The latest version of rstudio-desktop is 2025.05.0+496.

While it does build and install, when it runs, I receive the following error on the RStudio window:
```
/usr/lib64/rstudio/resources/app/bin/rsession: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```
Posit (the organization developing RStudio) no longer provides binary packages for Ubuntu 20 or Red Hat Enterprise Linux 8 (i.e. the operating system versions that still support openssl 1.1.1.) Due to this, rstudio-desktop versions after 2024.12.1+563 no longer run on Slackware 15.0.