### PR TITLE
system/pass-import: Update dependency from python3-zxcvbn-python to python3-zxcvbn

### DIFF
--- a/system/pass-import/pass-import.SlackBuild
+++ b/system/pass-import/pass-import.SlackBuild
@@ -29,7 +29,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=pass-import
 VERSION=${VERSION:-3.5}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 

--- a/system/pass-import/pass-import.info
+++ b/system/pass-import/pass-import.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/roddhjav/pass-import/releases/download/v3.5/pass-im
 MD5SUM="6eea4688951ab6c2fab5d3359468962c"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="password-store python3-zxcvbn-python"
+REQUIRES="password-store python3-zxcvbn"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
python3-zxcvbn is the new version of python3-zxcvbn-python.

Also, bump build number in accordance with dependency change.

In addition, there is a file at `/usr/lib/password-store/extensions/import.bash`.
Must I change it to `/usr/lib${LIBDIRSUFFIX}/password-store/extensions/import.bash` (for example, `/usr/lib64/password-store/extensions/import.bash`?)