### PR TITLE
system/file-roller: Edit README, slack-desc, maintainer info

### DIFF
--- a/system/file-roller/README
+++ b/system/file-roller/README
@@ -1,4 +1,4 @@
-File-roller is an archive manager for the GNOME environment. It allows
+File Roller is an archive manager for the GNOME environment. It allows
 you to:
 
  * Create and modify archives
@@ -6,20 +6,10 @@ you to:
  * View a file contained in an archive
  * Extract files from the archive
 
-File-roller supports the following formats:
-
- * Tar (.tar) archives, including those compressed with
-   gzip (.tar.gz, .tgz), bzip (.tar.bz, .tbz), bzip2 (.tar.bz2, .tbz2),
-   compress (.tar.Z, .taz), lzop (.tar.lzo, .tzo) and lzma (.tar.lzma)
- * Zip archives (.zip)
- * Jar archives (.jar, .ear, .war)
- * 7z archives (.7z)
- * iso9660 CD images (.iso)
- * Lha archives (.lzh)
- * Single files compressed with gzip (.gz), bzip (.bz), bzip2 (.bz2),
-   compress (.Z), lzop (.lzo) and lzma (.lzma)
-
-File-roller doesn't perform archive operations by itself, but relies on
+File Roller doesn't perform archive operations by itself, but relies on
 standard tools for this.
 
-It integrates well in Thunar (XFCE) using Thunar-Archive-Plugin.
+It integrates well with Thunar (XFCE) using thunar-archive-plugin.
+
+file-roller 43.1 is the last available version for Slackware 15.0. Newer
+versions require a newer GTK4. 

--- a/system/file-roller/file-roller.SlackBuild
+++ b/system/file-roller/file-roller.SlackBuild
@@ -5,7 +5,8 @@
 # Ryan P.C. McQuen | Everett, WA | ryanpcmcquen@member.fsf.org
 # Frank Endres | frank.endres@sud-ouest.org
 
-# Copyright 2010  Binh Nguyen <binhvng@gmail.com>
+# Copyright 2010 Binh Nguyen <binhvng@gmail.com>
+# Copyright 2026 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is

--- a/system/file-roller/slack-desc
+++ b/system/file-roller/slack-desc
@@ -8,12 +8,12 @@
            |-----handy-ruler------------------------------------------------------|
 file-roller: file-roller (a GTK archive manager)
 file-roller:
-file-roller: File-roller is an archive manager for the GNOME environment. It allows
+file-roller: File Roller is an archive manager for the GNOME environment. It allows
 file-roller: you to:
+file-roller:
 file-roller: * Create and modify archives
 file-roller: * View and search the content of an archive
 file-roller: * View a file contained in an archive
 file-roller: * Extract files from the archive
 file-roller:
-file-roller: Homepage: https://wiki.gnome.org/Apps/FileRoller
 file-roller:


### PR DESCRIPTION
Now that I am officially the maintainer of file-roller:

Here are my edits.
The key here is that file-roller > 43.1 requires GTK4 >= 4.8.1 (for context, Slackware 15 has GTK4 4.4.1).