### PR TITLE
git/ci: Update CI dependencies.

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -13,16 +13,18 @@ concurrency:
 
 env:
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=loose
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.5@sha256:ca21dea9c86ef80bdd08330d6e7b15e4d23b2bc036d2d0e419cbadcd55b85591
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.5@sha256:a313639001e6498de247b8012792756e84c5b8ca681bb2777f82ea27bb7c1f12
 
 jobs:
   pr-checks:
     name: PR checks
     runs-on: codeberg-small
     steps:
-      - uses: https://code.forgejo.org/actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: https://code.forgejo.org/actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          show-progress: false
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up buildah
         shell: bash
@@ -51,7 +53,8 @@ jobs:
           REPO_FULL_NAME: ${{ forgejo.repository }}
           PR_NUMBER: ${{ forgejo.event.pull_request.number }}
         run: |
-          set -euo pipefail
+          set -e
+          set -o pipefail
 
           api_url="${FORGEJO_API_URL:-${FORGEJO_SERVER_URL}/api/v1}"
 
@@ -146,6 +149,15 @@ jobs:
                 "$api_url/repos/$REPO_FULL_NAME/issues/$PR_NUMBER/comments" > /dev/null
             fi
           }
+
+          changed_count="$(printf '%s\n' "$changed_projects" | grep -c .)"
+          if [[ "$changed_count" -gt 10 ]] ; then
+            printf 'This PR contains too many changed packages (more than 10). Skipping normal PR checks.\n' > comment-output
+            upsert_comment "<!-- ci:too-many-changes -->" comment-output
+            rm -f comment-output comment-body
+            printf 'Too many changed packages (%s); skipping checks\n' "$changed_count"
+            exit 0
+          fi
 
           image="docker.io/$SBO_MAINTAINER_TOOLS_IMAGE"
 

--- a/.github/workflows/auto-create-build-check-issue.yml
+++ b/.github/workflows/auto-create-build-check-issue.yml
@@ -21,7 +21,7 @@ jobs:
     if: contains(fromJSON('["SlackBuildsOrg/slackbuilds"]'), github.repository)
     steps:
       - name: Check out repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           show-progress: false
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 ---
 name: PR checks
 
