### PR TITLE
python/python3-zeroconf: Backport other security fixes

### DIFF
--- a/python/python3-zeroconf/patches/stop-lan-local-dns.patch
+++ b/python/python3-zeroconf/patches/stop-lan-local-dns.patch
@@ -1,0 +1,87 @@
+--- a/src/zeroconf/_protocol/incoming.pxd
++++ b/src/zeroconf/_protocol/incoming.pxd
+@@ -83,7 +83,7 @@
+         link_py_int=object,
+         linked_labels=cython.list
+     )
+-    cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers)
++    cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers, unsigned int depth)
+ 
+     @cython.locals(offset="unsigned int")
+     cdef void _read_header(self)
+--- a/src/zeroconf/_protocol/incoming.py
++++ b/src/zeroconf/_protocol/incoming.py
+@@ -60,7 +60,7 @@
+ MAX_DNS_LABELS = 128
+ MAX_NAME_LENGTH = 253
+ 
+-DECODE_EXCEPTIONS = (IndexError, struct.error, IncomingDecodeError)
++DECODE_EXCEPTIONS = (IndexError, struct.error, IncomingDecodeError, RecursionError)
+ 
+ 
+ _seen_logs: dict[str, int | tuple] = {}
+@@ -409,7 +409,7 @@
+         labels: list[str] = []
+         seen_pointers: set[int] = set()
+         original_offset = self.offset
+-        self.offset = self._decode_labels_at_offset(original_offset, labels, seen_pointers)
++        self.offset = self._decode_labels_at_offset(original_offset, labels, seen_pointers, 0)
+         self._name_cache[original_offset] = labels
+         name = ".".join(labels) + "."
+         if len(name) > MAX_NAME_LENGTH:
+@@ -418,8 +418,14 @@
+             )
+         return name
+ 
+-    def _decode_labels_at_offset(self, off: _int, labels: list[str], seen_pointers: set[int]) -> int:
++    def _decode_labels_at_offset(
++        self, off: _int, labels: list[str], seen_pointers: set[int], depth: _int
++    ) -> int:
+         # This is a tight loop that is called frequently, small optimizations can make a difference.
++        if depth > MAX_DNS_LABELS:
++            raise IncomingDecodeError(
++                f"DNS compression pointer chain exceeds {MAX_DNS_LABELS} at {off} from {self.source}"
++            )
+         view = self.view
+         while off < self._data_len:
+             length = view[off]
+@@ -457,7 +463,7 @@
+             if not linked_labels:
+                 linked_labels = []
+                 seen_pointers.add(link_py_int)
+-                self._decode_labels_at_offset(link, linked_labels, seen_pointers)
++                self._decode_labels_at_offset(link, linked_labels, seen_pointers, depth + 1)
+                 self._name_cache[link_py_int] = linked_labels
+             labels.extend(linked_labels)
+             if len(labels) > MAX_DNS_LABELS:
+--- a/tests/test_protocol.py
++++ b/tests/test_protocol.py
+@@ -1011,6 +1011,28 @@
+     assert len(parsed.answers()) == 1
+ 
+ 
++def test_dns_compression_pointer_chain_depth_attack() -> None:
++    """Test our wire parser rejects deeply chained compression pointers without recursing."""
++    # Build a packet with one question whose name is a 1500-deep chain of forward
++    # compression pointers, ending in a root label. Each pointer is 2 bytes,
++    # so chain length easily exceeds CPython's default recursion limit.
++    header = b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00"
++    # Question at offset 12: pointer to offset 18 (past the question's type/class).
++    question_name = bytes([0xC0, 18])
++    question_type_class = b"\x00\x01\x00\x01"
++    chain_depth = 1500
++    chain = bytearray()
++    for i in range(chain_depth):
++        target = 18 + 2 * (i + 1)
++        chain.append(0xC0 | (target >> 8))
++        chain.append(target & 0xFF)
++    chain.append(0x00)
++    packet = header + question_name + question_type_class + bytes(chain)
++    parsed = r.DNSIncoming(packet, ("1.2.3.4", 5353))
++    assert parsed.valid is False
++    assert parsed.questions == []
++
++
+ def test_dns_compression_loop_attack():
+     """Test our wire parser does not loop forever when dns compression is in a loop."""
+     packet = (

--- a/python/python3-zeroconf/patches/stop-lan-local-memory-exhaustion.patch
+++ b/python/python3-zeroconf/patches/stop-lan-local-memory-exhaustion.patch
@@ -1,0 +1,367 @@
+--- a/src/zeroconf/_protocol/incoming.py
++++ b/src/zeroconf/_protocol/incoming.py
+@@ -37,7 +37,7 @@
+     DNSText,
+ )
+ from .._exceptions import IncomingDecodeError
+-from .._logger import log
++from .._logger import _mark_seen, log
+ from .._utils.time import current_time_millis
+ from ..const import (
+     _FLAGS_QR_MASK,
+@@ -63,7 +63,7 @@
+ DECODE_EXCEPTIONS = (IndexError, struct.error, IncomingDecodeError, RecursionError)
+ 
+ 
+-_seen_logs: dict[str, int | tuple] = {}
++_seen_logs: dict[str, None] = {}
+ _str = str
+ _int = int
+ 
+@@ -182,13 +182,7 @@
+ 
+     @classmethod
+     def _log_exception_debug(cls, *logger_data: Any) -> None:
+-        log_exc_info = False
+-        exc_info = sys.exc_info()
+-        exc_str = str(exc_info[1])
+-        if exc_str not in _seen_logs:
+-            # log the trace only on the first time
+-            _seen_logs[exc_str] = exc_info
+-            log_exc_info = True
++        log_exc_info = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
+         log.debug(*(logger_data or ["Exception occurred"]), exc_info=log_exc_info)
+ 
+     def answers(self) -> list[DNSRecord]:
+--- a/src/zeroconf/_logger.py
++++ b/src/zeroconf/_logger.py
+@@ -25,7 +25,7 @@
+ 
+ import logging
+ import sys
+-from typing import Any, ClassVar, cast
++from typing import Any
+ 
+ log = logging.getLogger(__name__.split(".", maxsplit=1)[0])
+ log.addHandler(logging.NullHandler())
+@@ -39,50 +39,73 @@
+ set_logger_level_if_unset()
+ 
+ 
+-class QuietLogger:
+-    _seen_logs: ClassVar[dict[str, int | tuple]] = {}
++_MAX_SEEN_LOGS = 512
++_seen_logs: dict[str, None] = {}
++
++
++def _evict_oldest(seen: dict[str, None]) -> bool:
++    """Pop the oldest entry from ``seen``; return False if it raced.
+ 
++    Individual dict ops (``pop`` with a default, ``next``) are atomic
++    on the free-threaded build, but the compound ``iter`` → ``next``
++    used to pick the FIFO victim can raise ``RuntimeError`` if
++    another thread mutates the dict between the two ops. The caller
++    breaks its drain loop on False so concurrent mutation can't make
++    it spin.
++    """
++    try:
++        seen.pop(next(iter(seen)), None)
++    except (RuntimeError, StopIteration):
++        return False
++    return True
++
++
++def _mark_seen(seen: dict[str, None], key: str) -> bool:
++    """Record ``key`` in ``seen`` and return True if it was newly added.
++
++    Bounds the dict so callers passing attacker-influenced keys (peer
++    addresses, packet offsets) cannot grow it without bound. Evicts
++    the oldest entries on overflow (dict preserves insertion order on
++    Python 3.7+), so ``_MAX_SEEN_LOGS`` is a recency window.
++
++    The dict is shared across all ``Zeroconf`` instances in the
++    process; on the free-threaded build (3.14t) and under multi-
++    instance sync use, callers can race the ``len < cap`` check and
++    both insert, leaving the dict transiently above the cap. The
++    drain loop runs on every call (steady-state-at-cap hits are a
++    single ``len`` + compare past the membership check because the
++    helper short-circuits) so a contention burst is corrected by the
++    next caller regardless of whether it's a hit or a miss.
++    """
++    inserting = key not in seen
++    # Hit (``inserting`` is False): drain only if drifted above cap.
++    # Miss (``inserting`` is True): drain to ``cap - 1`` to make room
++    # for the new key. Bool subtracts as 0/1 to pick the right limit.
++    while len(seen) > _MAX_SEEN_LOGS - inserting and _evict_oldest(seen):
++        pass
++    if inserting:
++        seen[key] = None
++    return inserting
++
++
++class QuietLogger:
+     @classmethod
+     def log_exception_warning(cls, *logger_data: Any) -> None:
+-        exc_info = sys.exc_info()
+-        exc_str = str(exc_info[1])
+-        if exc_str not in cls._seen_logs:
+-            # log at warning level the first time this is seen
+-            cls._seen_logs[exc_str] = exc_info
+-            logger = log.warning
+-        else:
+-            logger = log.debug
++        first_time = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
++        logger = log.warning if first_time else log.debug
+         logger(*(logger_data or ["Exception occurred"]), exc_info=True)
+ 
+     @classmethod
+     def log_exception_debug(cls, *logger_data: Any) -> None:
+-        log_exc_info = False
+-        exc_info = sys.exc_info()
+-        exc_str = str(exc_info[1])
+-        if exc_str not in cls._seen_logs:
+-            # log the trace only on the first time
+-            cls._seen_logs[exc_str] = exc_info
+-            log_exc_info = True
+-        log.debug(*(logger_data or ["Exception occurred"]), exc_info=log_exc_info)
++        first_time = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
++        log.debug(*(logger_data or ["Exception occurred"]), exc_info=first_time)
+ 
+     @classmethod
+     def log_warning_once(cls, *args: Any) -> None:
+-        msg_str = args[0]
+-        if msg_str not in cls._seen_logs:
+-            cls._seen_logs[msg_str] = 0
+-            logger = log.warning
+-        else:
+-            logger = log.debug
+-        cls._seen_logs[msg_str] = cast(int, cls._seen_logs[msg_str]) + 1
++        logger = log.warning if _mark_seen(_seen_logs, args[0]) else log.debug
+         logger(*args)
+ 
+     @classmethod
+     def log_exception_once(cls, exc: Exception, *args: Any) -> None:
+-        msg_str = args[0]
+-        if msg_str not in cls._seen_logs:
+-            cls._seen_logs[msg_str] = 0
+-            logger = log.warning
+-        else:
+-            logger = log.debug
+-        cls._seen_logs[msg_str] = cast(int, cls._seen_logs[msg_str]) + 1
++        logger = log.warning if _mark_seen(_seen_logs, args[0]) else log.debug
+         logger(*args, exc_info=exc)
+--- /dev/null
++++ b/tests/benchmarks/test_mark_seen.py
+@@ -0,0 +1,39 @@
++"""Benchmark for _logger._mark_seen."""
++
++from __future__ import annotations
++
++from pytest_codspeed import BenchmarkFixture
++
++from zeroconf._logger import _MAX_SEEN_LOGS, _mark_seen
++
++
++def test_mark_seen_hit(benchmark: BenchmarkFixture) -> None:
++    """Benchmark the cache-hit path (same key repeated)."""
++    seen: dict[str, None] = {"warm": None}
++
++    @benchmark
++    def _hit() -> None:
++        for _ in range(1000):
++            _mark_seen(seen, "warm")
++
++
++def test_mark_seen_fill(benchmark: BenchmarkFixture) -> None:
++    """Benchmark filling from empty up to the cap (no evictions)."""
++    keys = [f"key-{i}" for i in range(_MAX_SEEN_LOGS)]
++
++    @benchmark
++    def _fill() -> None:
++        seen: dict[str, None] = {}
++        for k in keys:
++            _mark_seen(seen, k)
++
++
++def test_mark_seen_churn(benchmark: BenchmarkFixture) -> None:
++    """Benchmark sustained eviction (every call past the cap drops oldest)."""
++    keys = [f"churn-{i}" for i in range(_MAX_SEEN_LOGS * 4)]
++
++    @benchmark
++    def _churn() -> None:
++        seen: dict[str, None] = {}
++        for k in keys:
++            _mark_seen(seen, k)
+--- a/tests/test_logger.py
++++ b/tests/test_logger.py
+@@ -5,7 +5,8 @@
+ import logging
+ from unittest.mock import call, patch
+ 
+-from zeroconf._logger import QuietLogger, set_logger_level_if_unset
++from zeroconf import _logger
++from zeroconf._logger import _MAX_SEEN_LOGS, QuietLogger, _mark_seen, set_logger_level_if_unset
+ 
+ 
+ def test_loading_logger():
+@@ -25,7 +26,7 @@
+ 
+ def test_log_warning_once():
+     """Test we only log with warning level once."""
+-    QuietLogger._seen_logs = {}
++    _logger._seen_logs.clear()
+     quiet_logger = QuietLogger()
+     with (
+         patch("zeroconf._logger.log.warning") as mock_log_warning,
+@@ -48,7 +49,7 @@
+ 
+ def test_log_exception_warning():
+     """Test we only log with warning level once."""
+-    QuietLogger._seen_logs = {}
++    _logger._seen_logs.clear()
+     quiet_logger = QuietLogger()
+     with (
+         patch("zeroconf._logger.log.warning") as mock_log_warning,
+@@ -71,7 +72,7 @@
+ 
+ def test_llog_exception_debug():
+     """Test we only log with a trace once."""
+-    QuietLogger._seen_logs = {}
++    _logger._seen_logs.clear()
+     quiet_logger = QuietLogger()
+     with patch("zeroconf._logger.log.debug") as mock_log_debug:
+         quiet_logger.log_exception_debug("the exception")
+@@ -84,9 +85,82 @@
+     assert mock_log_debug.mock_calls == [call("the exception", exc_info=False)]
+ 
+ 
++def test_mark_seen_absorbs_runtime_error_during_eviction() -> None:
++    """Concurrent mutation can make ``iter(seen)`` raise ``RuntimeError``.
++    Free-threaded (3.14t) and multi-instance sync callers share
++    ``_seen_logs``; if another thread mutates it between ``iter()``
++    and ``next()`` the iterator raises ``RuntimeError``.
++    ``_mark_seen`` must absorb that and still insert the new key.
++    """
++
++    class RacyDict(dict[str, None]):
++        def __iter__(self):  # type: ignore[override]
++            raise RuntimeError("dictionary changed size during iteration")
++
++    seen: dict[str, None] = RacyDict()
++    for i in range(_MAX_SEEN_LOGS):
++        seen[f"k-{i}"] = None
++    assert _mark_seen(seen, "new-key") is True
++    assert "new-key" in seen
++
++
++def test_mark_seen_drains_drift_above_cap() -> None:
++    """``_mark_seen`` drains a drifted-over-cap dict back to the cap.
++    Concurrent inserts on the free-threaded build can leave the dict
++    transiently above ``_MAX_SEEN_LOGS`` (e.g. two threads both passed
++    the ``len < cap`` check and both inserted). The next non-racing
++    call must drain the accumulated overshoot, not just evict one
++    entry — otherwise the cap silently inflates with thread count.
++    """
++    seen: dict[str, None] = {}
++    drift = 10
++    for i in range(_MAX_SEEN_LOGS + drift):
++        seen[f"k-{i}"] = None
++    assert len(seen) == _MAX_SEEN_LOGS + drift
++    assert _mark_seen(seen, "new-key") is True
++    assert len(seen) == _MAX_SEEN_LOGS
++    assert "new-key" in seen
++    for i in range(drift + 1):
++        assert f"k-{i}" not in seen
++
++
++def test_mark_seen_drains_drift_on_hit_path() -> None:
++    """``_mark_seen`` drains drift even when ``key`` is already cached.
++    A hit-heavy workload after a contention burst (e.g. the same
++    exception text deduplicated repeatedly) must still correct the
++    overshoot — otherwise the dict can sit permanently above the cap
++    until a miss happens to come along.
++    """
++    seen: dict[str, None] = {}
++    drift = 10
++    for i in range(_MAX_SEEN_LOGS + drift):
++        seen[f"k-{i}"] = None
++    # Hit on a non-oldest key — survives the drift drain.
++    hit_key = f"k-{_MAX_SEEN_LOGS}"
++    assert _mark_seen(seen, hit_key) is False
++    assert len(seen) == _MAX_SEEN_LOGS
++    assert hit_key in seen
++    for i in range(drift):
++        assert f"k-{i}" not in seen
++
++
++def test_seen_logs_is_bounded() -> None:
++    """``_seen_logs`` stays at the cap and evicts oldest-first (FIFO)."""
++    _logger._seen_logs.clear()
++    overflow = 5
++    with patch("zeroconf._logger.log.warning"), patch("zeroconf._logger.log.debug"):
++        for i in range(_MAX_SEEN_LOGS + overflow):
++            QuietLogger.log_warning_once(f"warning-{i}")
++    assert len(_logger._seen_logs) == _MAX_SEEN_LOGS
++    for i in range(overflow):
++        assert f"warning-{i}" not in _logger._seen_logs
++    for i in range(_MAX_SEEN_LOGS, _MAX_SEEN_LOGS + overflow):
++        assert f"warning-{i}" in _logger._seen_logs
++
++
+ def test_log_exception_once():
+     """Test we only log with warning level once."""
+-    QuietLogger._seen_logs = {}
++    _logger._seen_logs.clear()
+     quiet_logger = QuietLogger()
+     exc = Exception()
+     with (
+--- a/tests/test_protocol.py
++++ b/tests/test_protocol.py
+@@ -14,6 +14,8 @@
+ 
+ import zeroconf as r
+ from zeroconf import DNSHinfo, DNSIncoming, DNSText, const, current_time_millis
++from zeroconf._logger import _MAX_SEEN_LOGS
++from zeroconf._protocol import incoming as _incoming_module
+ 
+ from . import has_working_ipv6
+ 
+@@ -962,6 +964,38 @@
+     assert "Received invalid packet from ('1.2.3.4', 5353)" in caplog.text
+ 
+ 
++def test_seen_logs_is_bounded():
++    """Corrupt packets from varying peers fill ``_seen_logs`` exactly to the cap."""
++    packet = (
++        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x06domain\x05local\x00\x00\x01"
++        b"\x80\x01\x00\x00\x00\x01\x00\x04\xc0\xa8\xd0\x05-\x0c\x00\x01\x80\x01\x00\x00"
++        b"\x00\x01\x00\x04\xc0\xa8\xd0\x06"
++    )
++    overflow = 5
++    _incoming_module._seen_logs.clear()
++    # Snapshot the actual key the parser inserted per port. This is whatever
++    # ``str(exc_info()[1])`` produces today — the test stays agnostic to the
++    # exception text format so a future normalization of the message (see
++    # the discussion on #1714) doesn't break the assertions, while still
++    # pinning that the parser exception path actually entered the dict.
++    keys_per_port: list[str] = []
++    for port in range(_MAX_SEEN_LOGS + overflow):
++        r.DNSIncoming(packet, ("1.2.3.4", port))
++        keys_per_port.append(next(reversed(_incoming_module._seen_logs)))
++    # Bound is hit exactly.
++    assert len(_incoming_module._seen_logs) == _MAX_SEEN_LOGS
++    # Each port produced a distinct dedup key — a regression that dropped
++    # the per-packet-varying component (e.g. self.source) from the exception
++    # text would collapse all 517 calls to one key and fail this.
++    assert len(set(keys_per_port)) == _MAX_SEEN_LOGS + overflow
++    # FIFO eviction by key identity (no substring matching on the message
++    # format): the earliest ports' keys are gone, the latest ports' remain.
++    for port in range(overflow):
++        assert keys_per_port[port] not in _incoming_module._seen_logs
++    for port in range(_MAX_SEEN_LOGS, _MAX_SEEN_LOGS + overflow):
++        assert keys_per_port[port] in _incoming_module._seen_logs
++
++
+ def test_label_length_attack():
+     """Test our wire parser does not loop forever when the name exceeds 253 chars."""
+     packet = (

--- a/python/python3-zeroconf/patches/stop-mDNS-floods.patch
+++ b/python/python3-zeroconf/patches/stop-mDNS-floods.patch
@@ -1,0 +1,526 @@
+--- a/src/zeroconf/_cache.pxd
++++ b/src/zeroconf/_cache.pxd
+@@ -19,6 +19,7 @@
+ cdef unsigned int _TYPE_PTR
+ cdef cython.uint _ONE_SECOND
+ cdef unsigned int _MIN_SCHEDULED_RECORD_EXPIRATION
++cdef unsigned int _MAX_CACHE_RECORDS
+ 
+ 
+ @cython.locals(record_cache=dict)
+@@ -31,6 +32,7 @@
+     cdef public cython.dict service_cache
+     cdef public list _expire_heap
+     cdef public dict _expirations
++    cdef public unsigned int _total_records
+ 
+     cpdef bint async_add_records(self, object entries)
+ 
+@@ -60,10 +62,17 @@
+         service_store=cython.dict,
+         service_record=DNSService,
+         when=object,
+-        new=bint
++        new=bint,
++        is_new=bint
+     )
+     cdef bint _async_add(self, DNSRecord record)
+ 
++    @cython.locals(record=DNSRecord, when_record=tuple)
++    cdef void _async_evict_oldest(self)
++
++    @cython.locals(expire_heap_len="unsigned int")
++    cdef void _maybe_rebuild_heap(self)
++
+     @cython.locals(service_record=DNSService)
+     cdef void _async_remove(self, DNSRecord record)
+
+--- a/src/zeroconf/_cache.py
++++ b/src/zeroconf/_cache.py
+@@ -37,7 +37,7 @@
+     DNSText,
+ )
+ from ._utils.time import current_time_millis
+-from .const import _ONE_SECOND, _TYPE_PTR
++from .const import _MAX_CACHE_RECORDS, _ONE_SECOND, _TYPE_PTR
+ 
+ _UNIQUE_RECORD_TYPES = (DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService)
+ _UniqueRecordsType = Union[DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService]
+@@ -72,6 +72,7 @@
+         self._expire_heap: list[tuple[float, DNSRecord]] = []
+         self._expirations: dict[DNSRecord, float] = {}
+         self.service_cache: _DNSRecordCacheType = {}
++        self._total_records: int = 0
+ 
+     # Functions prefixed with async_ are NOT threadsafe and must
+     # be run in the event loop.
+@@ -89,15 +90,34 @@
+         # replaces any existing records that are __eq__ to each other which
+         # removes the risk that accessing the cache from the wrong
+         # direction would return the old incorrect entry.
+-        if (store := self.cache.get(record.key)) is None:
++        store = self.cache.get(record.key)
++        is_new = store is None or record not in store
++        # Bound total cache size; evict closest-to-expiration entry to
++        # make room before inserting a new record. Prevents a LAN-local
++        # flood of unique-name records from growing the cache without
++        # bound (RFC 6762 §10 advisory caching, defense-in-depth).
++        if is_new and self._total_records >= _MAX_CACHE_RECORDS:
++            self._async_evict_oldest()
++            # The victim may have been the last record under
++            # ``record.key``, in which case ``_remove_key`` deleted
++            # the bucket. Re-fetch before creating below.
++            store = self.cache.get(record.key)
++        if store is None:
+             store = self.cache[record.key] = {}
+-        new = record not in store and not isinstance(record, DNSNsec)
++        new = is_new and not isinstance(record, DNSNsec)
++        if is_new:
++            self._total_records += 1
+         store[record] = record
+         when = record.created + (record.ttl * 1000)
+         if self._expirations.get(record) != when:
+-            # Avoid adding duplicates to the heap
+             heappush(self._expire_heap, (when, record))
+             self._expirations[record] = when
++            # Re-adds of an existing record with a new TTL push a fresh
++            # entry but leave the prior tuple behind as stale, so a peer
++            # that just replays cached records can grow ``_expire_heap``
++            # without ever tripping the cap. Rebuild when stale entries
++            # dominate.
++            self._maybe_rebuild_heap()
+ 
+         if isinstance(record, DNSService):
+             service_record = record
+@@ -106,6 +126,28 @@
+             service_store[service_record] = service_record
+         return new
+ 
++    def _async_evict_oldest(self) -> None:
++        """Drop the closest-to-expiration record to make room for a new one."""
++        while self._expire_heap:
++            when_record = heappop(self._expire_heap)
++            record = when_record[1]
++            if self._expirations.get(record) != when_record[0]:
++                continue
++            self._async_remove(record)
++            return
++
++    def _maybe_rebuild_heap(self) -> None:
++        """Rebuild ``_expire_heap`` when stale entries dominate live ones."""
++        expire_heap_len = len(self._expire_heap)
++        if (
++            expire_heap_len > _MIN_SCHEDULED_RECORD_EXPIRATION
++            and expire_heap_len > len(self._expirations) * 2
++        ):
++            self._expire_heap = [
++                entry for entry in self._expire_heap if self._expirations.get(entry[1]) == entry[0]
++            ]
++            heapify(self._expire_heap)
++
+     def async_add_records(self, entries: Iterable[DNSRecord]) -> bool:
+         """Add multiple records.
+ 
+@@ -129,6 +171,7 @@
+             _remove_key(self.service_cache, service_record.server_key, service_record)
+         _remove_key(self.cache, record.key, record)
+         self._expirations.pop(record, None)
++        self._total_records -= 1
+ 
+     def async_remove_records(self, entries: Iterable[DNSRecord]) -> None:
+         """Remove multiple records.
+@@ -145,43 +188,23 @@
+ 
+         :param now: The current time in milliseconds.
+         """
+-        if not (expire_heap_len := len(self._expire_heap)):
++        if not self._expire_heap:
+             return []
+ 
+         expired: list[DNSRecord] = []
+-        # Find any expired records and add them to the to-delete list
+         while self._expire_heap:
+             when_record = self._expire_heap[0]
+             when = when_record[0]
+             if when > now:
+                 break
+             heappop(self._expire_heap)
+-            # Check if the record hasn't been re-added to the heap
+-            # with a different expiration time as it will be removed
+-            # later when it reaches the top of the heap and its
+-            # expiration time is met.
++            # Skip entries left behind by a TTL re-add; the live tuple is
++            # later in the heap and will be removed when it reaches the top.
+             record = when_record[1]
+             if self._expirations.get(record) == when:
+                 expired.append(record)
+ 
+-        # If the expiration heap grows larger than the number expirations
+-        # times two, we clean it up to avoid keeping expired entries in
+-        # the heap and consuming memory. We guard this with a minimum
+-        # threshold to avoid cleaning up the heap too often when there are
+-        # only a few scheduled expirations.
+-        if (
+-            expire_heap_len > _MIN_SCHEDULED_RECORD_EXPIRATION
+-            and expire_heap_len > len(self._expirations) * 2
+-        ):
+-            # Remove any expired entries from the expiration heap
+-            # that do not match the expiration time in the expirations
+-            # as it means the record has been re-added to the heap
+-            # with a different expiration time.
+-            self._expire_heap = [
+-                entry for entry in self._expire_heap if self._expirations.get(entry[1]) == entry[0]
+-            ]
+-            heapify(self._expire_heap)
+-
++        self._maybe_rebuild_heap()
+         self.async_remove_records(expired)
+         return expired
+
+--- a/src/zeroconf/const.py
++++ b/src/zeroconf/const.py
+@@ -59,6 +59,12 @@
+ # level of rate limit and safe guards so we use 1/4 of the recommended value
+ _DNS_PTR_MIN_TTL = 1125
+ 
++# Upper bound on the number of records the DNSCache will hold before it
++# starts evicting the closest-to-expiration entry to make room for new
++# arrivals. Bounds the memory a malicious LAN peer can force the cache
++# to retain by multicasting many unique-name records.
++_MAX_CACHE_RECORDS = 10000
++
+ _DNS_PACKET_HEADER_LEN = 12
+ 
+ _MAX_MSG_TYPICAL = 1460  # unused
+--- /dev/null
++++ b/tests/benchmarks/test_cache_bound.py
+@@ -0,0 +1,68 @@
++"""Benchmark for the DNSCache record-count bound + overflow eviction."""
++
++from __future__ import annotations
++
++from collections.abc import Iterator
++from itertools import count
++
++from pytest_codspeed import BenchmarkFixture
++
++from zeroconf import DNSAddress, DNSCache, current_time_millis
++from zeroconf.const import _CLASS_IN, _MAX_CACHE_RECORDS, _TYPE_A
++
++
++def _make_records(count_: int, now: float, prefix: str = "bench") -> list[DNSAddress]:
++    return [
++        DNSAddress(
++            f"{prefix}-{i}.local.",
++            _TYPE_A,
++            _CLASS_IN,
++            120,
++            bytes(((i >> 24) & 0xFF, (i >> 16) & 0xFF, (i >> 8) & 0xFF, i & 0xFF)),
++            created=now + i,
++        )
++        for i in range(count_)
++    ]
++
++
++def _unbounded_records(now: float, prefix: str = "evict") -> Iterator[DNSAddress]:
++    """Unbounded generator of unique-name DNSAddress records."""
++    for i in count():
++        yield DNSAddress(
++            f"{prefix}-{i}.local.",
++            _TYPE_A,
++            _CLASS_IN,
++            120,
++            bytes(((i >> 24) & 0xFF, (i >> 16) & 0xFF, (i >> 8) & 0xFF, i & 0xFF)),
++            created=now + i,
++        )
++
++
++def test_cache_add_below_cap(benchmark: BenchmarkFixture) -> None:
++    """Adding records while the cache is well below the cap (no eviction)."""
++    now = current_time_millis()
++    records = _make_records(1000, now)
++
++    @benchmark
++    def _add() -> None:
++        cache = DNSCache()
++        cache.async_add_records(records)
++
++
++def test_cache_add_at_cap_evicts(benchmark: BenchmarkFixture) -> None:
++    """Steady-state add at the cap: every measured insert forces one eviction.
++
++    Pre-fills the cache to ``_MAX_CACHE_RECORDS`` outside the timed body so
++    only the eviction-path adds are measured. Each benchmark iteration
++    pulls one fresh unique record from an unbounded generator, keeping the
++    cache permanently at the cap. The generator avoids the iteration-count
++    cap that a pre-built pool would impose for very fast operations.
++    """
++    now = current_time_millis()
++    cache = DNSCache()
++    cache.async_add_records(_make_records(_MAX_CACHE_RECORDS, now, prefix="fill"))
++    pool = _unbounded_records(now + _MAX_CACHE_RECORDS)
++
++    @benchmark
++    def _evict_one() -> None:
++        cache.async_add_records([next(pool)])
+--- a/tests/test_cache.py
++++ b/tests/test_cache.py
+@@ -439,7 +439,9 @@
+         )
+         cache.async_add_records([record])
+ 
+-    assert len(cache._expire_heap) == min_records_to_cleanup + 5
++    # ``_async_add`` rebuilds ``_expire_heap`` proactively when stale entries
++    # dominate (heap > 2x expirations), so the heap is already capped at
++    # ~one entry per unique record long before ``async_expire`` is called.
+     assert len(cache.async_entries_with_name(name)) == 1
+     assert len(cache.async_entries_with_name(name2)) == 5
+ 
+@@ -473,7 +475,8 @@
+         )
+         cache.async_add_records([record])
+ 
+-    assert len(cache._expire_heap) == min_records_to_cleanup + 5
++    # ``_async_add`` proactively rebuilds the heap when stale entries dominate,
++    # so the heap holds only one entry per unique record by this point.
+     assert len(cache.async_entries_with_name(name)) == 1
+     assert len(cache.async_entries_with_name(name2)) == 5
+ 
+@@ -482,3 +485,237 @@
+         ts, _ = heappop(cache._expire_heap)
+         assert ts >= start_ts
+         start_ts = ts
++
++
++def _addr(name: str, idx: int, *, ttl: int = 120, created: float | None = None) -> r.DNSAddress:
++    """Build a DNSAddress with idx-derived payload for the bound/eviction tests."""
++    return r.DNSAddress(
++        name,
++        const._TYPE_A,
++        const._CLASS_IN,
++        ttl,
++        bytes((idx & 0xFF, (idx >> 8) & 0xFF, 0, 1)),
++        created=r.current_time_millis() if created is None else created,
++    )
++
++
++def test_cache_size_is_bounded() -> None:
++    """A flood of unique-name records is capped at ``_MAX_CACHE_RECORDS``."""
++    cache = r.DNSCache()
++    now = r.current_time_millis()
++    overflow = 1000
++    flood_size = const._MAX_CACHE_RECORDS + overflow
++
++    cache.async_add_records(_addr(f"flood-{i}.local.", i, created=now + i) for i in range(flood_size))
++
++    total = sum(len(store) for store in cache.cache.values())
++    assert total == const._MAX_CACHE_RECORDS
++    assert cache._total_records == const._MAX_CACHE_RECORDS
++    # FIFO-ish: the earliest-created records (closest to expiration) get
++    # evicted first, so the names that remain are from the tail.
++    for i in range(overflow):
++        assert f"flood-{i}.local." not in cache.cache
++    for i in range(flood_size - overflow, flood_size):
++        assert f"flood-{i}.local." in cache.cache
++
++
++def test_cache_eviction_empty_heap_returns_without_evicting() -> None:
++    """Eviction tolerates an empty ``_expire_heap`` (invariant-violation safety net)."""
++    cache = r.DNSCache()
++    # By the cache invariant every record in ``_total_records`` has a heap
++    # entry, so eviction should never see an empty heap. Force the broken
++    # state directly to pin the defensive behaviour: ``_async_evict_oldest``
++    # returns without raising and the subsequent insert still lands. Since
++    # eviction can't free space, the counter is allowed to drift past the
++    # cap by exactly one — pinned so a future change to the recovery
++    # semantics (e.g., refusing the add or clamping) fails this test.
++    cache._total_records = const._MAX_CACHE_RECORDS
++    cache._expire_heap = []
++    cache.async_add_records([_addr("post-empty.local.", 0)])
++    assert "post-empty.local." in cache.cache
++    assert cache._total_records == const._MAX_CACHE_RECORDS + 1
++
++
++def test_cache_eviction_skips_stale_heap_entries() -> None:
++    """Eviction skips stale heap entries left by TTL re-adds."""
++    cache = r.DNSCache()
++    now = r.current_time_millis()
++    cache.async_add_records(
++        _addr(f"stale-{i}.local.", i, created=now + i) for i in range(const._MAX_CACHE_RECORDS)
++    )
++    assert cache._total_records == const._MAX_CACHE_RECORDS
++
++    # Re-add the closest-to-expiration record with a longer TTL; the prior
++    # ``(when, record)`` tuple stays as stale, eviction must skip it.
++    victim_name = "stale-0.local."
++    cache.async_add_records([_addr(victim_name, 0, ttl=7200, created=now)])
++    assert cache._total_records == const._MAX_CACHE_RECORDS
++
++    cache.async_add_records([_addr("trigger.local.", 0xFFFF, created=now + const._MAX_CACHE_RECORDS)])
++    assert cache._total_records == const._MAX_CACHE_RECORDS
++    assert victim_name in cache.cache
++    assert "stale-1.local." not in cache.cache
++
++
++def test_cache_eviction_victim_shares_key_with_new_record() -> None:
++    """Inserting a record whose key collides with the eviction victim keeps it reachable."""
++    cache = r.DNSCache()
++    now = r.current_time_millis()
++    cache.async_add_records(
++        _addr(f"filler-{i}.local.", i, created=now + 1000 + i) for i in range(const._MAX_CACHE_RECORDS - 1)
++    )
++
++    # Insert at "shared.local." with the earliest expiration so eviction
++    # picks it. ``_remove_key`` then deletes ``cache["shared.local."]``.
++    shared_key = "shared.local."
++    cache.async_add_records([_addr(shared_key, 0x0102, created=now)])
++    assert cache._total_records == const._MAX_CACHE_RECORDS
++
++    # Adding a new record under the SAME key: a pre-eviction-captured
++    # ``store`` would write into an orphaned dict; the fix re-resolves.
++    new_shared = _addr(shared_key, 0x0506, created=now + 999)
++    cache.async_add_records([new_shared])
++
++    assert shared_key in cache.cache, "new record orphaned: cache bucket missing"
++    assert new_shared in cache.cache[shared_key]
++    assert cache.async_get_unique(new_shared) == new_shared
++    total = sum(len(store) for store in cache.cache.values())
++    assert total == cache._total_records
++
++
++def test_cache_dnsnsec_at_cap_evicts_prior_record() -> None:
++    """A single DNSNsec arriving at the cap evicts one prior record and stays reachable."""
++    cache = r.DNSCache()
++    now = r.current_time_millis()
++    cache.async_add_records(
++        _addr(f"fill-{i}.local.", i, created=now + i) for i in range(const._MAX_CACHE_RECORDS)
++    )
++    assert cache._total_records == const._MAX_CACHE_RECORDS
++
++    nsec = r.DNSNsec(
++        "nsec-arrival.local.",
++        const._TYPE_NSEC,
++        const._CLASS_IN,
++        120,
++        "nsec-arrival.local.",
++        [const._TYPE_A],
++    )
++    cache.async_add_records([nsec])
++
++    assert cache._total_records == const._MAX_CACHE_RECORDS
++    assert nsec in cache.cache[nsec.key]
++    # The earliest-created fill record is gone (FIFO-ish eviction).
++    assert "fill-0.local." not in cache.cache
++
++
++def test_cache_dnsnsec_flood_is_bounded() -> None:
++    """DNSNsec records honour ``_MAX_CACHE_RECORDS`` (no bypass via the ``new`` flag)."""
++    cache = r.DNSCache()
++    overflow = 100
++    cache.async_add_records(
++        r.DNSNsec(
++            f"nsec-{i}.local.",
++            const._TYPE_NSEC,
++            const._CLASS_IN,
++            120,
++            f"nsec-{i}.local.",
++            [const._TYPE_A],
++        )
++        for i in range(const._MAX_CACHE_RECORDS + overflow)
++    )
++    assert cache._total_records == const._MAX_CACHE_RECORDS
++    total = sum(len(store) for store in cache.cache.values())
++    assert total == const._MAX_CACHE_RECORDS
++
++
++def test_cache_re_add_flood_does_not_grow_heap_unbounded() -> None:
++    """Replaying cached records with shifting TTLs cannot grow ``_expire_heap`` unbounded."""
++    cache = r.DNSCache()
++    now = r.current_time_millis()
++    # Stay below the cache cap so eviction never fires; the attack here is
++    # heap growth via re-add, not cap saturation. Clear the
++    # ``_MIN_SCHEDULED_RECORD_EXPIRATION`` floor so the rebuild engages.
++    record_count = 200
++    cache.async_add_records(_addr(f"flood-{i}.local.", i, created=now) for i in range(record_count))
++    assert cache._total_records == record_count
++
++    # 10 cycles x ``record_count`` stale pushes each. Without
++    # ``_maybe_rebuild_heap`` firing inside ``_async_add``, the heap would
++    # grow to ~11 x record_count.
++    for cycle in range(10):
++        cache.async_add_records(
++            _addr(f"flood-{i}.local.", i, ttl=7200 + cycle, created=now) for i in range(record_count)
++        )
++
++    # Heap is bounded near the rebuild threshold; ``+ record_count`` of slack
++    # to stay resilient to where in a re-add cycle the rebuild last fired.
++    assert len(cache._expire_heap) <= 2 * len(cache._expirations) + record_count
++    assert cache._total_records == record_count
++
++
++def test_cache_eviction_decrements_total_records() -> None:
++    """Natural removal (goodbyes, expirations) keeps ``_total_records`` in sync."""
++    cache = r.DNSCache()
++    now = r.current_time_millis()
++    records = [_addr(f"sync-{i}.local.", i, created=now) for i in range(50)]
++    cache.async_add_records(records)
++    assert cache._total_records == 50
++
++    cache.async_remove_records(records[:20])
++    assert cache._total_records == 30
++
++    cache.async_expire(now + (200 * 1000))
++    assert cache._total_records == 0
++    assert not cache.cache
++
++
++def test_cache_total_records_invariant_under_mixed_ops() -> None:
++    """``_total_records`` stays equal to the sum of bucket sizes across all touched paths."""
++    cache = r.DNSCache()
++    now = r.current_time_millis()
++
++    def actual() -> int:
++        return sum(len(store) for store in cache.cache.values())
++
++    addrs = [_addr(f"mix-{i}.local.", i, created=now + i) for i in range(20)]
++    cache.async_add_records(addrs)
++    assert cache._total_records == actual() == 20
++
++    # Re-add of an identical record: no increment.
++    cache.async_add_records([addrs[0]])
++    assert cache._total_records == actual() == 20
++
++    # DNSService writes service_cache too — counter still matches cache size.
++    svc = r.DNSService("svc.local.", const._TYPE_SRV, const._CLASS_IN, 120, 0, 0, 80, "host.local.")
++    cache.async_add_records([svc])
++    assert cache._total_records == actual() == 21
++    cache.async_remove_records([svc])
++    assert cache._total_records == actual() == 20
++
++    # DNSNsec is stored but excluded from the "new" return; counter tracks it anyway.
++    nsec = r.DNSNsec("nsec.local.", const._TYPE_NSEC, const._CLASS_IN, 120, "nsec.local.", [const._TYPE_A])
++    cache.async_add_records([nsec])
++    assert cache._total_records == actual() == 21
++    cache.async_remove_records([nsec])
++    assert cache._total_records == actual() == 20
++
++    # Shared-key insert/remove: emptying the bucket drops the cache key but
++    # counter decrements only by the records that left.
++    shared_a = _addr("shared.local.", 0x0101, created=now)
++    shared_b = _addr("shared.local.", 0x0202, created=now)
++    cache.async_add_records([shared_a, shared_b])
++    assert cache._total_records == actual() == 22
++    cache.async_remove_records([shared_a, shared_b])
++    assert cache._total_records == actual() == 20
++    assert "shared.local." not in cache.cache
++
++    cache.async_expire(now + (200 * 1000))
++    assert cache._total_records == actual() == 0
++    assert not cache.cache
++
++    # Full-cap eviction loop: counter never grows past the cap, never drifts.
++    cap_records = [_addr(f"cap-{i}.local.", i, created=now + i) for i in range(const._MAX_CACHE_RECORDS + 50)]
++    for rec in cap_records:
++        cache.async_add_records([rec])
++        assert cache._total_records == actual()
++    assert cache._total_records == const._MAX_CACHE_RECORDS

--- a/python/python3-zeroconf/patches/stop-read-string-rdlength-overruns.patch
+++ b/python/python3-zeroconf/patches/stop-read-string-rdlength-overruns.patch
@@ -1,6 +1,6 @@
 --- a/src/zeroconf/_protocol/incoming.py
 +++ b/src/zeroconf/_protocol/incoming.py
-@@ -260,12 +260,27 @@
+@@ -254,12 +254,27 @@
          """Reads a character string from the packet"""
          length = self.view[self.offset]
          self.offset += 1
@@ -28,7 +28,7 @@
          info = self.data[self.offset : self.offset + length]
          self.offset += length
          return info
-@@ -303,6 +318,19 @@
+@@ -297,6 +312,19 @@
                      self.data,
                      exc_info=True,
                  )
@@ -48,10 +48,9 @@
              if rec is not None:
                  self._answers.append(rec)
 
-
 --- a/tests/test_protocol.py
 +++ b/tests/test_protocol.py
-@@ -805,6 +805,89 @@
+@@ -807,6 +807,89 @@
      assert nsec_record.next_name == "MyHome54 (2)._meshcop._udp.local."
  
  

--- a/python/python3-zeroconf/patches/stop-spoofed-source-floods.patch
+++ b/python/python3-zeroconf/patches/stop-spoofed-source-floods.patch
@@ -1,0 +1,212 @@
+--- a/src/zeroconf/_listener.pxd
++++ b/src/zeroconf/_listener.pxd
+@@ -11,6 +11,8 @@
+ cdef object log
+ cdef object DEBUG_ENABLED
+ cdef bint TYPE_CHECKING
++cdef cython.uint _MAX_DEFERRED_ADDRS
++cdef cython.uint _MAX_DEFERRED_PER_ADDR
+ 
+ cdef cython.uint _MAX_MSG_ABSOLUTE
+ cdef cython.uint _DUPLICATE_PACKET_SUPPRESSION_INTERVAL
+@@ -38,6 +40,8 @@
+ 
+     cdef _cancel_any_timers_for_addr(self, object addr)
+ 
++    cdef _evict_oldest_deferred(self)
++
+     @cython.locals(incoming=DNSIncoming, deferred=list)
+     cpdef handle_query_or_defer(
+         self,
+--- a/src/zeroconf/_listener.py
++++ b/src/zeroconf/_listener.py
+@@ -32,7 +32,12 @@
+ from ._protocol.incoming import DNSIncoming
+ from ._transport import _WrappedTransport, make_wrapped_transport
+ from ._utils.time import current_time_millis, millis_to_seconds
+-from .const import _DUPLICATE_PACKET_SUPPRESSION_INTERVAL, _MAX_MSG_ABSOLUTE
++from .const import (
++    _DUPLICATE_PACKET_SUPPRESSION_INTERVAL,
++    _MAX_DEFERRED_ADDRS,
++    _MAX_DEFERRED_PER_ADDR,
++    _MAX_MSG_ABSOLUTE,
++)
+ 
+ if TYPE_CHECKING:
+     from ._core import Zeroconf
+@@ -197,7 +202,17 @@
+             self._respond_query(msg, addr, port, transport, v6_flow_scope)
+             return
+ 
++        if addr not in self._deferred and len(self._deferred) >= _MAX_DEFERRED_ADDRS:
++            # Bound total deferred addrs so a spoofed-source flood
++            # cannot keep adding distinct entries; evict the oldest
++            # (insertion-order) entry and discard its in-flight queue.
++            self._evict_oldest_deferred()
++
+         deferred = self._deferred.setdefault(addr, [])
++        if len(deferred) >= _MAX_DEFERRED_PER_ADDR:
++            # Bound per-addr queue length; further fragments from the
++            # same source are dropped until the timer flushes.
++            return
+         # If we get the same packet we ignore it
+         for incoming in reversed(deferred):
+             if incoming.data == msg.data:
+@@ -222,6 +237,21 @@
+         if addr in self._timers:
+             self._timers.pop(addr).cancel()
+ 
++    def _evict_oldest_deferred(self) -> None:
++        """Discard the oldest deferred addr's reassembly state.
++
++        Used when ``_MAX_DEFERRED_ADDRS`` would be exceeded; the
++        evicted addr's queue and timer are dropped without firing, so
++        the bound holds even when an attacker rotates source IPs.
++        Eviction is FIFO (oldest by first-seen, via dict insertion
++        order) rather than LRU so an active flooder cannot pin its
++        slots by re-sending into the same addr.
++        """
++        oldest_addr = next(iter(self._deferred))
++        self._cancel_any_timers_for_addr(oldest_addr)
++        self._deferred_deadlines.pop(oldest_addr, None)
++        del self._deferred[oldest_addr]
++
+     def _respond_query(
+         self,
+         msg: DNSIncoming | None,
+--- a/src/zeroconf/const.py
++++ b/src/zeroconf/const.py
+@@ -65,6 +65,20 @@
+ # to retain by multicasting many unique-name records.
+ _MAX_CACHE_RECORDS = 10000
+ 
++# Per-addr cap on the number of truncated (TC-bit) packets retained for
++# RFC 6762 §18.5 reassembly. The spec anticipates only a handful of
++# segments per truncated query; 16 is well above legitimate need and
++# keeps the per-arrival dedup scan a constant-time cost under a flood.
++_MAX_DEFERRED_PER_ADDR = 16
++
++# Per-listener cap on the number of distinct addrs with in-flight
++# TC-deferral state. Each entry can hold up to _MAX_DEFERRED_PER_ADDR
++# packets of up to _MAX_MSG_ABSOLUTE bytes; 512 leaves headroom for a
++# legitimate burst (LAN-wide power-resume / boot storm where many
++# devices announce at once) while bounding worst-case memory at
++# ~72 MB even when a peer floods with spoofed source IPs.
++_MAX_DEFERRED_ADDRS = 512
++
+ _DNS_PACKET_HEADER_LEN = 12
+ 
+ _MAX_MSG_TYPICAL = 1460  # unused
+--- a/tests/test_core.py
++++ b/tests/test_core.py
+@@ -18,7 +18,7 @@
+ import pytest
+ 
+ import zeroconf as r
+-from zeroconf import NotRunningException, Zeroconf, const, current_time_millis
++from zeroconf import NotRunningException, Zeroconf, _listener, const, current_time_millis
+ from zeroconf._listener import AsyncListener, _WrappedTransport
+ from zeroconf._protocol.incoming import DNSIncoming
+ from zeroconf.asyncio import AsyncZeroconf
+@@ -676,6 +676,101 @@
+     zc.close()
+ 
+ 
++def _make_distinct_tc_packets(count: int, name_prefix: str = "q") -> list[bytes]:
++    """Generate ``count`` byte-distinct TC-flagged query packets for flood inputs."""
++    packets = []
++    for i in range(count):
++        out = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_TC)
++        out.add_question(r.DNSQuestion(f"{name_prefix}{i}._tcp.local.", const._TYPE_PTR, const._CLASS_IN))
++        packets.append(out.packets()[0])
++    return packets
++
++
++def _synthetic_source_ip(i: int) -> str:
++    """Distinct synthetic source IPs from the documentation ranges."""
++    if i < 256:
++        return f"203.0.113.{i}"
++    if i < 512:
++        return f"198.51.100.{i - 256}"
++    return f"192.0.2.{i - 512}"
++
++
++def test_tc_bit_per_addr_queue_is_bounded(quick_timing: None) -> None:
++    """Per-addr deferred queue must not grow past ``_MAX_DEFERRED_PER_ADDR``."""
++    zc = Zeroconf(interfaces=["127.0.0.1"])
++    _wait_for_start(zc)
++    protocol = zc.engine.protocols[0]
++    source_ip = "203.0.113.21"
++
++    extra = 4
++    packets = _make_distinct_tc_packets(const._MAX_DEFERRED_PER_ADDR + extra)
++
++    # Push the reassembly timer well past any possible test runtime
++    # so the bound under test is the only thing that can drop entries.
++    with patch.object(_listener, "_TC_DELAY_RANDOM_INTERVAL", (60_000, 60_001)):
++        for raw in packets:
++            threadsafe_query(zc, protocol, r.DNSIncoming(raw), source_ip, const._MDNS_PORT, Mock(), ())
++
++        assert len(protocol._deferred[source_ip]) == const._MAX_DEFERRED_PER_ADDR
++        # Last ``extra`` packets must have been dropped, not displaced; the
++        # earlier ``_MAX_DEFERRED_PER_ADDR`` entries are the ones retained.
++        retained = [incoming.data for incoming in protocol._deferred[source_ip]]
++        assert retained == packets[: const._MAX_DEFERRED_PER_ADDR]
++
++    zc.close()
++
++
++def test_tc_bit_total_addrs_is_bounded(quick_timing: None) -> None:
++    """Distinct addrs with deferred state must not exceed ``_MAX_DEFERRED_ADDRS``."""
++    zc = Zeroconf(interfaces=["127.0.0.1"])
++    _wait_for_start(zc)
++    protocol = zc.engine.protocols[0]
++
++    raw = _make_distinct_tc_packets(1)[0]
++    extra = 4
++    addrs = [_synthetic_source_ip(i) for i in range(const._MAX_DEFERRED_ADDRS + extra)]
++
++    # Push the reassembly timer well past any possible test runtime
++    # so the bound under test is the only thing that can drop entries;
++    # without this, PyPy / slow runners can fire timers between the
++    # last enqueue and the assertion.
++    with patch.object(_listener, "_TC_DELAY_RANDOM_INTERVAL", (60_000, 60_001)):
++        for source_ip in addrs:
++            threadsafe_query(zc, protocol, r.DNSIncoming(raw), source_ip, const._MDNS_PORT, Mock(), ())
++
++        assert len(protocol._deferred) == const._MAX_DEFERRED_ADDRS
++        assert len(protocol._timers) == const._MAX_DEFERRED_ADDRS
++
++    zc.close()
++
++
++def test_tc_bit_eviction_drops_oldest_addr(quick_timing: None) -> None:
++    """Adding a new addr at capacity drops the oldest insertion (FIFO)."""
++    zc = Zeroconf(interfaces=["127.0.0.1"])
++    _wait_for_start(zc)
++    protocol = zc.engine.protocols[0]
++
++    raw = _make_distinct_tc_packets(1)[0]
++    fillers = [_synthetic_source_ip(i) for i in range(const._MAX_DEFERRED_ADDRS)]
++    new_addr = _synthetic_source_ip(const._MAX_DEFERRED_ADDRS)
++    oldest = fillers[0]
++
++    with patch.object(_listener, "_TC_DELAY_RANDOM_INTERVAL", (60_000, 60_001)):
++        for source_ip in fillers:
++            threadsafe_query(zc, protocol, r.DNSIncoming(raw), source_ip, const._MDNS_PORT, Mock(), ())
++        assert len(protocol._deferred) == const._MAX_DEFERRED_ADDRS
++        assert oldest in protocol._deferred
++
++        # One more distinct addr must evict the oldest insertion-order entry.
++        threadsafe_query(zc, protocol, r.DNSIncoming(raw), new_addr, const._MDNS_PORT, Mock(), ())
++        assert oldest not in protocol._deferred
++        assert oldest not in protocol._timers
++        assert new_addr in protocol._deferred
++        assert len(protocol._deferred) == const._MAX_DEFERRED_ADDRS
++
++    zc.close()
++
++
+ @pytest.mark.asyncio
+ async def test_open_close_twice_from_async() -> None:
+     """Test we can close twice from a coroutine when using Zeroconf.

--- a/python/python3-zeroconf/python3-zeroconf.SlackBuild
+++ b/python/python3-zeroconf/python3-zeroconf.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=python3-zeroconf
 VERSION=${VERSION:-0.148.0}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -64,10 +64,23 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-# Backport security patch from python3-zeroconf 0.149.16
-# This patch bounds record payload reads against rdlength overruns. For more information, please read:
+# Backport security patches from python3-zeroconf >= 0.149.0
+# For more information, please read the security advisory associated with each patch
+
+# https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-9pgc-3ccv-5297
+patch -p1 < $CWD/patches/stop-lan-local-dns.patch
+
+# https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-phvx-9mgw-67r5
+patch -p1 < $CWD/patches/stop-lan-local-memory-exhaustion.patch
+
+# https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-rfg2-pjw2-56x2
+patch -p1 < $CWD/patches/stop-mDNS-floods.patch
+
+# https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-9663-mqmp-p9mm
+patch -p1 < $CWD/patches/stop-spoofed-source-floods.patch
+
 # https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-qc2x-6f54-m6h9
-patch -p1 < $CWD/stop-read-string-rdlength-overruns.patch
+patch -p1 < $CWD/patches/stop-read-string-rdlength-overruns.patch
 
 PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 export PYTHONPATH="/opt/python$PYVER/site-packages:/opt/cython/python$PYVER/site-packages"


### PR DESCRIPTION
There are actually 5 security vulnerabilities:
https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-9pgc-3ccv-5297
https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-phvx-9mgw-67r5
https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-rfg2-pjw2-56x2
https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-9663-mqmp-p9mm
https://github.com/python-zeroconf/python-zeroconf/security/advisories/GHSA-qc2x-6f54-m6h9

As much as I would rather update python3-zeroconf to 0.149.16, there is syntax since version 0.149.0 that is unavailable in Python 3.9.