### PR TITLE
system/zim-tools: Updated for version 3.6.0.

### DIFF
--- a/system/zim-tools/zim-tools.SlackBuild
+++ b/system/zim-tools/zim-tools.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=zim-tools
 VERSION=${VERSION:-3.6.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -76,6 +76,9 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# fix libzim >= 9.4.0
+sed -i "/warning_level=1/ s/, 'werror=true'//g" meson.build
 
 mkdir build
 cd build


### PR DESCRIPTION
- fixing FTBFS when libzim >= 9.4.0