### PR TITLE
development/gedit: Fix building on Slackware-current

### DIFF
--- a/development/gedit/gedit.SlackBuild
+++ b/development/gedit/gedit.SlackBuild
@@ -93,9 +93,16 @@ find -L . \
 sed -i "s/meson_version: '>= 0.64'/meson_version: '>= 0.59'/;
   s/'gio-2.0', version: '>= 2.74'/'gio-2.0', version: '>= 2.70'/" meson.build
 
+# Define G_CONNECT_DEFAULT=0 if glib2 version is less than 2.74.0
+# This is needed to build gedit on Slackware-15.0 with it's glib2-2.70.3 version,
+# but causes gedit to FTB on Slackware-current with its newer glib2 version, so
+# set it depending on detected glib-2.0 version:
+if ! pkg-config --atleast-version 2.74.0 glib-2.0; then
+  SLKCFLAGS="$SLKCFLAGS -DG_CONNECT_DEFAULT=0"
+fi
 
 cd build
-  CFLAGS="$SLKCFLAGS -DG_CONNECT_DEFAULT=0" \
+  CFLAGS="$SLKCFLAGS" \
   CXXFLAGS="$SLKCFLAGS" \
   meson .. \
     --buildtype=release \


### PR DESCRIPTION
Detect the glib-2.0 version and set G_CONNECT_DEFAULT=0 only on Slackware-15.0 builds, so that gedit still builds on Slackware-current.