### PR TITLE
python/python3-pynacl: Update README

### DIFF
--- a/python/python3-pynacl/README
+++ b/python/python3-pynacl/README
@@ -2,6 +2,3 @@ PyNaCl is a Python binding to libsodium, which is a fork of the
 Networking and Cryptography library. These libraries have a stated goal
 of improving usability, security and speed. It supports Python 3.8+ as
 well as PyPy 3.
-
-python3-pynacl 1.6.0 is the last available version for Slackware 15.0.
-Newer versions require cffi >= 2.0.0.


### PR DESCRIPTION
It turns out @willysr has released the python3-cffi SlackBuild. Therefore, the README about being unable to update python3-pynacl does not apply.

That being said, I am not updating python3-pynacl any further (I am not sure about the consequences of installing python3-cffi on Slackware 15.0, given that Slackware already provides a package named python-cffi at 1.15.0.)

Also, I am making this my last pull request for this month. There are increasingly diminishing returns for me to maintain/update SlackBuilds (I am not using Slackware as my main/host operating system at this time. My goal for maintaining SlackBuilds is to prepare for a return to Slackware when a new version comes out - ex. 15.1, 16.0.)