### PR TITLE
development/jupyter_server: Update README

### DIFF
--- a/development/jupyter_server/README
+++ b/development/jupyter_server/README
@@ -1,3 +1,6 @@
 The Jupyter Server provides the backend (i.e. the core services,
 APIs, and REST endpoints) for Jupyter web applications like 
 Jupyter notebook, JupyterLab, and Voila.
+
+jupyter_server 2.18.2 is the last available version on Slackware 15.0.
+Later versions require Python >= 3.10.


### PR DESCRIPTION
Later versions of jupyter_server have dropped Python 3.9.