### PR TITLE
desktop/qtile: Update README (change info on wlroots version requirement)

### DIFF
--- a/desktop/qtile/README
+++ b/desktop/qtile/README
@@ -10,8 +10,8 @@ It sends notifications through dbus - please additionally install a
 notification daemon such as dunst for displaying notifications on qtile.
 
 This SlackBuild does not provide Wayland support. Slackware 15.0 is only
-able to build wlroots 0.15. qtile >= 0.26.0 requires wlroots 0.17 (which
-cannot be built with Slackware 15).
+able to build wlroots 0.15. qtile >= 0.26.0 requires wlroots >= 0.17
+(which cannot be built with Slackware 15).
 
 To enable DBus support when starting up qtile using a login manager
 (ex. sddm), pass DBUS=yes to the SlackBuild:


### PR DESCRIPTION
qtile since version 0.34.0 requires wlroots >= 0.19.0.

Therefore, it's not accurate to say "qtile >= 0.26.0 requires wlroots 0.17". That previous statement only applies up to qtile 0.33.0.