### PR TITLE
python/python3-webcolors: Update README

### DIFF
--- a/python/python3-webcolors/README
+++ b/python/python3-webcolors/README
@@ -1,1 +1,4 @@
 webcolors is a module for working with HTML/CSS color definitions.
+
+python3-webcolors 24.11.1 is the last available version for Slackware
+15.0. Later versions require Python >= 3.10.


### PR DESCRIPTION
The source pyproject.toml indicates that python3-webcolors 25.11.0 (the latest version) does not support Python 3.9:
```
requires-python = ">=3.10"
```

Also, please view this commit (further supporting my finding):
https://github.com/ubernostrum/webcolors/commit/ab9328be645d107f25e37b5f7c0acbd1802a94f5