### PR TITLE
system/trash-cli: Fix installation of shell completions

### DIFF
--- a/system/trash-cli/trash-cli.SlackBuild
+++ b/system/trash-cli/trash-cli.SlackBuild
@@ -76,8 +76,8 @@ if $(python3 -c 'import pkgutil; exit(not pkgutil.find_loader("shtab"))'); then
   mkdir -p $PKG/usr/share/bash-completion/completions
   mkdir -p $PKG/usr/share/zsh/site-functions
   for CMD in trash-empty trash-list trash-restore trash-put trash; do
-    $CMD --print-completion bash > "$PKG/usr/share/bash-completion/completions/$CMD"
-    $CMD --print-completion zsh >  "$PKG/usr/share/zsh/site-functions/_$CMD"
+    ./$CMD --print-completion bash > "$PKG/usr/share/bash-completion/completions/$CMD"
+    ./$CMD --print-completion zsh >  "$PKG/usr/share/zsh/site-functions/_$CMD"
   done
 fi
 


### PR DESCRIPTION
If python3-shtab is installed, but trash-cli is not, then trash-cli fails to install on my system.

The reason is:
Looking inside the for loop, the lines start with the following:
$CMD --print-completion ...

The lines should instead be the following:
./$CMD --print-completion ...

The loop currently runs commands like the following:
trash-empty --print-completion ...

The loop should instead run commands like the following:
./trash-empty --print-completion ...

The loop should run the files inside the /tmp/SBo/trash-cli-0.24.5.26 source folder, not the system files.