### PR TITLE
games/pcsx2: Updated for version 2.4.0.

### DIFF
--- a/games/pcsx2/README
+++ b/games/pcsx2/README
@@ -1,16 +1,17 @@
-PCSX2 is a free and open-source PlayStation 2 (PS2) emulator. Its
-purpose is to emulate the PS2's hardware, using a combination of MIPS
-CPU Interpreters, Recompilers and a Virtual Machine which manages
-hardware states and PS2 system memory. This allows you to play PS2
-games on your PC, with many additional features and benefits.
+pcsx2 (PlayStation 2 emulator)
+
+PCSX2 is a free and open-source PlayStation 2 (PS2) emulator.
+
+Its purpose is to emulate the PS2's hardware, using a combination of
+MIPS CPU Interpreters, Recompilers and a Virtual Machine which manages
+hardware states and PS2 system memory.
 
 PCSX2 requires a CPU that supports the SSE4.1 instruction set.
+
 Check your processor flags with lscpu for sse4_1.
 
 PCSX2 requires a GPU that supports OpenGL 3.3 or Vulkan 1.1.
 
-RetroAchievements are enabled by default, to disable this
-functionality, pass ACHIEVEMENTS=OFF to the build script.
-
-Discord Rich Presence is disabled by default, to enable Discord
-functionality, pass DISCORD=ON to the build script.
+LLVM_OPT: llvm-opt is enabled by default, since upstream only supports
+clang. If you already installed llvm >=17 from extra or used llvm in
+current branch, LLVM_OPT could be disabled with LLVM_OPT=OFF.

--- a/games/pcsx2/pcsx2.SlackBuild
+++ b/games/pcsx2/pcsx2.SlackBuild
@@ -3,6 +3,7 @@
 # Slackware build script for pcsx2
 
 # Copyright 2022-2024 Steven Voges <Oregon, USA>
+# Copyright 2025 Ruoh-Shoei LIN
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -25,18 +26,26 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=pcsx2
-VERSION=${VERSION:-1.7.3772}
-COMMIT=$(echo $VERSION | cut -c 5-)
-SRCVER=${SRCVER:-7cb22815e63df2def2f5e5d008ef1b91b895130a}
-FMT=${FMT:-a33701196adfad74917046096bf5a2aa0ab0bb50}
-GLSLANG=${GLSLANG:-c9706bdda0ac22b9856f1aa8261e5b9e15cd20c5}
-LIBCHDR=${LIBCHDR:-5de1a59019815ccdbba0fe07c71b31406d023248}
-RCHEEVOS=${RCHEEVOS:-31f8788fe0e694e99db7ce138d45a655c556fa96}
-VULKANHEADERS=${VULKANHEADERS:-9f4c61a31435a7a90a314fc68aeb386c92a09c0f}
-ACHIEVEMENTS=$ACHIEVEMENTS=:-ON}
-DISCORD=${DISCORD:-OFF}
-QT=${QT:-OFF}
-WAYLAND=${WAYLAND:-ON}
+VERSION=${VERSION:-2.4.0}
+PATCHVER=${PATCHVER:-2fdc835f0725b318efcdaae84db1c73a9139b6f6}
+GIT_DATE=${GIT_DATE:-2025-06-29 15:47:12 -0400}
+GIT_VERSION=${GIT_VERSION:-v2.4.0}
+GIT_HASH=${GIT_HASH:-e4af1c424451c6b65c5c387404315cef77e9901b}
+
+LIBBACKTRACE=${LIBBACKTRACE:-ad106d5fdd5d960bd33fae1c48a351af567fd075}
+LIBJPEGTURBO=${LIBJPEGTURBO:-3.1.0}
+LIBPNG=${LIBPNG:-1.6.48}
+LIBWEBP=${LIBWEBP:-1.5.0}
+SDL=${SDL:-3.2.14}
+LZ4=${LZ4:-1.10.0}
+ZSTD=${ZSTD:-1.5.7}
+KDDOCKWIDGETS=${KDDOCKWIDGETS:-2.2.3}
+PLUTOVG=${PLUTOVG:-0.0.13}
+PLUTOSVG=${PLUTOSVG:-0.0.6}
+SHADERC=${SHADERC:-2024.1}
+SHADERC_GLSLANG=${SHADERC_GLSLANG:-142052fa30f9eca191aa9dcf65359fcaed09eeec}
+SHADERC_SPIRVHEADERS=${SHADERC_SPIRVHEADERS:-5e3ad389ee56fca27c9705d093ae5387ce404df4}
+SHADERC_SPIRVTOOLS=${SHADERC_SPIRVTOOLS:-dd4b663e13c07fea4fbb3f70c1c91c86731099f7}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -57,7 +66,7 @@ fi
 TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
