### PR TITLE
git/ci: Update CI dependencies.

### DIFF
--- a/.github/workflows/auto-create-build-check-issue.yml
+++ b/.github/workflows/auto-create-build-check-issue.yml
@@ -14,7 +14,7 @@ jobs:
   create-build-check-issue:
     name: Create build check issue
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       contents: read # for actions/checkout
       issues: write # for peter-evans/create-issue-from-file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ concurrency:
 
 env:
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=loose
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.4@sha256:c7c84bb146efb38fffb2c5e57e023439a4b7148ce9c4f0d88b45342f94d97a67
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.5@sha256:081534b874192dcd0a8a3218d63ac2ff8d71bb128f2377a8139bae0bfe48ec40
 
 permissions: {}
 
 jobs:
   changes:
     name: Detect changed SlackBuilds
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
@@ -174,7 +174,7 @@ jobs:
 
   dependencies:
     name: Compute reverse dependencies
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: write # for peter-evans/create-or-update-comment

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,18 @@
 variables:
   FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: "true"
   # renovate: datasource=gitlab-releases depName=gitlab-org/cli
-  GLAB_VERSION: 1.95.0
+  GLAB_VERSION: 1.100.0
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=loose
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.4@sha256:c7c84bb146efb38fffb2c5e57e023439a4b7148ce9c4f0d88b45342f94d97a67
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.5@sha256:081534b874192dcd0a8a3218d63ac2ff8d71bb128f2377a8139bae0bfe48ec40
 
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
 
 default:
-  image: docker:29.4.3@sha256:685b91dca8eab7de1dce1c303dbb7a763e4082d6a60db10968adf3295fbd2495
+  image: docker:29.5.2@sha256:6b9cd914eb9c6b342c040a49a27a5eb3804453bae6ecc90f7ff96133595a95e8
   services:
-    - docker:29.4.3-dind@sha256:685b91dca8eab7de1dce1c303dbb7a763e4082d6a60db10968adf3295fbd2495
+    - docker:29.5.2-dind@sha256:6b9cd914eb9c6b342c040a49a27a5eb3804453bae6ecc90f7ff96133595a95e8
 
 pr-checks:
   script: |


### PR DESCRIPTION
Updates:

- gitlab ci build images
- gitlab cli version bump
- bump sbo-maintainer-tools to 0.9.5
- switch some more jobs to ubuntu-slim runners