### PR TITLE
update the script

### DIFF
--- a/development/typescript/typescript.SlackBuild
+++ b/development/typescript/typescript.SlackBuild
@@ -2,10 +2,10 @@
 
 # Slackware build script for typescript
 
-# Copyright 2025 Vijay Marcel
+# Copyright 2025-2026 Vijay Marcel
 # All rights reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# This Script is  Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 
@@ -21,7 +21,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=typescript
 VERSION=${VERSION:-5.9.3}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 SRCNAM=${SRCNAM:-TypeScript}
@@ -67,6 +67,13 @@ find -L . \
 
 mkdir -pv $PKG/usr/bin
 mkdir -pv $PKG/usr/lib${LIBDIRSUFFIX}/node_modules/$PRGNAM
+
+# make npm to download the deps to $TMP/$SRCNAM-$VERSION/cache
+
+mkdir $TMP/$SRCNAM-$VERSION/cache
+mkdir $TMP/$SRCNAM-$VERSION/node-compile-cache
+export npm_config_cache=$TMP/$SRCNAM-$VERSION/cache
+export NODE_COMPILE_CACHE=$TMP/$SRCNAM-$VERSION/node-compile-cache
 
 npm ci
 npx hereby LKG


### PR DESCRIPTION
This script update makes npm to download the  dependencies to the $TMP/$SRCNAM-$VERSION/cache instead
of  in root dir