### PR TITLE
libraries/grpc: Allow building on 32-bit systems

### DIFF
--- a/libraries/grpc/grpc.SlackBuild
+++ b/libraries/grpc/grpc.SlackBuild
@@ -87,6 +87,9 @@ find -L . \
 
 sed -i 's|^prefix ?= /usr/local|prefix ?= /usr|' Makefile
 
+# If arch is 32-bit, disable gRPC_BUILD_CODEGEN (otherwise, build fails there)
+[[ $ARCH == i586 || $ARCH == i686 ]] && ENABLE_CODEGEN=OFF || ENABLE_CODEGEN=ON
+
 # Build instructions adapted from the Arch Linux PKGBUILD:
 # https://gitlab.archlinux.org/archlinux/packaging/packages/grpc/-/blob/main/PKGBUILD
 # However, this SlackBuild does not build tests (therefore, grpc-cli will not be installed)
@@ -102,7 +105,7 @@ cmake -Bbuild \
   -DCMAKE_CXX_STANDARD=17 \
   -DCMAKE_SKIP_INSTALL_RPATH=ON \
   -DgRPC_BUILD_TESTS=OFF \
-  -DgRPC_BUILD_CODEGEN=ON \
+  -DgRPC_BUILD_CODEGEN=$ENABLE_CODEGEN \
   -DgRPC_ZLIB_PROVIDER='package' \
   -DgRPC_CARES_PROVIDER='package' \
   -DgRPC_RE2_PROVIDER='package' \

--- a/libraries/grpc/grpc.info
+++ b/libraries/grpc/grpc.info
@@ -1,12 +1,12 @@
 PRGNAM="grpc"
 VERSION="1.80.0"
 HOMEPAGE="https://grpc.io/"
-DOWNLOAD="UNSUPPORTED"
-MD5SUM=""
-DOWNLOAD_x86_64="https://github.com/grpc/grpc/archive/v1.80.0/grpc-1.80.0.tar.gz \
-                 https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0/opencensus-proto-0.3.0.tar.gz"
-MD5SUM_x86_64="dc3e0cbfb480db5ea814b9741ac37138 \
-               0b208800a68548cbf2d4bff763c050a2"
+DOWNLOAD="https://github.com/grpc/grpc/archive/v1.80.0/grpc-1.80.0.tar.gz \
+          https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0/opencensus-proto-0.3.0.tar.gz"
+MD5SUM="dc3e0cbfb480db5ea814b9741ac37138 \
+        0b208800a68548cbf2d4bff763c050a2"
+DOWNLOAD_x86_64=""
+MD5SUM_x86_64=""
 REQUIRES="protobuf3 re2"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
The cause of build failures on x86 systems is enabling the option `gRPC_BUILD_CODEGEN`.
I will disable it on both x86 and x86_64 systems (why disable it on 1 architecture type and enable it on another?)

Also, trying to see whether this update will allow sysdig to compile.

Update 1:
Disable `gRPC_BUILD_CODEGEN` only on x86 systems so that sysdig compile successfully.
Keep `gRPC_BUILD_CODEGEN` on x86_64 ones.

This is only a bandaid solution (sure, grpc builds on x86 systems, but what about x86 programs that depend on grpc?)