### PR TITLE
development/rust-opt: Updated for version 1.95.0.

### DIFF
--- a/development/rust-opt/rust-opt.SlackBuild
+++ b/development/rust-opt/rust-opt.SlackBuild
@@ -26,8 +26,8 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust-opt
 SRCNAM=rust
-VERSION=${VERSION:-1.91.1}
-BUILD=${BUILD:-2}
+VERSION=${VERSION:-1.95.0}
+BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 

--- a/development/rust-opt/rust-opt.info
+++ b/development/rust-opt/rust-opt.info
@@ -1,12 +1,12 @@
 PRGNAM="rust-opt"
-VERSION="1.91.1"
+VERSION="1.95.0"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2025-11-10/rust-1.91.1-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2025-11-10/rust-1.91.1-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="e2b207e9194c51bc75ec6f8a9b195de3 \
-        4722d3a0e1950446ca9b22ecd970a582"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2025-11-10/rust-1.91.1-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="a4e9dac2c094baf0d17779567c5051c0"
+DOWNLOAD="https://static.rust-lang.org/dist/2026-04-16/rust-1.95.0-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2026-04-16/rust-1.95.0-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="ceb100701b8563f204a25b89f875261a \
+        65607b3e7b0c1c1dba60e115465cb231"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2026-04-16/rust-1.95.0-x86_64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="b0be0462e8b5d3fa2f80998b4ddcfc3b"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"

--- a/development/rust-opt/slack-desc
+++ b/development/rust-opt/slack-desc
@@ -11,7 +11,7 @@ rust-opt:
 rust-opt: rust-opt installs a limited set of up-to-date Rust stable binaries to
 rust-opt: /opt/rust for use in SlackBuilds.
 rust-opt:
-rust-opt: See /usr/doc/rust-opt-1.91.1/README.sw for usage instructions.
+rust-opt: See /usr/doc/rust-opt-1.95.0/README.sw for usage instructions.
 rust-opt:
 rust-opt:
 rust-opt:


### PR DESCRIPTION
`x86_64` and `i686` look fine on my end. `arm` tests will still be going for a while, but no issues so far.