### PR TITLE
desktop/qtile: Add ConsoleKit and DBus support options when starting qtile with a login manager

### DIFF
--- a/desktop/qtile/README
+++ b/desktop/qtile/README
@@ -12,3 +12,11 @@ notification daemon such as dunst for displaying notifications on qtile.
 This SlackBuild does not provide Wayland support. Slackware 15.0 is only
 able to build wlroots 0.15. qtile >= 0.26.0 requires wlroots 0.17 (which
 cannot be built with Slackware 15).
+
+To enable DBus support when starting up qtile using a login manager
+(ex. sddm), pass DBUS=yes to the SlackBuild:
+DBUS=yes ./qtile.SlackBuild
+
+To enable ConsoleKit and DBus support when starting up qtile using a
+login manager, pass CK=yes to the SlackBuild:
+CK=yes ./qtile.SlackBuild

--- a/desktop/qtile/qtile.SlackBuild
+++ b/desktop/qtile/qtile.SlackBuild
@@ -63,6 +63,19 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# Default options: DBUS=no CK=no
+# If DBUS=yes: The login manager (ex. sddm) starts qtile with DBus support
+# If CK=yes: The login manager starts qtile with ConsoleKit and DBus support
+# If DBUS=yes and CK=yes: Same result as CK=yes 
+[ ${DBUS:-no} = yes ] && sed -i "s/qtile start/dbus-launch --exit-with-session qtile start/g" resources/$PRGNAM.desktop
+if [ ${CK:-no} = yes ]; then
+  if [ $DBUS = yes ]; then
+    sed -i "s/dbus-launch/ck-launch-session dbus-launch/g" resources/$PRGNAM.desktop
+  else
+    sed -i "s/qtile start/ck-launch-session dbus-launch --exit-with-session qtile start/g" resources/$PRGNAM.desktop
+  fi
+fi
+
 PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 export PYTHONPATH=/opt/python$PYVER/site-packages/
 


### PR DESCRIPTION
This SlackBuild's xinitrc displays the following code for starting qtile:
```
if [ -z "$DESKTOP_SESSION" -a -x /usr/bin/ck-launch-session ]; then
 exec ck-launch-session dbus-launch --exit-with-session qtile start
else
 exec dbus-launch --exit-with-session qtile start
fi
````

I would like to adopt a similar (but not the same) line of logic for qtile's .desktop file.
By default, the .desktop file will run 'qtile start'.
If the user passes 'DBUS=yes', then the command will change to 'dbus-launch --exit-with-session qtile start'.
If the user instead passes 'CK=yes', then the command will change to 'ck-launch-session dbus-launch --exit-with-session qtile start'.
In case the user passes 'DBUS=yes CK=yes', I made sure that the behaviour is the same as that for 'CK=yes'.

To put this in more concrete terms:
If 'DBUS=yes', then the login manager (ex. sddm) starts qtile with DBus support.
If 'CK=yes', then the login manager starts qtile with DBus and ConsoleKit support.

I have not bumped the build number (if the user does not pass either DBUS=yes or CK=yes to ./qtile.SlackBuild, then the .desktop file does not change.)