### PR TITLE
multimedia/totem: Patch meson build for graphics-update.

### DIFF
--- a/multimedia/totem/bac013c6b7dda0f43a396af16f5c95b153c9137e.patch
+++ b/multimedia/totem/bac013c6b7dda0f43a396af16f5c95b153c9137e.patch
@@ -1,0 +1,39 @@
+From bac013c6b7dda0f43a396af16f5c95b153c9137e Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Thu, 6 Jan 2022 17:21:28 +0100
+Subject: [PATCH] build: Remove unused i18n.merge_file() "name"
+
+data/meson.build:78:0: ERROR: Function does not take positional arguments.
+data/appdata/meson.build:3:0: ERROR: Function does not take positional arguments.
+---
+ data/appdata/meson.build | 1 -
+ data/meson.build         | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/data/appdata/meson.build b/data/appdata/meson.build
+index c4d17e927..c2e646327 100644
+--- a/data/appdata/meson.build
++++ b/data/appdata/meson.build
+@@ -1,7 +1,6 @@
+ appdata = 'org.gnome.Totem.appdata.xml'
+ 
+ appdata_file = i18n.merge_file (
+-    'appdata',
+     input: appdata + '.in',
+     output: appdata,
+     install: true,
+diff --git a/data/meson.build b/data/meson.build
+index 4c6df3ba3..a1d0060de 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -69,7 +69,6 @@ desktop_in = configure_file(
+ )
+ 
+ desktop_file = i18n.merge_file (
+-    desktop,
+     type: 'desktop',
+     input: desktop_in,
+     output: desktop,
+-- 
+GitLab
+

--- a/multimedia/totem/totem.SlackBuild
+++ b/multimedia/totem/totem.SlackBuild
@@ -76,6 +76,10 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# Patch to fix building on slackware-15.0, when the updated graphics
+# packages from /testing are installed:
+patch -Np1 -i "$CWD/bac013c6b7dda0f43a396af16f5c95b153c9137e.patch"
+
 mkdir build
 cd build
   CFLAGS="$SLKCFLAGS" \


### PR DESCRIPTION
Added a patch from upstream which fixes building totem on Slackware-15.0 when the 'graphics-updates' from slackware-15.0's 'testing' branch are installed to the system.

Installations without the 'graphics-updates' installed are unaffected by the patch.