### PR TITLE
python/python3-gensim: Fix build

### DIFF
--- a/python/python3-gensim/python3-gensim.SlackBuild
+++ b/python/python3-gensim/python3-gensim.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for python3-gensim
 
-# Copyright 2023-2024 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2023-2026 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-gensim
 VERSION=${VERSION:-4.4.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -73,6 +73,11 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# Build python3-gensim with python3-numpy-legacy (which is located in /opt)
+# This addresses a build failure within Slackware 15.0
+PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+export PYTHONPATH=/opt/python$PYVER/site-packages
 
 python3 setup.py install --root=$PKG
 

--- a/python/python3-gensim/python3-gensim.info
+++ b/python/python3-gensim/python3-gensim.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/g/gensim/gensim-4.4.0.t
 MD5SUM="17bc0b1e2f4bd50aae7a657f0abbb7d9"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-scipy python3-smart_open"
+REQUIRES="python3-scipy python3-smart_open python3-numpy-legacy"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
My goal is to get python3-scipy updated to 1.13.1. I am checking its dependencies.
I found out that python3-gensim currently does not build.

The build error has nothing to do with python3-scipy, but rather is related to python3-numpy.

Personally, I don't like this approach where the user has to install both python3-numpy and python3-numpy-legacy on the same system. Furthermore, I don't like to have to install python3-numpy-legacy at all.

Regardless, this is what I have to do to fix the build.