### PR TITLE
libraries/plasma-wayland-protocols-opt: Fix HOMEPAGE

### DIFF
--- a/libraries/plasma-wayland-protocols-opt/plasma-wayland-protocols-opt.info
+++ b/libraries/plasma-wayland-protocols-opt/plasma-wayland-protocols-opt.info
@@ -1,6 +1,6 @@
 PRGNAM="plasma-wayland-protocols-opt"
 VERSION="1.12.0"
-HOMEPAGE="https://invent.kde.org/frameworks/plasma-wayland-protocols"
+HOMEPAGE="https://invent.kde.org/libraries/plasma-wayland-protocols"
 DOWNLOAD="https://download.kde.org/stable/plasma-wayland-protocols/plasma-wayland-protocols-1.12.0.tar.xz"
 MD5SUM="7755dcac14e90068a7e26922c3a4a296"
 DOWNLOAD_x86_64=""


### PR DESCRIPTION
https://invent.kde.org/libraries/plasma-wayland-protocols actually works.
https://invent.kde.org/frameworks/plasma-wayland-protocols leads to a sign-in page.

From here on out, I won't regularly update SlackBuilds.
In fact, I plan on quitting maintaining SlackBuilds after Christmas - but I found something I had to fix.
https://lists.slackbuilds.org/pipermail/slackbuilds-users/2025-December/030703.html

My future plans: when I get the time, I'll update the LXQt SlackBuilds series. 