### PR TITLE
libraries/lxqt-build-tools: Update README and slack-desc

### DIFF
--- a/libraries/lxqt-build-tools/README
+++ b/libraries/lxqt-build-tools/README
@@ -3,3 +3,6 @@ LXQt applications.
 
 lxqt-build-tools providing several tools needed to build LXQt itself
 as well as other components maintained by the LXQt project.
+
+This SlackBuild (which supports qt5) can be installed alongside
+lxqt-build-tools-qt6.

--- a/libraries/lxqt-build-tools/slack-desc
+++ b/libraries/lxqt-build-tools/slack-desc
@@ -11,7 +11,7 @@ lxqt-build-tools:
 lxqt-build-tools: lxqt-build-tools is a set of various packaging tools and scripts for
 lxqt-build-tools: LXQt applications.
 lxqt-build-tools:
-lxqt-build-tools: homepage: https://github.com/lxde/lxqt-build-tools
+lxqt-build-tools: Homepage: https://github.com/lxqt/lxqt-build-tools
 lxqt-build-tools:
 lxqt-build-tools:
 lxqt-build-tools:


### PR DESCRIPTION
*Update 1: I have edited the README slightly and rebased the pull request accordingly.

I am about to upload lxqt-build-tools-qt6.

@LinRs is working on updating qt6 to 6.8.3.
To update LXQt to >=2.0.0, qt6 >= 6.6.0 is required.
My plan is to (gradually) update the LXQt SlackBuilds accordingly (once @LinRs successfully updates qt6).