-DEPS=$TMP/$PRGNAM-$SRCVER/3rdparty
+DEPS=$TMP/$PRGNAM-$VERSION/deps
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -78,23 +87,32 @@ set -e
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
-rm -rf $PRGNAM-$SRCVER
-tar xvf $CWD/$PRGNAM-$SRCVER.tar.gz
-cd $PRGNAM-$SRCVER
+rm -rf $PRGNAM-$VERSION
+tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
+cd $PRGNAM-$VERSION
 
-tar xvf $CWD/fmt-$FMT.tar.gz -C \
-  $DEPS/fmt/fmt --strip-components 1
-tar xvf $CWD/glslang-$GLSLANG.tar.gz -C \
-  $DEPS/glslang/glslang --strip-components 1
-tar xvf $CWD/libchdr-$LIBCHDR.tar.gz -C \
-  $DEPS/libchdr/libchdr --strip-components 1
-tar xvf $CWD/rcheevos-$RCHEEVOS.tar.gz -C \
-  $DEPS/rcheevos/rcheevos --strip-components 1
-tar xvf $CWD/Vulkan-Headers-$VULKANHEADERS.tar.gz -C \
-  $DEPS/vulkan-headers --strip-components 1
-
-sed -i "s/#define PCSX2_VersionLo     0/#define PCSX2_VersionLo     ${COMMIT}/g" \
-  pcsx2/SysForwardDefs.h
+mkdir -p ${DEPS}-build
+pushd ${DEPS}-build
+tar xvf $CWD/KDDockWidgets-$KDDOCKWIDGETS.tar.gz
+tar xvf $CWD/SDL3-$SDL.tar.gz
+tar xvf $CWD/libbacktrace-$LIBBACKTRACE.tar.gz
+tar xvf $CWD/libjpeg-turbo-$LIBJPEGTURBO.tar.gz
+tar xvf $CWD/libpng-$LIBPNG.tar.xz
+tar xvf $CWD/libwebp-$LIBWEBP.tar.gz
+tar xvf $CWD/lz4-$LZ4.tar.gz
+tar xvf $CWD/plutosvg-$PLUTOSVG.tar.gz
+tar xvf $CWD/plutovg-$PLUTOVG.tar.gz
+tar xvf $CWD/shaderc-$SHADERC.tar.gz
+mkdir -p shaderc-$SHADERC/third_party/{glslang,spirv-headers,spirv-tools}
+tar xvf $CWD/glslang-$SHADERC_GLSLANG.tar.gz \
+    -C shaderc-$SHADERC/third_party/glslang --strip-components=1
+tar xvf $CWD/SPIRV-Headers-$SHADERC_SPIRVHEADERS.tar.gz \
+    -C shaderc-$SHADERC/third_party/spirv-headers --strip-components=1
+tar xvf $CWD/SPIRV-Tools-$SHADERC_SPIRVTOOLS.tar.gz \
+    -C shaderc-$SHADERC/third_party/spirv-tools --strip-components=1
+tar xvf $CWD/zstd-$ZSTD.tar.gz
+tar xvf $CWD/${PRGNAM}_patches-${PATCHVER}.tar.gz
+popd
 
 chown -R root:root .
 find -L . \
