### PR TITLE
python/python3-cookiecutter: Remove python3-jinja2-time dependency, add python3-arrow dependency

### DIFF
--- a/python/python3-cookiecutter/python3-cookiecutter.SlackBuild
+++ b/python/python3-cookiecutter/python3-cookiecutter.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for python3-cookiecutter
 
-# Copyright 2023-2024 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2023-2025 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is

--- a/python/python3-cookiecutter/python3-cookiecutter.info
+++ b/python/python3-cookiecutter/python3-cookiecutter.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/cookiecutter/cookiecutter/archive/2.6.0/cookiecutte
 MD5SUM="fe5c6c2bc42b6ba6352be7b6d258460e"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="binaryornot click python3-jinja2-time python3-rich python3-slugify"
+REQUIRES="binaryornot click python3-arrow python3-rich python3-slugify"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
1. python3-cookiecutter (since version 2.2.0) no longer depends python3-jinja2-time.
2. I am removing the python3-jinja2-time dependency. Since python3-jinja2-time itself depends on python3-arrow, I have to add back the python3-arrow dependency (python3-cookiecutter still depends on python3-arrow).
3. Also, bump copyright version year (but that's just an addition.)
4. I am not bumping the SlackBuild build number.