### PR TITLE
development/jupyter-ipykernel: Update README

### DIFF
--- a/development/jupyter-ipykernel/README
+++ b/development/jupyter-ipykernel/README
@@ -1,1 +1,5 @@
 Python 3 kernel for Jupyter.
+
+Later versions of jupyter-ipykernel (i.e. at >= 6.30.0) depend on
+python-packaging >= 22.0 (Slackware 15.0 has python-packaging 21.3).
+Therefore, on Slackware 15.0, jupyter-ipykernel should remain at 6.29.5.


### PR DESCRIPTION
jupyter-ipykernel >= 6.30.0 requires python-packaging >= 22.0.

Update README to indicate why jupyter-ipykernel should not be updated.