### PR TITLE
development/jupyter-nbclient: Update README (why software version should not be updated)

### DIFF
--- a/development/jupyter-nbclient/README
+++ b/development/jupyter-nbclient/README
@@ -1,2 +1,5 @@
 nbclient is a tool for running Jupyter Notebooks in different execution
 contexts.
+
+jupyter-nbclient 0.10.2 is the last available version for Slackware
+15.0. Newer versions require Python >= 3.10.


### PR DESCRIPTION
Upstream has dropped support for Python < 3.10.