### PR TITLE
development/rust-opt: Updated for version 1.89.0.

### DIFF
--- a/development/rust-opt/rust-opt.SlackBuild
+++ b/development/rust-opt/rust-opt.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust-opt
 SRCNAM=rust
-VERSION=${VERSION:-1.88.0}
+VERSION=${VERSION:-1.89.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/development/rust-opt/rust-opt.info
+++ b/development/rust-opt/rust-opt.info
@@ -1,12 +1,12 @@
 PRGNAM="rust-opt"
-VERSION="1.88.0"
+VERSION="1.89.0"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2025-06-26/rust-1.88.0-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2025-06-26/rust-1.88.0-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="07b612dc8f027c4a34d540c965b0f4e8 \
-        a87b223e2e4bd6b347bc0309f76c035b"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2025-06-26/rust-1.88.0-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="93c089e4fc20f840065493234ab7ee65"
+DOWNLOAD="https://static.rust-lang.org/dist/2025-08-07/rust-1.89.0-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2025-08-07/rust-1.89.0-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="371ded03468db5a803b03d282ddf156c \
+        d2123e53b49308773e227f1eb44bd5bd"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2025-08-07/rust-1.89.0-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="03fe43e1e0808c17d536f69698039a6b"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"

--- a/development/rust-opt/slack-desc
+++ b/development/rust-opt/slack-desc
@@ -11,7 +11,7 @@ rust-opt:
 rust-opt: rust-opt installs a limited set of up-to-date Rust stable binaries to
 rust-opt: /opt/rust for use in SlackBuilds.
 rust-opt:
-rust-opt: See /usr/doc/rust-opt-1.88.0/README.sw for usage instructions.
+rust-opt: See /usr/doc/rust-opt-1.89.0/README.sw for usage instructions.
 rust-opt:
 rust-opt:
 rust-opt:


### PR DESCRIPTION
@aclemons I got an "exec format error" when trying to run the slackware-arm docker image (never seen that before; reinstalling docker and qemu didn't help), so the arm build/deps haven't been tested.

EDIT: Mystery solved. The "binfmt_misc" file system wasn't mounted. No idea how or why that happened. Testing for arm is underway, ETA several hours from now. I'll comment again if something goes awry.