### PR TITLE
libraries/libminizip: Update README

### DIFF
--- a/libraries/libminizip/README
+++ b/libraries/libminizip/README
@@ -1,2 +1,7 @@
 libminizip is the small library to compress and uncompress zip files
 with the help of zlib.
+
+The version of libminizip at SlackBuilds.org corresponds to the current
+version of zlib on the official Slackware repository. For instance,
+since Slackware 15.0 has zlib 1.2.13, libminizip on SlackBuilds.org is
+also at 1.2.13.


### PR DESCRIPTION
Update README.
Explain why I am keeping libminizip at version 1.2.13.