### PR TITLE
python/pyfuse3: Updated deps

### DIFF
--- a/python/pyfuse3/pyfuse3.info
+++ b/python/pyfuse3/pyfuse3.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/libfuse/pyfuse3/releases/download/3.4.0/pyfuse3-3.4
 MD5SUM="08b7869fb0f0007bd3014c1ebfb212cd"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES=""
+REQUIRES="python3-trio"
 MAINTAINER="Sean Hinchee"
 EMAIL="henesy.dev@gmail.com"


### PR DESCRIPTION
Add Trio to the REQUIRES.
Trio is needed (at least) when pyfuse3 is used with borgfs.

NOTE:

I have the maintainer's permission to update the script.
