### PR TITLE
python/python3-lsp-server: Restore default yapf >= 0.33.0 requirement

### DIFF
--- a/python/python3-lsp-server/python3-lsp-server.SlackBuild
+++ b/python/python3-lsp-server/python3-lsp-server.SlackBuild
@@ -71,12 +71,6 @@ sed -i "s|pycodestyle>=2.11.0,<2.12.0|pycodestyle>=2.11.0|" -i pyproject.toml
 sed -i "s|pyflakes>=3.1.0,<3.2.0|pyflakes>=3.1.0|" -i pyproject.toml
 sed -i "s|pylint>=2.5.0,<3.1|pylint>=2.5.0|" -i pyproject.toml
 
-# If yapf is still on 0.32.0, take this into account
-# This involves reverting the following pull requests:
-# https://github.com/python-lsp/python-lsp-server/pull/346
-# https://github.com/python-lsp/python-lsp-server/pull/377 
-sed -i "s|yapf>=0.33.0|yapf>=0.32.0|" -i pyproject.toml
-
 PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 export PYTHONPATH=/opt/python$PYVER/site-packages/
 


### PR DESCRIPTION
Tonus already had upgraded yapf from 0.32.0 to 0.43.0 at the end of July of this year.
Therefore, I can bring back the default yapf version requirement (i.e. yapf >= 0.33.0).