### PR TITLE
python/python3-pynacl: Update README

### DIFF
--- a/python/python3-pynacl/README
+++ b/python/python3-pynacl/README
@@ -2,3 +2,6 @@ PyNaCl is a Python binding to libsodium, which is a fork of the
 Networking and Cryptography library. These libraries have a stated goal
 of improving usability, security and speed. It supports Python 3.8+ as
 well as PyPy 3.
+
+python3-pynacl 1.6.0 is the last available version for Slackware 15.0.
+Newer versions require cffi >= 2.0.0.


### PR DESCRIPTION
Upstream has updated the list of dependencies. From the source pyproject.toml:
```
requires = [
    "setuptools>=61.0.0,!=74.0.0",
    "wheel",
    "cffi>=1.4.1; platform_python_implementation != 'PyPy' and python_version < '3.9'",
    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.9'",
]
```

Please read https://github.com/pyca/pynacl/pull/894 for more details.