### PR TITLE
development/llvm-opt: Use '-exec command {} +'

### DIFF
--- a/development/llvm-opt/llvm-opt.SlackBuild
+++ b/development/llvm-opt/llvm-opt.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=llvm-opt
 SRCNAM=llvm
 VERSION=${VERSION:-20.1.8}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -79,9 +79,9 @@ cd $SRCNAM-project-$VERSION.src
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
-  -o -perm 511 \) -exec chmod 755 {} \; -o \
+  -o -perm 511 \) -exec chmod 755 '{}' \+ -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
-  -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+  -o -perm 440 -o -perm 400 \) -exec chmod 644 '{}' \+
 
 if [ "$ARCH" = "i586" -o "$ARCH" = "i686" ]; then
     LLVM_ENABLE_PROJECTS=${LLVM_ENABLE_PROJECTS:-"clang;clang-tools-extra;compiler-rt;lld;lldb;llvm"}


### PR DESCRIPTION
- using '-exec command {} +' instead of '-exec command ;'. Thanks to Lockywolf.