### PR TITLE
libraries/qt6: Security fix for version 6.8.3.

### DIFF
--- a/libraries/qt6/qt6.SlackBuild
+++ b/libraries/qt6/qt6.SlackBuild
@@ -28,7 +28,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=qt6
 SRCNAM=qt-everywhere-src
 VERSION=${VERSION:-6.8.3}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -92,7 +92,7 @@ if [ "${QTGRPC:-OFF}" = "OFF" ]; then
    QTGRPC="-skip qtgrpc"
 fi
 
-cd qtbase
+pushd qtbase
 patch -Np1 -i $CWD/CVE-2025-3512-qtbase-6.8.diff
 patch -Np1 -i $CWD/CVE-2025-4211-qtbase-6.8.diff
 patch -Np1 -i $CWD/CVE-2025-5455-qtbase-6.8.patch
@@ -102,12 +102,21 @@ patch -Np1 -i $CWD/CVE-2025-5992-qtbase-6.8.patch
 
 sed -i 's/QPCCertContextPointer certificateContext;/const CERT_CONTEXT *certificateContext = nullptr;/g' $CWD/CVE-2025-6338-qtbase-6.8.patch
 patch -Np1 -i $CWD/CVE-2025-6338-qtbase-6.8.patch
-cd ../qtsvg
+popd
+
+pushd qtsvg
 patch -Np1 -i $CWD/CVE-2025-10728-qtsvg-6.8.diff
 patch -Np1 -i $CWD/CVE-2025-10729-qtsvg-6.8.diff
-cd ../qtimageformats
+popd
+
+pushd qtimageformats
 patch -Np1 -i $CWD/CVE-2025-5683-qtimageformats-6.8.patch
-cd ..
+popd
+
+pushd qtdeclarative
+patch -Np1 -i $CWD/CVE-2025-12385-qtdeclarative-6.8-0001.diff
+patch -Np1 -i $CWD/CVE-2025-12385-qtdeclarative-6.8-0002.diff
+popd
 
 export QT6PREFIX="/usr"
 export CFLAGS="$SLKCFLAGS"

--- a/libraries/qt6/qt6.info
+++ b/libraries/qt6/qt6.info
@@ -6,6 +6,8 @@ MD5SUM=""
 DOWNLOAD_x86_64="https://download.qt.io/archive/qt/6.8/6.8.3/single/qt-everywhere-src-6.8.3.tar.xz \
 		 https://download.qt.io/archive/qt/6.8/CVE-2025-10728-qtsvg-6.8.diff \
 		 https://download.qt.io/archive/qt/6.8/CVE-2025-10729-qtsvg-6.8.diff \
+		 https://download.qt.io/archive/qt/6.8/CVE-2025-12385-qtdeclarative-6.8-0001.diff \
+		 https://download.qt.io/archive/qt/6.8/CVE-2025-12385-qtdeclarative-6.8-0002.diff \
 		 https://download.qt.io/archive/qt/6.8/CVE-2025-23050-qtconnectivity-6.8.diff \
 		 https://download.qt.io/archive/qt/6.8/CVE-2025-3512-qtbase-6.8.diff \
 		 https://download.qt.io/archive/qt/6.8/CVE-2025-4211-qtbase-6.8.diff \
@@ -16,6 +18,8 @@ DOWNLOAD_x86_64="https://download.qt.io/archive/qt/6.8/6.8.3/single/qt-everywher
 MD5SUM_x86_64="10a39c4b4af4f465c4ff0352a6d18a0a \
 	       ae252a683d070e33ecd10862d6a7cafc \
 	       2b35e543b1bd14db40e527f6afcacfa1 \
+	       985de0a4937a90b5610beb76e642ed3d \
+	       c7d1bf693c6a7624ac2d49d906d3a16e \
 	       57e1509b3f645db6224468a2acafc8d0 \
 	       d694e774679816f0b8c1bb2f579fa749 \
 	       269fbd2ab17845fc1fe99946f51bf779 \


### PR DESCRIPTION
- applying upstream patch for CVE-2025-12385