### PR TITLE
development/jupyter_client: Update README

### DIFF
--- a/development/jupyter_client/README
+++ b/development/jupyter_client/README
@@ -1,3 +1,6 @@
 jupyter_client contains the reference implementation of the Jupyter
 protocol.  It also provides client and kernel management APIs for
 working with kernels.
+
+jupyter_client 8.6.3 is the last available version on Slackware 15.0.
+Later versions require Python >= 3.10. 


### PR DESCRIPTION
I cannot update jupyter_client to >= 8.7.0.

This commit is the reason why:
https://github.com/jupyter/jupyter_client/commit/bc5d2d5a6bc56e0d88245e8a89fc9e44c9e2d673

Upstream dropped Python 3.9 support since jupyter_client 8.7.0.