@@ -103,48 +121,84 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+echo "#define DEFAULT_UPDATER_CHANNEL \"stable\"" > ./pcsx2-qt/DefaultUpdaterChannel.h
+sed -i '37,83d;149,219d;252,259d;265,268d;/rm -fr \"/d;/unzip \"/d;/tar xf \"/d;' \
+    ./.github/workflows/scripts/linux/build-dependencies-qt.sh
+CFLAGS="$SLKCFLAGS" CXXFLAGS="$SLKCFLAGS" \
+    .github/workflows/scripts/linux/build-dependencies-qt.sh deps
+
+if [ "${LLVM_OPT:-ON}" = "ON" ]; then
+    export PATH="/opt/llvm-opt/bin:$PATH"
+    if [ -z "$LD_LIBRARY_PATH" ]; then
+	export LD_LIBRARY_PATH="/opt/llvm-opt/lib$LIBDIRSUFFIX"
+    else
+	export LD_LIBRARY_PATH="/opt/llvm-opt/lib$LIBDIRSUFFIX:$LD_LIBRARY_PATH"
+    fi
+fi
+
 mkdir -p build
 cd build
-  cmake \
-    -Wno-dev \
+  cmake -GNinja \
     -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
     -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
     -DCMAKE_INSTALL_PREFIX=/usr \
-    -DCMAKE_BUILD_STRIP=ON \
-    -DDISABLE_PCSX2_WRAPPER=ON \
-    -DDISABLE_SETCAP=ON \
-    -DENABLE_TESTS=OFF \
+    -DLIB_SUFFIX=${LIBDIRSUFFIX} \
+    -DMAN_INSTALL_DIR=/usr/man \
+    -DCMAKE_PREFIX_PATH="${DEPS}" \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld -lrt" \
+    -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld -lrt" \
+    -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld -lrt" \
+    -DENABLE_SETCAP=OFF \
     -DPACKAGE_MODE=ON \
-    -DQT_BUILD=$QT \
-    -DUSE_ACHIEVEMENTS=$ACHIEVEMENTS \
-    -DUSE_DISCORD_PRESENCE=$DISCORD \
-    -DUSE_SYSTEM_FMT=OFF \
-    -DUSE_VULKAN=ON \
-    -DWAYLAND_API=$WAYLAND \
-    -DXDG_STD=ON \
+    -DDISABLE_ADVANCE_SIMD=ON \
+    -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
+    -DPCSX2_APP_DATADIR=/usr/share/PCSX2/resources \
     -DCMAKE_BUILD_TYPE=Release ..
-  make
-  make install/strip DESTDIR=$PKG
+  ninja
+  ninja unittests
+  DESTDIR=$PKG ninja install
 cd ..
