### PR TITLE
desktop/libqt6xdg: Update README and slack-desc

### DIFF
--- a/desktop/libqt6xdg/README
+++ b/desktop/libqt6xdg/README
@@ -1,4 +1,4 @@
-libqtxdg is a Qt implementation of freedesktop.org XDG
+libqt6xdg is a Qt implementation of freedesktop.org XDG
 specifications.
 
 The library is able to use GTK+ icon theme caches for faster

--- a/desktop/libqt6xdg/slack-desc
+++ b/desktop/libqt6xdg/slack-desc
@@ -8,7 +8,7 @@
          |-----handy-ruler------------------------------------------------------|
 libqt6xdg: libqt6xdg (Provides freedesktop.org specs implementations for Qt)
 libqt6xdg:
-libqt6xdg: libqtxdg is a Qt implementation of freedesktop.org XDG
+libqt6xdg: libqt6xdg is a Qt implementation of freedesktop.org XDG
 libqt6xdg: specifications.
 libqt6xdg:
 libqt6xdg: homepage: https://lxqt.org


### PR DESCRIPTION
Please read https://github.com/SlackBuildsOrg/slackbuilds/pull/13086 for further context.

The README should not start with "libqtxdg is a Qt implementation..."
libqtxdg is a separate SlackBuild - it is for qt5 support.