-"on":
-  pull_request_target:
+on:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -10,24 +10,20 @@ name: PR checks
 
 concurrency:
   group: ci-${{ github.event.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=loose
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.5@sha256:ca21dea9c86ef80bdd08330d6e7b15e4d23b2bc036d2d0e419cbadcd55b85591
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.5@sha256:a313639001e6498de247b8012792756e84c5b8ca681bb2777f82ea27bb7c1f12
 
 permissions: {}
 
 jobs:
-  changes:
-    name: Detect changed SlackBuilds
-    runs-on: ubuntu-slim
+  pr-checks:
+    name: PR checks
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      has_changes: ${{ steps.get-changes.outputs.has_changes }}
-      too_many_changes: ${{ steps.get-changes.outputs.too_many_changes }}
     steps:
       - name: Calculate clone depth.
         id: clone-depth
@@ -35,203 +31,96 @@ jobs:
           PR_COMMITS: ${{ github.event.pull_request.commits }}
         run: printf "fetch_depth=%s\n" "$(( PR_COMMITS + 1 ))" >> "${GITHUB_OUTPUT}"
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           show-progress: false
           fetch-depth: ${{ steps.clone-depth.outputs.fetch_depth }}
-          ref: ${{ github.head_ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
 
-      - name: Get slackbuild directories which have changes.
-        id: get-changes
+      - name: Run checks
+        shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          CHANGED_FILES="$(git diff-tree --name-only --diff-filter=d --no-commit-id -r "$BASE_SHA" "$HEAD_SHA" | sed '/^\./d' | sed -n '/[^\/][^\/]*\/[^\/][^\/]*\//p' | xargs -I xx dirname xx | sort -u | sed '/.github/d' | sed 's/^/"/;s/$/"/g' | paste -d, -s | sed 's/^/[/;s/$/]/')"
+          set -e
+          set -o pipefail
 
-          delimiter="$(openssl rand -hex 8)"
-          {
-            printf "CHANGED_FILES<<%s\n" "$delimiter"
-            printf "%s\n" "$CHANGED_FILES"
-            printf "%s\n" "$delimiter"
-          } >> "$GITHUB_OUTPUT"
+          mkdir -p comments
 
-          if [[ "$CHANGED_FILES" == '[]' || -z "$CHANGED_FILES" ]] ; then
-            printf 'has_changes=false\n' >> "$GITHUB_OUTPUT"
-            printf 'too_many_changes=false\n' >> "$GITHUB_OUTPUT"
-          else
-            printf 'has_changes=true\n' >> "$GITHUB_OUTPUT"
-            CHANGED_COUNT=$(jq 'length' <<< "$CHANGED_FILES")
-            if [[ "$CHANGED_COUNT" -gt 10 ]] ; then
-              printf 'too_many_changes=true\n' >> "$GITHUB_OUTPUT"
-            else
-              printf 'too_many_changes=false\n' >> "$GITHUB_OUTPUT"
-            fi
+          changed_projects="$(git diff-tree --name-only --diff-filter=d --no-commit-id -r "$BASE_SHA" "$HEAD_SHA" | sed '/^\./d' | sed -n '/[^\/][^\/]*\/[^\/][^\/]*\//p' | xargs -r -I xx dirname xx | sort -u)"
+
+          if [[ -z "$changed_projects" ]] ; then
+            printf 'No changed SlackBuild directories detected\n'
+            exit 0
           fi
 
-      - name: Get matrix output
-        id: set-matrix
-        env:
-          CHANGED_FILES: ${{ steps.get-changes.outputs.CHANGED_FILES }}
-        run: |
-          {
-            printf 'matrix<<SLACKBUILDS\n'
-            jq -r -c 'map({dir: .})' <<< "$CHANGED_FILES"
-            printf 'SLACKBUILDS\n'
-          } >> "$GITHUB_OUTPUT"
+          changed_count="$(printf '%s\n' "$changed_projects" | grep -c .)"
+          if [[ "$changed_count" -gt 10 ]] ; then
+            {
+              printf '<!-- ci:too-many-changes -->\n'
+              printf 'This PR contains too many changed packages (more than 10). Skipping normal PR checks.\n'
+            } > comments/too-many-changes.md
+            printf 'Too many changed packages (%s); skipping checks\n' "$changed_count"
+            exit 0
+          fi
 
-  too_many_changes:
-    name: Too many changed packages
-    runs-on: ubuntu-slim
-    permissions:
-      pull-requests: write # for peter-evans/create-or-update-comment
-    needs: [changes]
-    if: needs.changes.outputs.too_many_changes == 'true'
-    steps:
-      - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: fc
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: "too many changed packages"
-
-      - name: Comment
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.number }}
-          body: |
-            This PR contains too many changed packages (more than 10). Skipping normal PR checks.
-          edit-mode: replace
-
-  sbolint:
-    name: Checks with sbolint
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      pull-requests: write # for peter-evans/create-or-update-comment
-    needs: [changes]
-    if: needs.changes.outputs.has_changes == 'true' && needs.changes.outputs.too_many_changes != 'true'
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.changes.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          show-progress: false
-          ref: ${{ github.head_ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          persist-credentials: false
-
-      - name: Run sbolint
-        env:
-          MATRIX_DIR: ${{ matrix.dir }}
-        run: |
           docker pull "$SBO_MAINTAINER_TOOLS_IMAGE"
 
-          mkfifo pipe
-          tee sbolint-output < pipe &
-          set +e
-
-          docker run --rm -v "$(pwd):/work" -w /work "$SBO_MAINTAINER_TOOLS_IMAGE" sbolint "$MATRIX_DIR" > pipe 2>&1
-
-          sbolint_status="$?"
-          set -e
-
-          {
-            if [[ "$sbolint_status" -eq 0 ]] ; then
-              printf '#### ✅ sbolint - %s ✅\n\n' "$MATRIX_DIR"
-            else
-              printf '#### ⛔️ sbolint - %s ⛔️\n\n' "$MATRIX_DIR"
+          while IFS= read -r project ; do
+            if [[ -z "$project" ]] ; then
+              continue
             fi
 
-            printf '```\n'
-            cat sbolint-output
-            rm sbolint-output
-            printf '```\n'
-          } > comment-output
-        shell:
-          bash
+            set +e
+            docker run --rm -v "$(pwd):/work" -w /work "$SBO_MAINTAINER_TOOLS_IMAGE" sbolint "$project" 2>&1 | tee sbolint-output
+            sbolint_status="${PIPESTATUS[0]}"
+            set -e
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: fc
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: "sbolint - ${{ matrix.dir }}"
+            slug="${project//\//:}"
+            file_slug="${project//\//--}"
+            {
+              printf '<!-- ci:sbolint:%s -->\n' "$slug"
+              if [[ "$sbolint_status" -eq 0 ]] ; then
+                printf '#### ✅ sbolint - %s ✅\n\n' "$project"
+              else
+                printf '#### ⛔️ sbolint - %s ⛔️\n\n' "$project"
+              fi
 
-      - name: Comment with sbolint results
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.number }}
-          body-path: comment-output
-          edit-mode: replace
+              printf '```\n'
+              cat sbolint-output
+              printf '```\n'
+            } > "comments/sbolint-${file_slug}.md"
 
-  dependencies:
-    name: Compute reverse dependencies
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      pull-requests: write # for peter-evans/create-or-update-comment
-    needs: [changes]
-    if: needs.changes.outputs.has_changes == 'true' && needs.changes.outputs.too_many_changes != 'true'
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.changes.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          show-progress: false
-          ref: ${{ github.head_ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          persist-credentials: false
+            rm -f sbolint-output
+          done <<< "$changed_projects"
 
-      - name: Get short package name
-        run: printf '%s\n' "$MATRIX_DIR" | cut -d/ -f2 | sed 's/^/PACKAGE_NAME=/' >> "$GITHUB_ENV"
-        env:
-          MATRIX_DIR: ${{ matrix.dir }}
-
-      - name: Look up dependencies
-        id: get_deps
-        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
-        with:
-          url: 'https://slackbuilds.org/revdeps.php?q=${{ env.PACKAGE_NAME }}'
-          method: 'GET'
-          preventFailureOnNoResponse: "true"
-
-      - name: Build comment
-        env:
-          MATRIX_DIR: ${{ matrix.dir }}
-          DEP_RESPONSE: ${{ steps.get_deps.outputs.response }}
-        run: |
-          {
-            printf '#### reverse dependencies - %s\n\n' "$MATRIX_DIR"
-            if [[ "$DEP_RESPONSE" == '""' ]] ; then
-              printf 'None\n'
-            else
-              printf '%s' "$DEP_RESPONSE" | sed 's/\\n/\n/g' | sed 's/^"//' | sort | sed 's/^/- [ ] /'
+          while IFS= read -r project ; do
+            if [[ -z "$project" ]] ; then
+              continue
             fi
-          } > comment-output
-        shell:
-          bash
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: fc
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: "reverse dependencies - ${{ matrix.dir }}"
+            short_project="$(printf '%s\n' "$project" | cut -d/ -f2)"
+            response="$(wget -q -O - "https://slackbuilds.org/revdeps.php?q=$short_project" | sort || true)"
 
-      - name: Comment with dependency results
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+            slug="${project//\//:}"
+            file_slug="${project//\//--}"
+            {
+              printf '<!-- ci:reverse-deps:%s -->\n' "$slug"
+              printf '#### reverse dependencies - %s\n\n' "$project"
+              if [[ -z "$response" ]] ; then
+                printf 'None\n'
+              else
+                printf '%s\n' "$response" | sort | sed 's/^/- [ ] /'
+              fi
+            } > "comments/reverse-deps-${file_slug}.md"
+          done <<< "$changed_projects"
+
+      - name: Upload comment bodies
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.number }}
-          body-path: comment-output
-          edit-mode: replace
+          name: pr-comments
+          path: comments/
+          if-no-files-found: ignore
+          retention-days: 1

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,108 @@
+---
+name: PR comment
+
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows:
+      - PR checks
+    types:
+      - completed
+
+permissions: {}
+
+concurrency:
+  group: pr-comment-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: Post PR comments
+    runs-on: ubuntu-slim
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write # create/update the PR comments produced by the check run
+      actions: read # download the check run's artifact via the actions API
+    steps:
+      - name: Download comment bodies
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-comments
+          path: comments
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Post comments
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const dir = 'comments';
+
+            if (!fs.existsSync(dir)) {
+              core.info('No comment artifact found; nothing to do.');
+              return;
+            }
+
+            const headSha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+
+            const associated =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: headSha,
+              });
+
+            const pr = associated.data.find((p) => p.state === 'open');
+
+            if (!pr) {
+              core.info(`No open PR found for ${headSha}; nothing to do.`);
+              return;
+            }
+
+            const issue_number = pr.number;
+
+            const allowed = /^(sbolint-|reverse-deps-|too-many-changes).*\.md$/;
+            const files = fs
+              .readdirSync(dir)
+              .filter((f) => allowed.test(f))
+              .slice(0, 50);
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+
+            for (const file of files) {
+              const body = fs.readFileSync(path.join(dir, file), 'utf8');
+              const match = body.match(/<!-- (ci:[^\n>]+) -->/);
+
+              if (!match) {
+                core.warning(`No marker in ${file}; skipping.`);
+                continue;
+              }
+
+              const marker = `<!-- ${match[1]} -->`;
+              const found = existing.find((c) => (c.body || '').includes(marker));
+
+              if (found) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: found.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body,
+                });
+              }
+            }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,18 @@
 variables:
   FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: "true"
   # renovate: datasource=gitlab-releases depName=gitlab-org/cli
