### PR TITLE
python/python3-trezor: Fix missing dep.

### DIFF
--- a/python/python3-trezor/python3-trezor.info
+++ b/python/python3-trezor/python3-trezor.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/t/trezor/trezor-0.13.10
 MD5SUM="487f8dcf2ea818fc5e0df54f309fe8d6"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="click python3-wheel python3-mnemonic python3-shamir-mnemonic python3-typing-extensions python3-construct-classes python3-slip10"
+REQUIRES="click python3-wheel python3-mnemonic python3-shamir-mnemonic python3-typing-extensions python3-construct-classes python3-slip10 python3-libusb1"
 MAINTAINER="nomnombtc"
 EMAIL="nomnombtc@arcor.de"


### PR DESCRIPTION
forgot to add python3-libusb1 to REQUIRES