### PR TITLE
system/OpenSnitch: Fix build error

### DIFF
--- a/system/OpenSnitch/OpenSnitch.SlackBuild
+++ b/system/OpenSnitch/OpenSnitch.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=OpenSnitch
 VERSION=${VERSION:-1.6.8}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -103,6 +103,10 @@ SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")
 # Prevent creation of cache files in /root/.cache/go-build
 export GOCACHE="${GOCACHE:-"$TMP/$SRCNAM-$VERSION/go-cache"}"
 export GOMODCACHE="${GOMODCACHE:-"$TMP/$SRCNAM-$VERSION/go"}"
+
+# Fix build error with grpc_tools.protoc
+# See https://github.com/evilsocket/opensnitch/issues/1429 for more details
+sed -i 's/grpc_tools.protoc/grpc_tools.protoc --experimental_editions/' proto/Makefile
 
 # Generate protobuf files
 cd proto


### PR DESCRIPTION
I received the following error when building OpenSnitch:
```
6 warnings generated.
llc -march=bpf -mcpu=generic -filetype=obj -o opensnitch.o opensnitch.bc
rm opensnitch-procs.bc opensnitch.bc opensnitch-dns.bc
protoc -I. ui.proto --go_out=../daemon/ui/protocol/ --go-grpc_out=../daemon/ui/protocol/ --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative
python3 -m grpc_tools.protoc -I. --python_out=../ui/opensnitch/proto/ --grpc_python_out=../ui/opensnitch/proto/ ui.proto
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1758082783.173534   30973 command_line_interface.cc:1557] Built-in generator --grpc_python_out specifies a maximum edition 2023 which is not the protoc maximum 2024.
make: *** [Makefile:7: ../ui/opensnitch/ui_pb2.py] Error 1
```

The line `sed -i 's/grpc_tools.protoc/grpc_tools.protoc --experimental_editions/' proto/Makefile` fixes this error.
See https://github.com/evilsocket/opensnitch/issues/1429 for further context.

I am keeping OpenSnitch at version 1.6.8 (I still have not found out how to get opensnitch-ui to run successfully on later versions of OpenSnitch.)

Also:
1. Bump build number accordingly (the build failure warrants said bump.)
2. I found this out on Slackware current (this error might not be on Slackware 15.)