### PR TITLE
libraries/re2: Update README (Why re2 cannot be updated)

### DIFF
--- a/libraries/re2/README
+++ b/libraries/re2/README
@@ -1,1 +1,4 @@
 Fast, safe, thread-friendly regular expression engine.
+
+On Slackware 15.0, later versions of re2 (i.e. at >= 2025-11-05) require
+a newer Python (>= 3.10).


### PR DESCRIPTION
The version of re2 that has just been released (2025-11-05) has dropped support for Python 3.9.

Please view this commit for more details:
https://github.com/google/re2/commit/11c643a48e5d05c7a10c17a7b175ab8da263a623