### PR TITLE
network/element-desktop: Updated for version 1.12.9; switch to nodejs22.

### DIFF
--- a/network/element-desktop/element-desktop.SlackBuild
+++ b/network/element-desktop/element-desktop.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=element-desktop
 WEBNAM=element-web
-VERSION=${VERSION:-1.12.8}
+VERSION=${VERSION:-1.12.9}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/network/element-desktop/element-desktop.info
+++ b/network/element-desktop/element-desktop.info
@@ -1,14 +1,14 @@
 PRGNAM="element-desktop"
-VERSION="1.12.8"
+VERSION="1.12.9"
 HOMEPAGE="https://element.io/"
 DOWNLOAD="UNSUPPORTED"
 MD5SUM=""
-DOWNLOAD_x86_64="https://github.com/element-hq/element-desktop/archive/v1.12.8/element-desktop-1.12.8.tar.gz \
-                 https://github.com/element-hq/element-web/archive/v1.12.8/element-web-1.12.8.tar.gz \
-                 https://sbo.t-rg.ws/element-desktop-1.12.8-vendored-sources.tar.xz"
-MD5SUM_x86_64="027415fb6be686b616f76a7485e5cd49 \
-               b594503e3a32543d49cc6fd5a26e11a6 \
-               7a4e4d42bbcdcf27c3c7759e39057c67"
-REQUIRES="sqlcipher rust-opt nodejs24-bin"
+DOWNLOAD_x86_64="https://github.com/element-hq/element-desktop/archive/v1.12.9/element-desktop-1.12.9.tar.gz \
+                 https://github.com/element-hq/element-web/archive/v1.12.9/element-web-1.12.9.tar.gz \
+                 https://sbo.t-rg.ws/element-desktop-1.12.9-vendored-sources.tar.xz"
+MD5SUM_x86_64="afefecf1f43cad6c383d4dcde541e807 \
+               07d0c112c470893318ee7622665f380e \
+               a29b5de64db136f45cc90202f99abc58"
+REQUIRES="sqlcipher rust-opt nodejs22"
 MAINTAINER="Vladislav 'fsLeg' Borisov"
 EMAIL="fsleg@t-rg.ws"


### PR DESCRIPTION
Forgot to update dependency.