### PR TITLE
Stellarium 26.1

### DIFF
--- a/academic/stellarium/README
+++ b/academic/stellarium/README
@@ -7,3 +7,11 @@ acceleration.
 
 gpsd is an optional dependency for enabling location detection through
 a GPS device.
+
+qt6 is another optional dependency. To enable building using qt6, set
+the QT6 variable before building:
+
+  QT6=yes sh stellarium.SlackBuild
+
+NOTE: for the qt6 build to work, you need to build the qt6 support for
+BOTH the CalcMySky and QXlsx dependencies too.

--- a/academic/stellarium/README
+++ b/academic/stellarium/README
@@ -8,10 +8,11 @@ acceleration.
 gpsd is an optional dependency for enabling location detection through
 a GPS device.
 
-qt6 is another optional dependency. To enable building using qt6, set
-the QT6 variable before building:
+qt6 is another optional dependency. It should enable speech and the sky
+culture converter component. To enable building using qt6, set the QT6
+variable before building:
 
   QT6=yes sh stellarium.SlackBuild
 
-NOTE: for the qt6 build to work, you need to build the qt6 support for
-BOTH the CalcMySky and QXlsx dependencies too.
+NOTE: for the qt6 build to work, you need to build BOTH the CalcMySky
+and QXlsx dependencies with qt6 too.

--- a/academic/stellarium/stellarium.SlackBuild
+++ b/academic/stellarium/stellarium.SlackBuild
@@ -87,46 +87,6 @@ else
 	qt6_opt="-DENABLE_QT6=OFF"
 fi
 
-# CPM dependency retrieval lifting: prepare a cache dir in the format
-# expected by CPM with pre-downloaded sources.
-
-# CPM normally puts downloaded deps under this dir
-CPM_CACHE_DIR=$TMP/$PRGNAM-$VERSION/build/_deps
-
-#CPM_SHOWMYSKY_VERSION=v0.4.0
-CPM_QXSLX_VERSION=9f545935a1effa0144ba76598e95a7597210553a
-#CPM_INDI_VERSION=1.8.5
-#CPM_GLM_VERSION=0.9.9.8
-#CPM_NLOPT_VERSION=v2.7.1
-
-# We need to match dependencies names used in cmake files with the
-# actual dependency tarball names
-declare -A CPM_SOURCE CPM_DEST
-#CPM_SOURCE["SHOWMYSKY"]="$CWD/CalcMySky-$CPM_SHOWMYSKY_VERSION.tar.gz"
-CPM_SOURCE["QXLSX"]="$CWD/QXlsx-$CPM_QXSLX_VERSION.zip"
-#CPM_SOURCE["INDI"]="$CWD/indi-$CPM_INDI_VERSION.zip"
-#CPM_SOURCE["GLM"]="$CWD/glm-$CPM_GLM_VERSION.7z"
-#CPM_SOURCE["NLOPT"]="$CWD/nlopt-$CPM_NLOPT_VERSION.tar.gz"
-
-#CPM_DEST["SHOWMYSKY"]="$CPM_CACHE_DIR/showmysky-qt5-subbuild/showmysky-qt5-populate-prefix/src/$CPM_SHOWMYSKY_VERSION.tar.gz"
-if [ "$ENABLE_QT6" = 1 ]
-then
-	CPM_DEST["QXLSX"]="$CPM_CACHE_DIR/qxlsxqt6-subbuild/qxlsxqt6-populate-prefix/src/$CPM_QXSLX_VERSION.zip"
-else
-	CPM_DEST["QXLSX"]="$CPM_CACHE_DIR/qxlsxqt5-subbuild/qxlsxqt5-populate-prefix/src/$CPM_QXSLX_VERSION.zip"
-fi
-#CPM_DEST["INDI"]="$CPM_CACHE_DIR/indiclient-subbuild/indiclient-populate-prefix/src/v$CPM_INDI_VERSION.zip"
-#CPM_DEST["GLM"]="$CPM_CACHE_DIR/glm-subbuild/glm-populate-prefix/src/glm-$CPM_GLM_VERSION.7z"
-#CPM_DEST["NLOPT"]="$CPM_CACHE_DIR/nlopt-subbuild/nlopt-populate-prefix/src/$CPM_NLOPT_VERSION.tar.gz"
-
-for dep in "${!CPM_SOURCE[@]}"
-do
-	mkdir -p "$(dirname "${CPM_DEST[$dep]}")"
-	ln -s "${CPM_SOURCE[$dep]}" "${CPM_DEST[$dep]}"
-done
-
-# End of CPM deps management
-
 mkdir -p build
 cd build
   cmake \
