### PR TITLE
python/python3-babel: fix when more than one cldr files are in the script directory

### DIFF
--- a/python/python3-babel/python3-babel.SlackBuild
+++ b/python/python3-babel/python3-babel.SlackBuild
@@ -28,6 +28,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-babel
 VERSION=${VERSION:-2.18.0}
+CLDRSRCVER=${CLDRVER:-47}
 CLDRVER=${CLDRVER:-47.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
@@ -69,7 +70,7 @@ find -L . \
 
 sed -i "s/getiterator/iter/" scripts/import_cldr.py # support Python 3.9
 sed -i "s/elem.getchildren()/list(elem)/" scripts/import_cldr.py # support Python 3.9
-ln -s $CWD/cldr-common-*.zip cldr/cldr-common-$CLDRVER.zip
+ln -s $CWD/cldr-common-$CLDRSRCVER.zip cldr/cldr-common-$CLDRVER.zip
 python3 setup.py import_cldr
 python3 setup.py install --root=$PKG
 


### PR DESCRIPTION
This is really minor, and will break the build if for example someone has an older cldr file in the SlackBuild directory.
The line stating `ln -s $CWD/cldr-common-*.zip cldr/cldr-common-$CLDRVER.zip` will break.
I'm being completely explicit about what is expected to be linked.
It changes nothing for the build itself, so I'm not bumping the build number.