### PR TITLE
system/OpenSnitch: Edit README (add instruction on rc.local_shutdown file)

### DIFF
--- a/system/OpenSnitch/README
+++ b/system/OpenSnitch/README
@@ -10,6 +10,9 @@ chmod +x /etc/rc.d/rc.opensnitchd
 2. Add the following line to /etc/rc.d/rc.local:
 [ -x /etc/rc.d/rc.opensnitchd ] && /etc/rc.d/rc.opensnitchd start
 
+3. Add the following line to /etc/rc.d/rc.local_shutdown:
+[ -x /etc/rc.d/rc.opensnitchd ] && /etc/rc.d/rc.opensnitchd stop
+
 To install the eBPF process monitor module (requires kernel-source),
 pass in eBPF=yes to the SlackBuild.
 


### PR DESCRIPTION
Add instruction regarding the rc.local_shutdown file.
This is similar to how the virtualbox SlackBuild has instructions for adding lines to the rc.local and rc.local_shutdown files.

Also, I am not updating this to OpenSnitch 1.7.0.0.
It does build; however, the ui does not run.