### PR TITLE
desktop/slstatus: add backported patches from upstream

### DIFF
--- a/desktop/slstatus/slstatus.SlackBuild
+++ b/desktop/slstatus/slstatus.SlackBuild
@@ -82,12 +82,17 @@ if [ -e "$CWD/config.h" ]; then
   cp -v $CWD/config.h config.def.h
 fi
 
+# Now apply any other patches the user might have added. Have to
+# do this *after* applying custom config.h, so any changes to
+# config.h here won't get overwritten.
+PATCHES=""
 if [ -d "$CWD/patches" ]; then
-  for i in "$CWD"/patches/*.patch; do
-    [ -e "$i" ] || continue
-    echo "Applying patch $(basename "$i")"
+  for i in $CWD/patches/*.patch; do
+    [ ! -f "$i" ] && continue
+    basename_i="$(basename $i)"
+    echo "=== applying patch $basename_i"
     patch -p1 < "$i" || exit 1
-    PATCHES="$PATCHES $(basename "$i")"
+    PATCHES+=" $basename_i"
   done
 fi
 


### PR DESCRIPTION
Add patches/ directory with four commits backported from upstream
(https://git.suckless.org/slstatus):

- 8723e8b: more concise memory calculation on Linux (lscanf, /proc/meminfo)
- 6fa36ba: volume: avoid NULL dereference in onval() on sndio device switch
- 4f61bbb: wifi: always retry ioctl for ifindex
- 98769df: fix buffer overflow in battery state parsing (state[12] -> state[13])

Patches apply cleanly against slstatus-1.1 source.