### PR TITLE
multimedia/popcorntime: Download URL update.

### DIFF
--- a/multimedia/popcorntime/popcorntime.info
+++ b/multimedia/popcorntime/popcorntime.info
@@ -1,13 +1,13 @@
 PRGNAM="popcorntime"
 VERSION="0.5.1"
 HOMEPAGE="https://popcorn-time.site/"
-DOWNLOAD="https://github.com/popcorn-official/popcorn-desktop/archive/v0.5.1/popcorn-desktop-0.5.1.tar.gz \
+DOWNLOAD="https://sbo.t-rg.ws/popcorn-desktop-0.5.1.tar.gz \
           https://sbo.t-rg.ws/popcorntime-0.5.1-vendored-sources.tar \
           https://popcorn-time.serv00.net/nw/v0.44.5/nwjs-sdk-v0.44.5-linux-ia32.tar.gz"
 MD5SUM="11bcb10ac85da77b619247e924958127 \
         9a5ece4a5dc8680db6c5b8be9baa9e85 \
         f2b279adc41d43f9d48307f2decb45e1"
-DOWNLOAD_x86_64="https://github.com/popcorn-official/popcorn-desktop/archive/v0.5.1/popcorn-desktop-0.5.1.tar.gz \
+DOWNLOAD_x86_64="https://sbo.t-rg.ws/popcorn-desktop-0.5.1.tar.gz \
                  https://sbo.t-rg.ws/popcorntime-0.5.1-vendored-sources.tar \
                  https://popcorn-time.serv00.net/nw/v0.86.0/nwjs-sdk-v0.86.0-linux-x64.tar.gz"
 MD5SUM_x86_64="11bcb10ac85da77b619247e924958127 \


### PR DESCRIPTION
There was a hostile takeover of the upstream repo by previous developers who completely wiped the code and all uploaded artifacts. I'll mirror the sources for now, in the meantime I'll look into other forks.