### PR TITLE
git/ci: Adjust workflow for large PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_changes: ${{ steps.get-changes.outputs.has_changes }}
+      too_many_changes: ${{ steps.get-changes.outputs.too_many_changes }}
     steps:
       - name: Calculate clone depth.
         id: clone-depth
@@ -59,8 +60,15 @@ jobs:
 
           if [[ "$CHANGED_FILES" == '[]' || -z "$CHANGED_FILES" ]] ; then
             printf 'has_changes=false\n' >> "$GITHUB_OUTPUT"
+            printf 'too_many_changes=false\n' >> "$GITHUB_OUTPUT"
           else
             printf 'has_changes=true\n' >> "$GITHUB_OUTPUT"
+            CHANGED_COUNT=$(jq 'length' <<< "$CHANGED_FILES")
+            if [[ "$CHANGED_COUNT" -gt 10 ]] ; then
+              printf 'too_many_changes=true\n' >> "$GITHUB_OUTPUT"
+            else
+              printf 'too_many_changes=false\n' >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Get matrix output
@@ -74,6 +82,31 @@ jobs:
             printf 'SLACKBUILDS\n'
           } >> "$GITHUB_OUTPUT"
 
+  too_many_changes:
+    name: Too many changed packages
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write # for peter-evans/create-or-update-comment
+    needs: [changes]
+    if: needs.changes.outputs.too_many_changes == 'true'
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "too many changed packages"
+
+      - name: Comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.number }}
+          body: |
+            This PR contains too many changed packages (more than 10). Skipping normal PR checks.
+          edit-mode: replace
+
   sbolint:
     name: Checks with sbolint
     runs-on: ubuntu-24.04
@@ -81,7 +114,7 @@ jobs:
       contents: read
       pull-requests: write # for peter-evans/create-or-update-comment
     needs: [changes]
-    if: needs.changes.outputs.has_changes == 'true'
+    if: needs.changes.outputs.has_changes == 'true' && needs.changes.outputs.too_many_changes != 'true'
     strategy:
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.matrix) }}
@@ -146,7 +179,7 @@ jobs:
       contents: read
       pull-requests: write # for peter-evans/create-or-update-comment
     needs: [changes]
-    if: needs.changes.outputs.has_changes == 'true'
+    if: needs.changes.outputs.has_changes == 'true' && needs.changes.outputs.too_many_changes != 'true'
     strategy:
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.matrix) }}


### PR DESCRIPTION
Don't run normal checks for PRs with many packages.