### PR TITLE
development/jupyter_core: Update README

### DIFF
--- a/development/jupyter_core/README
+++ b/development/jupyter_core/README
@@ -3,3 +3,6 @@ configuration used by other Jupyter projects.
 
 This SlackBuild also installs shell completions.
 Bash completion in particular additionally requires python3-argcomplete.
+
+jupyter_core 5.8.1 is the last available version on Slackware 15.0.
+Later versions require Python >= 3.10.


### PR DESCRIPTION
I cannot update jupyter_core to >= 5.9.0.

This pull request is the reason why:
https://github.com/jupyter/jupyter_core/pull/445/commits/baae8251466f2939d0318f63dd53c71097371b50

Upstream dropped Python 3.9 support since jupyter_core 5.9.0.