### PR TITLE
python/python3-smart_open: Update README

### DIFF
--- a/python/python3-smart_open/README
+++ b/python/python3-smart_open/README
@@ -7,3 +7,6 @@ formats.
 smart_open is a drop-in replacement for Python's built-in open():
 it can do anything open can (100% compatible, falls back to native
 open whenever possible) plus lots of nifty extra stuff on top.
+
+python3-smart_open 7.5.0 is the last available version on Slackware
+15.0. Newer versions require Python >= 3.10.


### PR DESCRIPTION
Later versions of python3-smart_open (>=7.5.1) have dropped support for Python 3.9.