### PR TITLE
network/Electrum: Update README

### DIFF
--- a/network/Electrum/README
+++ b/network/Electrum/README
@@ -3,4 +3,14 @@ Electrum is an easy to use Bitcoin client.
 There is no waiting time when you start the client, because it does
 not download the Bitcoin blockchain.
 
-zbar is an optional dependency (enables scanning QRCodes).
+Optional dependencies:
+zbar (enables scanning QRCodes)
+python3-trezor (Trezor hardware wallet)
+
+Please Note:
+- Electrum 4.5.8 is the last direct supported version for Slackware 15.0.
+  Newer versions will require a minimum python3 version 3.10.
+
+- However, it is possible to use an "AppImage" provided by Electrum at
+  the URL linked below (or in the Electrum.info file). This also
+  works on Slackware 15.0 as an option to run newer versions.


### PR DESCRIPTION
This only updates the README file, no changes to the script itself.

informs the user that newer version would require python3.10, but that
there is also the option to use an APPImage provided by upstreams website.