### PR TITLE
games/scummvm: Removed gold linker

### DIFF
--- a/games/scummvm/scummvm.SlackBuild
+++ b/games/scummvm/scummvm.SlackBuild
@@ -33,7 +33,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=scummvm
 VERSION=${VERSION:-2026.1.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -86,12 +86,8 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
  -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-# avoid linking breakage on i?86
-if [[ $ARCH == i?86 ]]; then linker=bfd; else linker=gold; fi
-
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
-LDFLAGS="-fuse-ld=$linker" \
 ./configure \
   --prefix=/usr \
   --bindir=/usr/games \


### PR DESCRIPTION
Removed gold linker. 

This linker brings problem to compile binary file on Slackware current.