### PR TITLE
libraries/grpc: Update README, mark as x86_64 only

### DIFF
--- a/libraries/grpc/README
+++ b/libraries/grpc/README
@@ -5,3 +5,7 @@ of connected systems.
 
 This SlackBuild builds gRPC in C++. python3-grpcio contains the Python 3
 build of gRPC.
+
+grpc is kept back at 1.80.0 on Slackware 15.0. The program version is
+meant to synchronize with python3-grpcio (which cannot be updated due to
+requiring Python >= 3.10).

--- a/libraries/grpc/grpc.info
+++ b/libraries/grpc/grpc.info
@@ -1,12 +1,12 @@
 PRGNAM="grpc"
 VERSION="1.80.0"
 HOMEPAGE="https://grpc.io/"
-DOWNLOAD="https://github.com/grpc/grpc/archive/v1.80.0/grpc-1.80.0.tar.gz \
-          https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0/opencensus-proto-0.3.0.tar.gz"
-MD5SUM="dc3e0cbfb480db5ea814b9741ac37138 \
-        0b208800a68548cbf2d4bff763c050a2"
-DOWNLOAD_x86_64=""
-MD5SUM_x86_64=""
-REQUIRES="protobuf3 re2 abseil-cpp"
+DOWNLOAD="UNSUPPORTED"
+MD5SUM=""
+DOWNLOAD_x86_64="https://github.com/grpc/grpc/archive/v1.80.0/grpc-1.80.0.tar.gz \
+                 https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0/opencensus-proto-0.3.0.tar.gz"
+MD5SUM_x86_64="dc3e0cbfb480db5ea814b9741ac37138 \
+               0b208800a68548cbf2d4bff763c050a2"
+REQUIRES="protobuf3 re2"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
I am not updating grpc. It is meant to synchronize with the python3-grpcio version (they're both the same program but split into 2 different SlackBuilds.)

Also, I am running sbo-bot (to see if @willysr's fix actually worked for x86 systems.)