### PR TITLE
python/python3-dbus-fast: Update README

### DIFF
--- a/python/python3-dbus-fast/README
+++ b/python/python3-dbus-fast/README
@@ -1,3 +1,7 @@
 dbus-fast is a Python library for DBus that aims to be a performant
 fully featured high level library primarily geared towards integration
 of applications into Linux desktop and mobile environments.
+
+Note: Unable to upgrade python3-dbus-fast beyond version 2.45.1.
+Newer versions require a newer Python than available in Slackware 15.0
+(i.e. at >= 3.10).


### PR DESCRIPTION
pyhton3-dbus-fast >= 2.45.2 requires Python 3.10.
Upstream has dropped Python 3.9 to fix CI.