### PR TITLE
development/jupyter-ipykernel: Update tests to enable compatibility with python3-pytest 8

### DIFF
--- a/development/jupyter-ipykernel/add-compat-with-pytest-8.patch
+++ b/development/jupyter-ipykernel/add-compat-with-pytest-8.patch
@@ -1,0 +1,84 @@
+--- a/tests/__init__.py
++++ b/tests/__init__.py
+@@ -7,6 +7,8 @@
+ import tempfile
+ from unittest.mock import patch
+ 
++import pytest
++
+ from ipykernel.kernelspec import install
+ 
+ pjoin = os.path.join
+@@ -15,7 +17,8 @@
+ patchers: list = []
+ 
+ 
+-def setup():
++@pytest.fixture(autouse=True)
++def _global_setup():
+     """setup temporary env for tests"""
+     global tmp
+     tmp = tempfile.mkdtemp()
+@@ -34,9 +37,7 @@
+ 
+     # install IPython in the temp home:
+     install(user=True)
+-
+-
+-def teardown():
++    yield
+     for p in patchers:
+         p.stop()
+
+--- a/tests/test_async.py
++++ b/tests/test_async.py
+@@ -8,14 +8,13 @@
+ KC = KM = None
+ 
+ 
+-def setup_function():
++@pytest.fixture(autouse=True)
++def _setup_env():
+     """start the global kernel (if it isn't running) and return its client"""
+     global KM, KC
+     KM, KC = start_new_kernel()
+     flush_channels(KC)
+-
+-
+-def teardown_function():
++    yield
+     assert KC is not None
+     assert KM is not None
+     KC.stop_channels()
+--- a/tests/test_eventloop.py
++++ b/tests/test_eventloop.py
+@@ -42,14 +42,13 @@
+ _get_qt_vers()
+ 
+ 
+-def setup():
++@pytest.fixture(autouse=True)
++def _setup_env():
+     """start the global kernel (if it isn't running) and return its client"""
+     global KM, KC
+     KM, KC = start_new_kernel()
+     flush_channels(KC)
+-
+-
+-def teardown():
++    yield
+     assert KM is not None
+     assert KC is not None
+     KC.stop_channels()
+--- a/tests/test_message_spec.py
++++ b/tests/test_message_spec.py
+@@ -21,7 +21,8 @@
+ KC: BlockingKernelClient = None  # type:ignore
+ 
+ 
+-def setup():
++@pytest.fixture(autouse=True)
++def _setup_env():
+     global KC
+     KC = start_global_kernel()
+ 

--- a/development/jupyter-ipykernel/jupyter-ipykernel.SlackBuild
+++ b/development/jupyter-ipykernel/jupyter-ipykernel.SlackBuild
@@ -3,7 +3,7 @@
 # Slackware build script for jupyter-ipykernel
 
 # Copyright 2017-2021 Benjamin Trigona-Harany <slackbuilds@jaxartes.net>
-# Copyright 2022-2024 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2022-2025 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=jupyter-ipykernel
 VERSION=${VERSION:-6.29.5}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -64,6 +64,11 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# Update tests for compatibility with pytest 8
+# This fix has already been included in jupyter-ipykernel 6.30.0 
+# https://github.com/ipython/ipykernel/pull/1231
+patch -p1 < $CWD/add-compat-with-pytest-8.patch
 
 PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 export PYTHONPATH=/opt/python$PYVER/site-packages


### PR DESCRIPTION
jupyter-ipykernel 6.30.0 already includes this change.
However, its pyproject.toml states a requirement of packaging >= 22.0 (for context, Slackware 15.0 has packaging 21.3).

Therefore, I am not updating jupyter-ipykernel.
I am worried that updating jupyter-ipykernel 6.30.0 will break spyder.
Instead, I am uploading this patch in order to fix compatibility with python3-pytests >= 8.0.0.

Issue https://github.com/ipython/ipykernel/issues/1230 for your reference.

In addition, bump build number (as I am including this patch).

Debian also has included this patch:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1070112