### PR TITLE
gis/libspatialite: Fix compilation on -current

### DIFF
--- a/gis/libspatialite/libspatialite.SlackBuild
+++ b/gis/libspatialite/libspatialite.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for libspatialite
 #
-# Copyright 2023-2024 Gregory J. L. Tourte <artourter@gmail.com>
+# Copyright 2023-2026 Gregory J. L. Tourte <artourter@gmail.com>
 # Copyright 2012-2015 Alexander Bruy <alexander.bruy@gmail.com>
 # All rights reserved.
 #
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=libspatialite
 VERSION=${VERSION:-5.1.0}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -74,6 +74,8 @@ chown -R root:root .
 find -L . \
   -perm /111 -a \! -perm 755 -a -exec chmod 755 {} + -o \
   \! -perm /111 -a \! -perm 644 -a -exec chmod 644 {} +
+
+patch -p1 < $CWD/spatialite-5.1.0-libxml2-2.14.patch
 
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \

--- a/gis/libspatialite/spatialite-5.1.0-libxml2-2.14.patch
+++ b/gis/libspatialite/spatialite-5.1.0-libxml2-2.14.patch
@@ -1,0 +1,52 @@
+Source: https://www.gaia-gis.it/fossil/libspatialite/tktview?name=ac85f0fca3
+
+Index: spatialite-5.1.0/configure.ac
+===================================================================
+--- spatialite-5.1.0.orig/configure.ac
++++ spatialite-5.1.0/configure.ac
+@@ -61,6 +61,8 @@ AH_TEMPLATE([OMIT_FREEXL],
+             [Should be defined in order to disable FREEXL support.])
+ AH_TEMPLATE([ENABLE_LIBXML2],
+             [Should be defined in order to enable LIBXML2 support.])
++AH_TEMPLATE([ENABLE_LIBXML2_NANOHTTP],
++            [Should be defined in order to enable LIBXML2 HTTP support.])
+ AH_TEMPLATE([ENABLE_MINIZIP],
+             [Should be defined in order to enable MiniZIP support.])
+ AH_TEMPLATE([ENABLE_GEOPACKAGE],
+@@ -441,6 +443,7 @@ if test x"$enable_libxml2" != "xno"; the
+   AC_SUBST(LIBXML2_CFLAGS)
+   AC_SUBST(LIBXML2_LIBS)
+   AC_DEFINE(ENABLE_LIBXML2)
++  AC_SEARCH_LIBS(xmlNanoHTTPCleanup,xml2,AC_DEFINE(ENABLE_LIBXML2_NANOHTTP),,)
+ fi
+
+ #-----------------------------------------------------------------------
+Index: spatialite-5.1.0/src/wfs/wfs_in.c
+===================================================================
+--- spatialite-5.1.0.orig/src/wfs/wfs_in.c
++++ spatialite-5.1.0/src/wfs/wfs_in.c
+@@ -76,7 +76,10 @@ Regione Toscana - Settore Sistema Inform
+ #ifdef ENABLE_LIBXML2          /* LIBXML2 enabled: supporting XML documents */
+
+ #include <libxml/parser.h>
++
++#ifdef ENABLE_LIBXML2_NANOHTTP
+ #include <libxml/nanohttp.h>
++#endif
+
+ #define MAX_GTYPES     28
+
+@@ -4636,8 +4639,13 @@ get_wfs_schema_column_info (gaiaWFScolum
+ SPATIALITE_DECLARE void
+ reset_wfs_http_connection (void)
+ {
++#ifdef ENABLE_LIBXML2_NANOHTTP
+ /* Resets the libxml2 "nano HTTP": useful when changing the HTTP_PROXY settings */
+     xmlNanoHTTPCleanup ();
++#else
++/* LIBXML2 doesn't have HTTP support: does absolutely nothing */
++    return;
++#endif
+ }
+
+ #else /* LIBXML2 isn't enabled */


### PR DESCRIPTION
fix compilation with libxml2 2.14+ with patch proposed at https://www.gaia-gis.it/fossil/libspatialite/tktview?name=ac85f0fca3

patch is used in gentoo package
https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=ab4e4668cb945f5dab1cdb3f31daf6deda35b552