### PR TITLE
python/numpydoc: Remove python3-setuptools-opt dependency

### DIFF
--- a/python/numpydoc/numpydoc.info
+++ b/python/numpydoc/numpydoc.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/n/numpydoc/numpydoc-1.6
 MD5SUM="227e5a257f4bfe488a257d963c2df5bc"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-setuptools-opt Sphinx python3-tabulate"
+REQUIRES="Sphinx python3-tabulate"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
On .info, python3-setuptools-opt is redundant.

Here is a schematic of the dependency tree:

python3-setuptools-opt
&emsp;-> python-zipp
&emsp;&emsp;-> python-importlib_metadata
&emsp;&emsp;&emsp;-> Sphinx
&emsp;&emsp;&emsp;&emsp;-> numpydoc