### PR TITLE
misc/fcitx5-mozc: New maintainer.

### DIFF
--- a/misc/fcitx5-mozc/fcitx5-mozc.info
+++ b/misc/fcitx5-mozc/fcitx5-mozc.info
@@ -26,5 +26,5 @@ MD5SUM="257fcb244249a3c65c576cceb5cbb7c8 \
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="fcitx5"
-MAINTAINER="orphaned - no maintainer"
-EMAIL="NOEMAIL"
+MAINTAINER="K. Eugene Carlson"
+EMAIL="kvngncrlsn@gmail.com"


### PR DESCRIPTION
I'd push an update, but it would require `qt6`. That's fine for -current, but I'm not sure the new version is a big enough improvement to justify making everyone who wants this do the extra dependency builds.