### PR TITLE
development/sccache: fix build for i686 target

### DIFF
--- a/development/sccache/README
+++ b/development/sccache/README
@@ -33,3 +33,6 @@ Alternatively you can use the environment variable RUSTC_WRAPPER:
 
   export RUSTC_WRAPPER=/path/to/sccache
   cargo build
+
+NOTE: the sccache-dist binary is only built on x86_64, as other
+architectures are unsupported upstream.

--- a/development/sccache/mkvendor.sh
+++ b/development/sccache/mkvendor.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Use this script to package up vendored dependencies for sccache.
+# It should be run inside an unpacked sccache source tarball root dir.
 
 PWD="$CWD"
 OUTDIR=${OUTDIR:-/tmp}

--- a/development/sccache/sccache.SlackBuild
+++ b/development/sccache/sccache.SlackBuild
@@ -26,22 +26,17 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=sccache
 VERSION=${VERSION:-0.15.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
-    i?86) ARCH=i586 ;;
+    # i586 is not properly supported by rustc
+    i?86) ARCH=i686 ;;
     arm*) ARCH=arm ;;
        *) ARCH=$( uname -m ) ;;
   esac
-
-  if [ "$ARCH" = "i586" ]; then
-    if rustc -Vv | grep host | grep i686 > /dev/null ; then
-      ARCH=i686
-    fi
-  fi
 fi
 
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
@@ -53,25 +48,24 @@ TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
+# Build parameters tweaking. Default values
+TARGET=$ARCH-unknown-linux-gnu
+TARGETDIR=target/$TARGET/release
+FEATURES=all
+
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  CARGOTARGET="--target $ARCH-unknown-linux-gnu"
-  TARGETDIR=target/$ARCH-unknown-linux-gnu/release
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "i686" ]; then
   SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  CARGOTARGET="--target $ARCH-unknown-linux-gnu"
-  TARGETDIR=target/$ARCH-unknown-linux-gnu/release
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "x86_64" ] ; then
   SLKCFLAGS="-O2 -fPIC"
-  CARGOTARGET="--target $ARCH-unknown-linux-gnu"
-  TARGETDIR=target/$ARCH-unknown-linux-gnu/release
+  # The sccache-dist binary (dist-server feature) is only supported on x86_64
+  FEATURES=all,dist-server
   LIBDIRSUFFIX="64"
 elif [ "$ARCH" = "aarch64" ] ; then
   SLKCFLAGS="-O2 -fPIC"
-  CARGOTARGET="--target $ARCH-unknown-linux-gnu"
-  TARGETDIR=target/$ARCH-unknown-linux-gnu/release
   LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
@@ -104,17 +98,22 @@ else
   export LD_LIBRARY_PATH="/opt/rust/lib$LIBDIRSUFFIX:$LD_LIBRARY_PATH"
 fi
 
-#rm -f .cargo/config.toml
-
 CARGO_HOME=.cargo \
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
-cargo build --frozen --release $CARGOTARGET --features all,dist-server
+cargo build \
+  --frozen \
+  --release \
+  --target $TARGET \
+  --features $FEATURES
 
 mkdir -p $PKG/usr/bin/
 
-install -Dm 0755 $TARGETDIR/sccache $PKG/usr/bin/sccache
-install -Dm 0755 $TARGETDIR/sccache-dist $PKG/usr/bin/sccache-dist
+install -vDm 0755 $TARGETDIR/sccache $PKG/usr/bin/sccache
+if [ -e $TARGETDIR/sccache-dist ]
+then
+  install -vDm 0755 $TARGETDIR/sccache-dist $PKG/usr/bin/sccache-dist
+fi
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true

--- a/development/sccache/sccache.info
+++ b/development/sccache/sccache.info
@@ -1,12 +1,12 @@
 PRGNAM="sccache"
 VERSION="0.15.0"
 HOMEPAGE="https://github.com/mozilla/sccache"
-DOWNLOAD="UNSUPPORTED"
-MD5SUM=""
-DOWNLOAD_x86_64="https://github.com/mozilla/sccache/archive/v0.15.0/sccache-0.15.0.tar.gz \
+DOWNLOAD="https://github.com/mozilla/sccache/archive/v0.15.0/sccache-0.15.0.tar.gz \
 	https://sourceforge.net/projects/slackbuildsdirectlinks/files/sccache/sccache-0.15.0-vendor.tar.xz"
-MD5SUM_x86_64="99270f72dabcef9cdfd31e27d1ccd466 \
+MD5SUM="99270f72dabcef9cdfd31e27d1ccd466 \
 	b3d60f4dcd7dbecd033b78ec3299e1b0"
+DOWNLOAD_x86_64=""
+MD5SUM_x86_64=""
 REQUIRES="rust-opt"
 MAINTAINER="Alan Alberghini"
 EMAIL="414n@slacky.it"


### PR DESCRIPTION
Disable building the sccache-dist binary on anything other than x86_64, as those ARCHs are [not supported upstream](https://github.com/mozilla/sccache/commit/86abf9065ef22610475d9e037a469e8cb1a22ee8).

Also, set the 32-bit support explictly i686, as i586 does not seem fully supported by the [rust project upstream itself (tier 2)](https://github.com/rust-lang/compiler-team/issues/543).