@@ -136,6 +96,7 @@ cd build
     -DPYTHON_EXECUTABLE=/usr/bin/python3 \
     -DCMAKE_INSTALL_LIBDIR=/usr/lib${LIBDIRSUFFIX} \
     -DCMAKE_INSTALL_MANDIR=/usr/man \
+    -DCPM_LOCAL_PACKAGES_ONLY=ON \
     "$qt6_opt" \
     -DCMAKE_BUILD_TYPE=Release ..
   make

--- a/academic/stellarium/stellarium.SlackBuild
+++ b/academic/stellarium/stellarium.SlackBuild
@@ -39,9 +39,6 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
-# the name of the created package would be, and then exit. This information
-# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0
@@ -108,7 +105,6 @@ cd build
   make install DESTDIR=$PKG
 cd -
 
-# Don't ship .la files:
 rm -f $PKG/{,usr/}lib${LIBDIRSUFFIX}/*.la
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/academic/stellarium/stellarium.SlackBuild
+++ b/academic/stellarium/stellarium.SlackBuild
@@ -25,10 +25,11 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=stellarium
-VERSION=${VERSION:-23.4}
+VERSION=${VERSION:-26.1}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
+ENABLE_QT6=${ENABLE_QT6:-0}
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
@@ -38,6 +39,9 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
+# If the variable PRINT_PACKAGE_NAME is set, then this script will report what
+# the name of the created package would be, and then exit. This information
+# could be useful to other scripts.
 if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
   echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
   exit 0
@@ -76,31 +80,44 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} +
 
+if [ "$ENABLE_QT6" = 1 ]
+then
+	qt6_opt="-DENABLE_QT6=ON"
+else
+	qt6_opt="-DENABLE_QT6=OFF"
+fi
+
 # CPM dependency retrieval lifting: prepare a cache dir in the format
 # expected by CPM with pre-downloaded sources.
 
 # CPM normally puts downloaded deps under this dir
 CPM_CACHE_DIR=$TMP/$PRGNAM-$VERSION/build/_deps
 
-CPM_SHOWMYSKY_VERSION=0.3.1
-CPM_QXSLX_VERSION=1.4.6
-CPM_INDI_VERSION=1.8.5
-CPM_GLM_VERSION=0.9.9.8
-CPM_NLOPT_VERSION=2.7.1
+#CPM_SHOWMYSKY_VERSION=v0.4.0
+CPM_QXSLX_VERSION=9f545935a1effa0144ba76598e95a7597210553a
+#CPM_INDI_VERSION=1.8.5
+#CPM_GLM_VERSION=0.9.9.8
+#CPM_NLOPT_VERSION=v2.7.1
 
 # We need to match dependencies names used in cmake files with the
 # actual dependency tarball names
 declare -A CPM_SOURCE CPM_DEST
-CPM_SOURCE["SHOWMYSKY"]="$CWD/CalcMySky-$CPM_SHOWMYSKY_VERSION.tar.gz"
-CPM_SOURCE["QXLSX"]="$CWD/QXlsx-$CPM_QXSLX_VERSION.tar.gz"
-CPM_SOURCE["INDI"]="$CWD/indi-$CPM_INDI_VERSION.zip"
-CPM_SOURCE["GLM"]="$CWD/glm-$CPM_GLM_VERSION.7z"
-CPM_SOURCE["NLOPT"]="$CWD/nlopt-$CPM_NLOPT_VERSION.tar.gz"
-CPM_DEST["SHOWMYSKY"]="$CPM_CACHE_DIR/showmysky-qt5-subbuild/showmysky-qt5-populate-prefix/src/v$CPM_SHOWMYSKY_VERSION.tar.gz"
-CPM_DEST["QXLSX"]="$CPM_CACHE_DIR/qxlsxqt5-subbuild/qxlsxqt5-populate-prefix/src/v$CPM_QXSLX_VERSION.tar.gz"
-CPM_DEST["INDI"]="$CPM_CACHE_DIR/indiclient-subbuild/indiclient-populate-prefix/src/v$CPM_INDI_VERSION.zip"
-CPM_DEST["GLM"]="$CPM_CACHE_DIR/glm-subbuild/glm-populate-prefix/src/glm-$CPM_GLM_VERSION.7z"
-CPM_DEST["NLOPT"]="$CPM_CACHE_DIR/nlopt-subbuild/nlopt-populate-prefix/src/v$CPM_NLOPT_VERSION.tar.gz"
+#CPM_SOURCE["SHOWMYSKY"]="$CWD/CalcMySky-$CPM_SHOWMYSKY_VERSION.tar.gz"
+CPM_SOURCE["QXLSX"]="$CWD/QXlsx-$CPM_QXSLX_VERSION.zip"
+#CPM_SOURCE["INDI"]="$CWD/indi-$CPM_INDI_VERSION.zip"
+#CPM_SOURCE["GLM"]="$CWD/glm-$CPM_GLM_VERSION.7z"
+#CPM_SOURCE["NLOPT"]="$CWD/nlopt-$CPM_NLOPT_VERSION.tar.gz"
+
+#CPM_DEST["SHOWMYSKY"]="$CPM_CACHE_DIR/showmysky-qt5-subbuild/showmysky-qt5-populate-prefix/src/$CPM_SHOWMYSKY_VERSION.tar.gz"
+if [ "$ENABLE_QT6" = 1 ]
+then
+	CPM_DEST["QXLSX"]="$CPM_CACHE_DIR/qxlsxqt6-subbuild/qxlsxqt6-populate-prefix/src/$CPM_QXSLX_VERSION.zip"
+else
+	CPM_DEST["QXLSX"]="$CPM_CACHE_DIR/qxlsxqt5-subbuild/qxlsxqt5-populate-prefix/src/$CPM_QXSLX_VERSION.zip"
+fi
+#CPM_DEST["INDI"]="$CPM_CACHE_DIR/indiclient-subbuild/indiclient-populate-prefix/src/v$CPM_INDI_VERSION.zip"
+#CPM_DEST["GLM"]="$CPM_CACHE_DIR/glm-subbuild/glm-populate-prefix/src/glm-$CPM_GLM_VERSION.7z"
+#CPM_DEST["NLOPT"]="$CPM_CACHE_DIR/nlopt-subbuild/nlopt-populate-prefix/src/$CPM_NLOPT_VERSION.tar.gz"
 
 for dep in "${!CPM_SOURCE[@]}"
 do
@@ -119,6 +136,7 @@ cd build
     -DPYTHON_EXECUTABLE=/usr/bin/python3 \
     -DCMAKE_INSTALL_LIBDIR=/usr/lib${LIBDIRSUFFIX} \
     -DCMAKE_INSTALL_MANDIR=/usr/man \
+    "$qt6_opt" \
     -DCMAKE_BUILD_TYPE=Release ..
   make
   make install DESTDIR=$PKG
@@ -130,8 +148,6 @@ rm -f $PKG/{,usr/}lib${LIBDIRSUFFIX}/*.la
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
-# upstream doesn't honor the CMAKE_INSTALL_MANDIR. Move files manually, for now
-mv $PKG/usr/share/man $PKG/usr/
 find $PKG/usr/man -type f -exec gzip -9 {} \;
 for i in $( find $PKG/usr/man -type l ) ; do ln -s $( readlink $i ).gz $i.gz ; rm $i ; done
 

--- a/academic/stellarium/stellarium.SlackBuild
+++ b/academic/stellarium/stellarium.SlackBuild
@@ -29,7 +29,7 @@ VERSION=${VERSION:-26.1}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
-ENABLE_QT6=${ENABLE_QT6:-0}
+QT6="${QT6:-0}"
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
@@ -60,6 +60,9 @@ elif [ "$ARCH" = "i686" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
@@ -80,12 +83,14 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} +
 
-if [ "$ENABLE_QT6" = 1 ]
-then
+case "${QT6,,}" in
+1|true|on|yes)
 	qt6_opt="-DENABLE_QT6=ON"
-else
+	;;
+*)
 	qt6_opt="-DENABLE_QT6=OFF"
-fi
+	;;
+esac
 
 mkdir -p build
 cd build
@@ -115,6 +120,7 @@ for i in $( find $PKG/usr/man -type l ) ; do ln -s $( readlink $i ).gz $i.gz ; r
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \
   CREDITS.md COPYING ChangeLog README.md \
+  BACKERS.md MAINTAINER_BUSINESS.md CONTRIBUTING.md \
   $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 

--- a/academic/stellarium/stellarium.info
+++ b/academic/stellarium/stellarium.info
@@ -1,20 +1,12 @@
 PRGNAM="stellarium"
-VERSION="23.4"
+VERSION="26.1"
 HOMEPAGE="http://www.stellarium.org"
-DOWNLOAD="https://github.com/Stellarium/stellarium/releases/download/v23.4/stellarium-23.4.tar.xz \
-https://github.com/10110111/CalcMySky/archive/refs/tags/v0.3.1/CalcMySky-0.3.1.tar.gz \
-https://github.com/QtExcel/QXlsx/archive/refs/tags/v1.4.6/QXlsx-1.4.6.tar.gz \
-https://github.com/indilib/indi/archive/v1.8.5/indi-1.8.5.zip \
-https://github.com/g-truc/glm/releases/download/0.9.9.8/glm-0.9.9.8.7z \
-https://github.com/stevengj/nlopt/archive/refs/tags/v2.7.1/nlopt-2.7.1.tar.gz"
-MD5SUM="c44271c128de0f2830ce465574e28ce8 \
-88def58da627a30135cd1871fffa5577 \
-fdc7a2bf239bd0ff84f6058694dcd9f9 \
-14a092a9eb2117e5c51ba3302197e097 \
-c8342552801ebeb31497288192c4e793 \
-ed1a3000a1c8c248d51df126dfcfaa78"
+DOWNLOAD="https://github.com/Stellarium/stellarium/releases/download/v26.1/stellarium-26.1.tar.xz \
+https://github.com/QtExcel/QXlsx/archive/9f54593/QXlsx-9f545935a1effa0144ba76598e95a7597210553a.zip"
+MD5SUM="e02dbabf01fd3c2bf2e4f544856981c1 \
+f6c3b04e00b06886e7baa735cfc60e06"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES=""
+REQUIRES="md4c nlopt libindi"
 MAINTAINER="Alan Alberghini"
 EMAIL="414N@slacky.it"

--- a/academic/stellarium/stellarium.info
+++ b/academic/stellarium/stellarium.info
@@ -1,12 +1,10 @@
 PRGNAM="stellarium"
 VERSION="26.1"
 HOMEPAGE="http://www.stellarium.org"
-DOWNLOAD="https://github.com/Stellarium/stellarium/releases/download/v26.1/stellarium-26.1.tar.xz \
-https://github.com/QtExcel/QXlsx/archive/9f54593/QXlsx-9f545935a1effa0144ba76598e95a7597210553a.zip"
-MD5SUM="e02dbabf01fd3c2bf2e4f544856981c1 \
-f6c3b04e00b06886e7baa735cfc60e06"
+DOWNLOAD="https://github.com/Stellarium/stellarium/releases/download/v26.1/stellarium-26.1.tar.xz"
+MD5SUM="e02dbabf01fd3c2bf2e4f544856981c1"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="md4c nlopt libindi"
+REQUIRES="md4c nlopt libindi CalcMySky QXslx"
 MAINTAINER="Alan Alberghini"
 EMAIL="414N@slacky.it"


### PR DESCRIPTION
This updates stellarium to version 26.1.

The main change is the removal of all the stuff to make CPM happy while avoiding it downloading anything during the build. This was done by packaging up the CalcMySky and QXslx dependencies as proper SBo packages.
Also, the libindi support got updated so it's now compatible with the version already on SBo.