-  GLAB_VERSION: 1.103.0
+  GLAB_VERSION: 1.106.0
   # renovate: datasource=docker depName=aclemons/sbo-maintainer-tools versioning=loose
-  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.5@sha256:ca21dea9c86ef80bdd08330d6e7b15e4d23b2bc036d2d0e419cbadcd55b85591
+  SBO_MAINTAINER_TOOLS_IMAGE: aclemons/sbo-maintainer-tools:0.9.5@sha256:a313639001e6498de247b8012792756e84c5b8ca681bb2777f82ea27bb7c1f12
 
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
 
 default:
-  image: docker:29.6.0@sha256:7bb861a04bb42bda1d237fc2cb539f9823c9b666ecfbfdbd3e534ab74c8cb976
+  image: docker:29.6.1@sha256:66d292e5c26bd33a6f6f61cacb880de2186339a524ecba1ce098dbbaceed6515
   services:
-    - docker:29.6.0-dind@sha256:7bb861a04bb42bda1d237fc2cb539f9823c9b666ecfbfdbd3e534ab74c8cb976
+    - docker:29.6.1-dind@sha256:66d292e5c26bd33a6f6f61cacb880de2186339a524ecba1ce098dbbaceed6515
 
 pr-checks:
   script: |


### PR DESCRIPTION
Update deps:

- bump github actions
- bump forgejo actions
- gitlab ci build images
- gitlab cli version bump
- bump sbo-maintainer-tools digest

Add "too many changes" handling to forgejo action to mirror github.

Split out dangerous `pull_request_target` usage.

Instead we now use `pull_request` and move the commenting to a
`workflow_run` workflow running without forked code. We don't have
any secrets in our repo, but this is still best practice.

https://gh.io/securely-using-pull_request_target
