### PR TITLE
network/modsecurity-apache: Updated for version 2.9.11 and CRS 4.16.0.

### DIFF
--- a/network/modsecurity-apache/modsecurity-apache.SlackBuild
+++ b/network/modsecurity-apache/modsecurity-apache.SlackBuild
@@ -25,12 +25,12 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=modsecurity-apache
 SRCNAM=modsecurity
-VERSION=${VERSION:-2.9.8}
+VERSION=${VERSION:-2.9.11}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
-CRS_VERSION="4.6.0"
+CRS_VERSION="4.16.0"
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in

--- a/network/modsecurity-apache/modsecurity-apache.info
+++ b/network/modsecurity-apache/modsecurity-apache.info
@@ -1,10 +1,10 @@
 PRGNAM="modsecurity-apache"
-VERSION="2.9.8"
+VERSION="2.9.11"
 HOMEPAGE="https://www.modsecurity.org/"
-DOWNLOAD="https://github.com/owasp-modsecurity/ModSecurity/releases/download/v2.9.8/modsecurity-v2.9.8.tar.gz \
-          https://github.com/coreruleset/coreruleset/archive/v4.6.0/coreruleset-4.6.0.tar.gz"
-MD5SUM="69ba67a0d1e93404919b276980d88331 \
-        2dfe58af935db7d3c843db9ba6c8794a"
+DOWNLOAD="https://github.com/owasp-modsecurity/ModSecurity/releases/download/v2.9.11/modsecurity-v2.9.11.tar.gz \
+          https://github.com/coreruleset/coreruleset/archive/v4.16.0/coreruleset-4.16.0.tar.gz"
+MD5SUM="8086c00c3513e2d3b985bbed4df35b01 \
+        b2c571fbd38fa56c3cce464eae33af28"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES=""


### PR DESCRIPTION
This update fixes the following vulnerabilities:

* [CVE 2025-47947](https://modsecurity.org/20250521/possible-dos-vulnerability-cve-2025-47947-2025-may/)
* [CVE 2025-48866](https://modsecurity.org/20250602/dos-vulnerability-cve-2025-48866-2025-june/)
* [CVE 2025-52891](https://modsecurity.org/20250701/dos-vulnerability-cve-2025-52891-2025-july/)