### PR TITLE
development/jupyterlab: Update README

### DIFF
--- a/development/jupyterlab/README
+++ b/development/jupyterlab/README
@@ -6,3 +6,6 @@ rich outputs, etc.) in a flexible and powerful user interface.
 Jupyter kernels are needed for JupyterLab to be fully functional. The
 following kernels are currently available as SlackBuilds:
 * jupyter-ipykernel
+
+NOTE: Unable to update jupyterlab to versions >= 4.6.0 on Slackware 15.0
+(due to requiring Python >= 3.10).


### PR DESCRIPTION
jupyterlab 4.5.9 and 4.6.0 have been released.

I am not updating jupyterlab to either version.
1. jupyterlab 4.6.0 requires Python >= 3.10 (which is not available on Slackware 15.0)
2. While I can update jupyterlab to 4.5.9, jupyter-notebook does not have a corresponding version at 7.5.8. There are jupyter-notebook versions 7.5.7 and 7.6.0.