### PR TITLE
network/senpai: update to 0.4.1

### DIFF
--- a/network/senpai/patches/0038-Fix-nicks-with-brackets-becoming-invisible-after-res.patch
+++ b/network/senpai/patches/0038-Fix-nicks-with-brackets-becoming-invisible-after-res.patch
@@ -1,0 +1,49 @@
+From b209af17265907093988732c478025a37d2d1395 Mon Sep 17 00:00:00 2001
+From: delthas <delthas@dille.cc>
+Date: Tue, 10 Mar 2026 19:27:03 +0100
+Subject: [PATCH 38/54] Fix nicks with brackets becoming invisible after
+ restart
+
+s.nickCf was computed at RPL_WELCOME (001) using the default casemap
+(rfc1459), but ISUPPORT (005) arrives after and may change the casemap
+to ascii. For nicks containing brackets (e.g. [mynick]), rfc1459
+casemapping converts [ to { and ] to }, while ascii does not. This
+caused IsMe() to fail for all subsequent JOINs, so channels were never
+added to the buffer list.
+
+Recompute s.nickCf and rekey s.users when the casemap changes in
+ISUPPORT.
+
+Fixes: https://todo.sr.ht/~delthas/senpai/231
+---
+ irc/session.go | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/irc/session.go b/irc/session.go
+index e4bd917..e34fd40 100644
+--- a/irc/session.go
++++ b/irc/session.go
+@@ -2211,12 +2211,20 @@ func (s *Session) updateFeatures(features []string) {
+ 		case "BOUNCER_NETID":
+ 			s.netID = value
+ 		case "CASEMAPPING":
++			oldNickCf := s.nickCf
+ 			switch value {
+ 			case "ascii":
+ 				s.casemap = CasemapASCII
+ 			default:
+ 				s.casemap = CasemapRFC1459
+ 			}
++			s.nickCf = s.casemap(s.nick)
++			if oldNickCf != s.nickCf {
++				if u, ok := s.users[oldNickCf]; ok {
++					delete(s.users, oldNickCf)
++					s.users[s.nickCf] = u
++				}
++			}
+ 		case "CHANMODES":
+ 			// We only care about the first four params
+ 			types := strings.SplitN(value, ",", 5)
+-- 
+2.54.0
+

--- a/network/senpai/patches/0051-Set-User-Agent-header-in-fetchImage-HTTP-requests.patch
+++ b/network/senpai/patches/0051-Set-User-Agent-header-in-fetchImage-HTTP-requests.patch
@@ -1,0 +1,93 @@
+From 21079b04f6c573324ea1b854255e73d6f6188979 Mon Sep 17 00:00:00 2001
+From: delthas <delthas@dille.cc>
+Date: Thu, 19 Mar 2026 17:12:57 +0100
+Subject: [PATCH 51/54] Set User-Agent header in fetchImage HTTP requests
+
+Image fetching timed out on some hosts (e.g. catbox.moe) because Go's
+default HTTP client sends "Go-http-client/2.0" as the User-Agent when
+HTTP/2 is negotiated, which certain servers silently block by never
+sending response headers.
+
+Set a "senpai/<version>" (or "senpai") User-Agent on all HTTP requests
+in fetchImage (HEAD, HTML GET, and image GET). Also close the HEAD
+response body and fix minor whitespace.
+
+Fixes: https://todo.sr.ht/~delthas/senpai/230
+---
+ app.go | 25 +++++++++++++++++++++----
+ 1 file changed, 21 insertions(+), 4 deletions(-)
+
+diff --git a/app.go b/app.go
+index 697ffbd..e781c0f 100644
+--- a/app.go
++++ b/app.go
+@@ -243,7 +243,7 @@ func NewApp(cfg Config) (app *App, err error) {
+ }
+ 
+ func (app *App) Close() {
+-	app.win.Exit()       // tell all instances of app.ircLoop to stop when possible
++	app.win.Exit() // tell all instances of app.ircLoop to stop when possible
+ 	app.postEvent(event{ // tell app.eventLoop to stop
+ 		src:     "*",
+ 		content: nil,
+@@ -1204,6 +1204,11 @@ var patternOpenGraphImage = regexp.MustCompile(`<meta property="og:image" conten
+ var patternOpenGraphVideo = regexp.MustCompile(`<meta property="og:video"`)
+ 
+ func (app *App) fetchImage(link string) (image.Image, error) {
++	userAgent := "senpai"
++	if v, ok := BuildVersion(); ok {
++		userAgent = "senpai/" + v
++	}
++
+ 	if u, err := url.Parse(link); err == nil {
+ 		changed := true
+ 		switch u.Host {
+@@ -1220,10 +1225,16 @@ func (app *App) fetchImage(link string) (image.Image, error) {
+ 	cHead := http.Client{
+ 		Timeout: 1500 * time.Millisecond,
+ 	}
+-	res, err := cHead.Head(link)
++	req, err := http.NewRequest("HEAD", link, nil)
++	if err != nil {
++		return nil, err
++	}
++	req.Header.Set("User-Agent", userAgent)
++	res, err := cHead.Do(req)
+ 	if err != nil {
+ 		return nil, err
+ 	}
++	res.Body.Close()
+ 	if res.StatusCode != http.StatusOK {
+ 		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+ 	}
+@@ -1244,11 +1255,12 @@ func (app *App) fetchImage(link string) (image.Image, error) {
+ 		if err != nil {
+ 			return nil, err
+ 		}
++		req.Header.Set("User-Agent", userAgent)
+ 		var previewSize int64 = 10 * 1024
+ 		if res.Header.Get("Accept-Ranges") == "bytes" {
+ 			req.Header.Set("Range", fmt.Sprintf("bytes=0-%v", previewSize))
+ 		}
+-		res, err = cHead.Get(link)
++		res, err = cHead.Do(req)
+ 		if err != nil {
+ 			return nil, err
+ 		}
+@@ -1270,7 +1282,12 @@ func (app *App) fetchImage(link string) (image.Image, error) {
+ 	cGet := http.Client{
+ 		Timeout: 5 * time.Second,
+ 	}
+-	res, err = cGet.Get(link)
++	req, err = http.NewRequest("GET", link, nil)
++	if err != nil {
++		return nil, err
++	}
++	req.Header.Set("User-Agent", userAgent)
++	res, err = cGet.Do(req)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-- 
+2.54.0
+

--- a/network/senpai/patches/0053-Fix-member-list-highlight-below-last-member.patch
+++ b/network/senpai/patches/0053-Fix-member-list-highlight-below-last-member.patch
@@ -1,0 +1,31 @@
+From 9a0fd3db337912a6a09255c5667c9b7687bdccd1 Mon Sep 17 00:00:00 2001
+From: delthas <git@delthas.fr>
+Date: Mon, 20 Apr 2026 18:38:30 +0200
+Subject: [PATCH 53/54] Fix member list highlight below last member
+
+Clicking and holding below the last member in the vertical member list
+would highlight the last member due to clamping in the draw function.
+Remove the clamp so out-of-range memberClicked values simply highlight
+nothing.
+---
+ ui/ui.go | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/ui/ui.go b/ui/ui.go
+index 80a188c..94e83ac 100644
+--- a/ui/ui.go
++++ b/ui/ui.go
+@@ -936,10 +936,6 @@ func (ui *UI) drawVerticalMemberList(vx *Vaxis, x0, y0, width, height int, b *bu
+ 		return
+ 	}
+ 
+-	if ui.memberClicked >= len(members) {
+-		ui.memberClicked = len(members) - 1
+-	}
+-
+ 	if len(members) > 0 {
+ 		var memberString string
+ 		if len(members) > 1 {
+-- 
+2.54.0
+

--- a/network/senpai/patches/series
+++ b/network/senpai/patches/series
@@ -1,0 +1,3 @@
+0038-Fix-nicks-with-brackets-becoming-invisible-after-res.patch
+0051-Set-User-Agent-header-in-fetchImage-HTTP-requests.patch
+0053-Fix-member-list-highlight-below-last-member.patch

--- a/network/senpai/senpai.SlackBuild
+++ b/network/senpai/senpai.SlackBuild
@@ -62,6 +62,12 @@ cd $TMP
 rm -rf $PRGNAM-$VERSION
 tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
 cd $PRGNAM-$VERSION
+
+cat $CWD/patches/series | while read patch ; do
+  echo "*** Applying patch $patch"
+  cat $CWD/patches/$patch | patch -p1 --verbose || exit 1
+done || exit 1
+
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \


### PR DESCRIPTION
ackported 3 upstream patches:

- Fix casemapping issue causing nicks with brackets to break channel detection
- Set HTTP User-Agent to fix image fetching on some hosts
- Fix member list highlight behavior

No new dependencies introduced.