### PR TITLE
system/lightdm: Add pam rules for fscrypt

### DIFF
--- a/system/lightdm/README
+++ b/system/lightdm/README
@@ -14,3 +14,8 @@ Then, edit /etc/rc.d/rc.4 and add the following section:
 if [ -x /usr/bin/lightdm ]; then
   exec /usr/bin/lightdm
 fi
+
+
+To enable automatic unlocking of password-protected directories upon
+login, pass FSCRYPT=yes to the SlackBuild.
+This is useful (ex. when encrypting the /home directory with fscrypt).

--- a/system/lightdm/lightdm.SlackBuild
+++ b/system/lightdm/lightdm.SlackBuild
@@ -142,6 +142,12 @@ rm -rf $PKG/etc/apparmor.d
 # PAM
 cp $CWD/pam.d/* $PKG/etc/pam.d/
 
+# If FSCRYPT=yes is passed, add these PAM rules (to automatically unlock password-protected directories upon login)
+if [ ${FSCRYPT:no} = yes ]; then
+  sed -i '/-auth     optional pam_kwallet5.so/a-auth     optional pam_fscrypt.so' $PKG/etc/pam.d/lightdm
+  sed -i '/-session  optional pam_ck_connector.so nox11/a-session  optional pam_fscrypt.so' $PKG/etc/pam.d/lightdm
+fi
+
 # PolicyKit
 mkdir -p -m700 $PKG/usr/share/polkit-1/rules.d
 chown polkitd $PKG/usr/share/polkit-1/rules.d


### PR DESCRIPTION
If I add the following rules to `/etc/pam.d/login`:
```
auth            optional        pam_fscrypt.so
session         optional        pam_fscrypt.so
```

And to `/etc/pam.d/passwd`:

```
password        optional        pam_fscrypt.so
```

Since I use fscrypt to encrypt /home, if I log in through the console (ex. tty1), then fscrypt automatically decrypts upon login.
However, this is not the case if I log in through lightdm.

I would like to correct this. I have added the option FSCRYPT=yes to pass onto the SlackBuild (if passed, add pam rules to allow automatic unlocking of fscrypt-encrypted directories.)