### PR TITLE
python/python3-narwhals: Update README

### DIFF
--- a/python/python3-narwhals/README
+++ b/python/python3-narwhals/README
@@ -5,3 +5,6 @@ It contains full API support: cuDF, Modin, pandas, Polars, PyArrow.
 It also contains lazy-only support: Dask, SQLFrame, PySpark.
 
 Seamlessly support all, without depending on any!
+
+python3-narwhals 2.21.0 is the last available version for Slackware
+15.0. Later versions require Python >= 3.10.


### PR DESCRIPTION
This commit https://github.com/narwhals-dev/narwhals/commit/58b9a0f638df85666f3f7281820b632d6d22e2a9 has been published to the next version of python3-narwhals (2.21.2)