### PR TITLE
python/python3-formencode: Cleaned up REQUIRES

### DIFF
--- a/python/python3-formencode/python3-formencode.info
+++ b/python/python3-formencode/python3-formencode.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://pypi.python.org/packages/source/f/formencode/formencode-2.1.1.
 MD5SUM="d179386d31ae8c32e70d004dca19ac60"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-setuptools_scm_git_archive"
+REQUIRES=""
 MAINTAINER="Yth - Arnaud"
 EMAIL="yth@ythogtha.org"


### PR DESCRIPTION
I'll not even dignify that with a BUILD bump, the older requirement is not used anymore, and that's all, build is the same.