+
+install -v -Dm644 ./bin/resources/icons/AppIconLarge.png \
+	$PKG/usr/share/icons/hicolor/512x512/apps/net.pcsx2.PCSX2.png
+install -v -Dm644 ./.github/workflows/scripts/linux/pcsx2-qt.desktop \
+	$PKG/usr/share/applications/net.pcsx2.PCSX2.desktop
+desktop-file-edit \
+    --set-key=Icon \
+    --set-value=net.pcsx2.PCSX2 \
+    --set-key=Exec \
+    --set-value="env LD_LIBRARY_PATH=/usr/lib$LIBDIRSUFFIX/pcsx2 pcsx2-qt" \
+    $PKG/usr/share/applications/net.pcsx2.PCSX2.desktop
+sed -i \
+    "s/@GIT_VERSION@/$GIT_VERSION/g;s/@GIT_DATE@/$GIT_DATE/g;s/@GIT_HASH@/$GIT_HASH/g" \
+    .github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
+install -v -Dm644 .github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in \
+	$PKG/usr/share/metainfo/net.pcsx2.PCSX2.metainfo.xml
+install -v -dm755 "$PKG/usr/lib${LIBDIRSUFFIX}/$PRGNAM"
+find "$DEPS/lib${LIBDIRSUFFIX}" -maxdepth 1 ! -type d \
+     -exec cp -av '{}' "$PKG/usr/lib${LIBDIRSUFFIX}/$PRGNAM" \;
+
+# pcsx2_patches, collection of game patches (e.g. widescreen hacks)
+zip -mTj9 \
+    $CWD/patches.zip \
+    ${DEPS}-build/${PRGNAM}_patches-${PATCHVER}/patches/*
+install -Dm644 $CWD/patches.zip -t $PKG/usr/share/PCSX2/resources
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
-mv $PKG/usr/share/man $PKG/usr/man
-find $PKG/usr/man -type f -exec gzip -9 {} \;
-for i in $( find $PKG/usr/man -type l ) ; do ln -s $( readlink $i ).gz $i.gz ; rm $i ; done
-
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \
-  COPYING.* README.md \
+  COPYING.* README.md bin/docs \
   $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
-mv $PKG/usr/share/doc/Pcsx2/* $PKG/usr/doc/$PRGNAM-$VERSION
-rm -r $PKG/usr/share/doc
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc
 cat $CWD/doinst.sh > $PKG/install/doinst.sh
 
 cd $PKG
-/sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE
+/sbin/makepkg -l y -c n --remove-rpaths $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE

--- a/games/pcsx2/pcsx2.info
+++ b/games/pcsx2/pcsx2.info
@@ -1,20 +1,40 @@
 PRGNAM="pcsx2"
-VERSION="1.7.3772"
+VERSION="2.4.0"
 HOMEPAGE="https://pcsx2.net"
 DOWNLOAD="UNSUPPORTED"
 MD5SUM=""
-DOWNLOAD_x86_64="https://github.com/PCSX2/pcsx2/archive/7cb22815e63df2def2f5e5d008ef1b91b895130a/pcsx2-7cb22815e63df2def2f5e5d008ef1b91b895130a.tar.gz \
-                 https://github.com/KhronosGroup/Vulkan-Headers/archive/9f4c61a31435a7a90a314fc68aeb386c92a09c0f/Vulkan-Headers-9f4c61a31435a7a90a314fc68aeb386c92a09c0f.tar.gz \
-                 https://github.com/fmtlib/fmt/archive/a33701196adfad74917046096bf5a2aa0ab0bb50/fmt-a33701196adfad74917046096bf5a2aa0ab0bb50.tar.gz \
-                 https://github.com/KhronosGroup/glslang/archive/c9706bdda0ac22b9856f1aa8261e5b9e15cd20c5/glslang-c9706bdda0ac22b9856f1aa8261e5b9e15cd20c5.tar.gz \
-                 https://github.com/rtissera/libchdr/archive/5de1a59019815ccdbba0fe07c71b31406d023248/libchdr-5de1a59019815ccdbba0fe07c71b31406d023248.tar.gz \
-                 https://github.com/RetroAchievements/rcheevos/archive/31f8788fe0e694e99db7ce138d45a655c556fa96/rcheevos-31f8788fe0e694e99db7ce138d45a655c556fa96.tar.gz"
-MD5SUM_x86_64="a9c767fd77587be7cec5c7932b772027 \
-               d3ccd22b8486dae09a44462b2f06b7e8 \
-               5069920ee4e07003d7b135d0d477ced8 \
-               e2f744abeca9a55aa7e49e652a983ebd \
-               fc702efac9ba601156c27f7fc7055f98 \
-               cb03a7c28b5a9b184f609f2c9b0c6fae"
-REQUIRES="fast_float rapidyaml soundtouch wxWidgets zstd-cmake"
-MAINTAINER="Steven Voges"
-EMAIL="svoges.sbo@gmail.com"
+DOWNLOAD_x86_64="https://github.com/KDAB/KDDockWidgets/archive/v2.2.3/KDDockWidgets-2.2.3.tar.gz \
+		 https://libsdl.org/release/SDL3-3.2.14.tar.gz \
+		 https://github.com/KhronosGroup/SPIRV-Headers/archive/5e3ad389ee56fca27c9705d093ae5387ce404df4/SPIRV-Headers-5e3ad389ee56fca27c9705d093ae5387ce404df4.tar.gz \
+		 https://github.com/KhronosGroup/SPIRV-Tools/archive/dd4b663e13c07fea4fbb3f70c1c91c86731099f7/SPIRV-Tools-dd4b663e13c07fea4fbb3f70c1c91c86731099f7.tar.gz \
+		 https://github.com/KhronosGroup/glslang/archive/142052fa30f9eca191aa9dcf65359fcaed09eeec/glslang-142052fa30f9eca191aa9dcf65359fcaed09eeec.tar.gz \
+		 https://github.com/ianlancetaylor/libbacktrace/archive/ad106d5fdd5d960bd33fae1c48a351af567fd075/libbacktrace-ad106d5fdd5d960bd33fae1c48a351af567fd075.tar.gz \
+		 https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.0/libjpeg-turbo-3.1.0.tar.gz \
+		 https://downloads.sourceforge.net/project/libpng/libpng16/1.6.48/libpng-1.6.48.tar.xz \
+		 https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.5.0.tar.gz \
+		 https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz \
+		 https://github.com/PCSX2/pcsx2/archive/v2.4.0/pcsx2-2.4.0.tar.gz \
+		 https://github.com/PCSX2/pcsx2_patches/archive/2fdc835f0725b318efcdaae84db1c73a9139b6f6/pcsx2_patches-2fdc835f0725b318efcdaae84db1c73a9139b6f6.tar.gz \
+		 https://github.com/sammycage/plutosvg/archive/v0.0.6/plutosvg-0.0.6.tar.gz \
+		 https://github.com/sammycage/plutovg/archive/v0.0.13/plutovg-0.0.13.tar.gz \
+		 https://github.com/google/shaderc/archive/v2024.1/shaderc-2024.1.tar.gz \
+		 https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz"
+MD5SUM_x86_64="54a7cf8aae1effa2dd726c9a803c6b48 \
+	       df944f00b47df17c74e6c05b8d4c4f24 \
+	       89aeaa63555ebf77c2651a7f3dc3b52f \
+	       bec9b26fa484a26334e8b49a0c36d675 \
+	       84f2cb1cb711ca7892dcf49327219797 \
+	       6a32924c5e2e90a99f0bc853dc188c67 \
+	       ed3fb4bb4cf794898f11a6d30c54b479 \
+	       6ddbe2107e3811d51da698794b8fb4a2 \
+	       8f659e426eaa2aeec4b36bc9ea43b3f3 \
+	       dead9f5f1966d9ae56e1e32761e4e675 \
+	       62aa26d075fe08d358b9297ad81ac006 \
+	       c27ef008d2f6c5c9eeb8dc0a214e922f \
+	       3ebeae70224915e407a3815655477f0d \
+	       d8a6ab94b91e745ba68ef6ca61cf1137 \
+	       3d445aeffa0ad59f62b87124454f85f6 \
+	       780fc1896922b1bc52a4e90980cdda48"
+REQUIRES="qt6 llvm-opt"
+MAINTAINER="Ruoh-Shoei LIN"
+EMAIL="lin.ruohshoei@gmail.com"

--- a/games/pcsx2/slack-desc
+++ b/games/pcsx2/slack-desc
@@ -6,14 +6,14 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
      |-----handy-ruler------------------------------------------------------|
-pcsx2: pcsx2 (PlayStation 2 Emulator)
+pcsx2: pcsx2 (PlayStation 2 emulator)
 pcsx2:
-pcsx2: PCSX2 - The Playstation 2 Emulator
+pcsx2: PCSX2 is a free and open-source PlayStation 2 (PS2) emulator.
+pcsx2:
+pcsx2: Its purpose is to emulate the PS2's hardware, using a combination of
+pcsx2: MIPS CPU Interpreters, Recompilers and a Virtual Machine which
+pcsx2: manages hardware states and PS2 system memory.
 pcsx2:
 pcsx2: Homepage: https://pcsx2.net
-pcsx2:
-pcsx2:
-pcsx2:
-pcsx2:
 pcsx2:
 pcsx2:


### PR DESCRIPTION
- upstream release
- new dependency: llvm-opt
- removing rpaths from binaries and libraries.
- new maintainer