### PR TITLE
python/python3-pyinotify: If using Slackware current, make asyncore support optional

### DIFF
--- a/python/python3-pyinotify/pyinotify-python-3.12-fix.patch
+++ b/python/python3-pyinotify/pyinotify-python-3.12-fix.patch
@@ -1,0 +1,77 @@
+Make asyncore support optional for Python 3.
+Patch taken from Arch Linux:
+https://gitlab.archlinux.org/archlinux/packaging/packages/python-pyinotify/-/blob/main/pyinotify-python-3.12-fix.patch
+diff --git a/python3/pyinotify.py b/python3/pyinotify.py
+index bc24313..f4a5a90 100755
+--- a/python3/pyinotify.py
++++ b/python3/pyinotify.py
+@@ -68,7 +68,6 @@ from collections import deque
+ from datetime import datetime, timedelta
+ import time
+ import re
+-import asyncore
+ import glob
+ import locale
+ import subprocess
+@@ -1494,33 +1493,40 @@ class ThreadedNotifier(threading.Thread, Notifier):
+         self.loop()
+ 
+ 
+-class AsyncNotifier(asyncore.file_dispatcher, Notifier):
+-    """
+-    This notifier inherits from asyncore.file_dispatcher in order to be able to
+-    use pyinotify along with the asyncore framework.
++try:
++    import asyncore
+ 
+-    """
+-    def __init__(self, watch_manager, default_proc_fun=None, read_freq=0,
+-                 threshold=0, timeout=None, channel_map=None):
++    class AsyncNotifier(asyncore.file_dispatcher, Notifier):
+         """
+-        Initializes the async notifier. The only additional parameter is
+-        'channel_map' which is the optional asyncore private map. See
+-        Notifier class for the meaning of the others parameters.
++        This notifier inherits from asyncore.file_dispatcher in order to be able to
++        use pyinotify along with the asyncore framework.
+ 
+         """
+-        Notifier.__init__(self, watch_manager, default_proc_fun, read_freq,
+-                          threshold, timeout)
+-        asyncore.file_dispatcher.__init__(self, self._fd, channel_map)
++        def __init__(self, watch_manager, default_proc_fun=None, read_freq=0,
++                     threshold=0, timeout=None, channel_map=None):
++            """
++            Initializes the async notifier. The only additional parameter is
++            'channel_map' which is the optional asyncore private map. See
++            Notifier class for the meaning of the others parameters.
+ 
+-    def handle_read(self):
+-        """
+-        When asyncore tells us we can read from the fd, we proceed processing
+-        events. This method can be overridden for handling a notification
+-        differently.
++            """
++            Notifier.__init__(self, watch_manager, default_proc_fun, read_freq,
++                              threshold, timeout)
++            asyncore.file_dispatcher.__init__(self, self._fd, channel_map)
+ 
+-        """
+-        self.read_events()
+-        self.process_events()
++        def handle_read(self):
++            """
++            When asyncore tells us we can read from the fd, we proceed processing
++            events. This method can be overridden for handling a notification
++            differently.
++
++            """
++            self.read_events()
++            self.process_events()
++except ImportError:
++    # asyncore was removed in Python 3.12, but try the import instead of a
++    # version check in case the compatibility package is installed.
++    pass
+ 
+ 
+ class TornadoAsyncNotifier(Notifier):

--- a/python/python3-pyinotify/python3-pyinotify.SlackBuild
+++ b/python/python3-pyinotify/python3-pyinotify.SlackBuild
@@ -3,7 +3,7 @@
 # Slackware build script for python3-pyinotify
 
 # Copyright 2012-2015 Larry Hajali <larryhaja[at]gmail[dot]com>
-# Copyright 2024 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2024-2025 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -67,6 +67,15 @@ find -L . \
 
 # Compile the C extension.
 sed -i '/^compile_ext_mod/s|=.*|= True|' setup.py
+
+# Make asyncore support optional for Python 3. 
+# This patch is for Slackware current.
+# See https://github.com/seb-m/pyinotify/issues/204 for more details
+PYVER_MAJOR=$(python3 -c 'import sys; print("%d" % sys.version_info.major)')
+PYVER_MINOR=$(python3 -c 'import sys; print("%d" % sys.version_info.minor)')
+if [[ $PYVER_MAJOR == 3 ]] && [[ $PYVER_MINOR -ge 12 ]]; then
+  patch -p1 < $CWD/pyinotify-python-3.12-fix.patch
+fi
 
 python3 setup.py install --root=$PKG
 


### PR DESCRIPTION
This pull request is actually for Slackware current.

Nonetheless, I can still make it on this repo (for Slackware 15.0).

The context is that asyncore is removed in Python 3.12 (the version which is on Slackware current).
This patch addresses this issue (but will only activate if Python is at >= 3.12).