### PR TITLE
system/pass-import: Fix python3-zxcvbn ValueError

### DIFF
--- a/system/pass-import/pass-import.SlackBuild
+++ b/system/pass-import/pass-import.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for pass-import
 
-# Copyright 2021-2024 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2021-2025 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -29,7 +29,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=pass-import
 VERSION=${VERSION:-3.5}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -64,6 +64,10 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \+ -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \+
+
+# Workaround for python3-zxcvbn ValueError
+# See https://github.com/roddhjav/pass-import/issues/228 for more information
+sed -i "s/user_inputs=user_input/user_inputs=user_input, max_length=178/g" pass_import/audit.py
 
 python3 setup.py install --root=$PKG
 


### PR DESCRIPTION
This is the error that I received from importing a keepass database (I ran `pass import keepassxc Database_name.kdbx`):

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/lib/python3.12/site-packages/pass_import/__main__.py", line 519, in <module>
    main()
  File "/usr/lib/python3.12/site-packages/pass_import/__main__.py", line 512, in main
    paths_imported, paths_exported, audit = pass_export(conf, cls_export, data)
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/pass_import/__main__.py", line 400, in pass_export
    report = exporter.audit(conf['pwned'])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/pass_import/manager.py", line 186, in audit
    audit.zxcvbn()
  File "/usr/lib/python3.12/site-packages/pass_import/audit.py", line 95, in zxcvbn
    results = zxcvbn(password, user_inputs=user_input, max_length=72)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/zxcvbn/__init__.py", line 10, in zxcvbn
    raise ValueError(f"Password exceeds max length of {max_length} characters.")
ValueError: Password exceeds max length of 72 characters.
```

I would like to fix this error.
This is the code snippet for doing so:
`sed -i "s/user_inputs=user_input/user_inputs=user_input, max_length=178/g" pass_import/audit.py`

I would also like to get this fixed on upstream (so that I can then retract this fix on Slackware.)
However, I have not formalized what the upstream fix would look like.