### PR TITLE
desktop/rofi: Fix sbopkglint gripe - strip binary

### DIFF
--- a/desktop/rofi/rofi.SlackBuild
+++ b/desktop/rofi/rofi.SlackBuild
@@ -93,6 +93,8 @@ CXXFLAGS="$SLKCFLAGS" \
 make
 make install DESTDIR=$PKG PREFIX=/usr
 
+strip --strip-unneeded $PKG/usr/bin/rofi
+
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a AUTHORS Changelog COPYING INSTALL.md README.md \
    $PKG/usr/doc/$PRGNAM-$VERSION


### PR DESCRIPTION
I received the following error from running sbopkglint:
```
--- ELF object(s) not stripped:
-rwxr-xr-x 1 root root 531352 Aug  5 11:37 usr/bin/rofi
FAILED
```

Yesterday, I emailed the original maintainer (Andrew Payne) about this - however, he has not responded just yet.

I have not bumped the build number (no actual new feature is being added.)