### PR TITLE
python/python3-zeroconf: Update README

### DIFF
--- a/python/python3-zeroconf/README
+++ b/python/python3-zeroconf/README
@@ -1,2 +1,5 @@
 This is an implementation of the multicast DNS Service Discover Library
 zeroconf in pure Python.
+
+python3-zeroconf 0.148.0 is the last available version on Slackware
+15.0. Later versions require Python >= 3.10.


### PR DESCRIPTION
This commit https://github.com/python-zeroconf/python-zeroconf/commit/327b93dc602707e25d53788f0fb14e142f4558b3 has been published to the next version of python3-zeroconf (0.149.0).