### PR TITLE
system/android-file-transfer: Update README

### DIFF
--- a/system/android-file-transfer/README
+++ b/system/android-file-transfer/README
@@ -1,5 +1,6 @@
 Android File Transfer for Linux - reliable MTP client with
 minimalistic UI similar to Android File Transfer for Mac.
 
-To build only the command-line client, pass QT_GUI=no to the SlackBuild:
+To build only the command-line client (this does not require qt6),
+pass QT_GUI=no to the SlackBuild:
 QT_GUI=no ./android-file-transfer.SlackBuild


### PR DESCRIPTION
Though I had orphaned this SlackBuild:

Update README (command line option does not require qt6).
I have not disabled x86 downloads (since command line option does not require qt6, android-file-transfer may be built in both x86 and x86_64. However, the default option with qt6 gui will only allow x86_64 downloads).

Note: Next update cycle, I will disable x86 downloads for my lxqt SlackBuilds. This pull request just now is related to that.