### PR TITLE
network/proxychains: Update for version 4.17.

### DIFF
--- a/network/proxychains/proxychains.SlackBuild
+++ b/network/proxychains/proxychains.SlackBuild
@@ -4,6 +4,7 @@
 
 # Copyright -2014 GPLeo <slackbuilds@gmail.com>
 # Copyright 2014-2015 Marcel Saegebarth <marc@mos6581.de>
+# Copyright 2026 Ruoh-Shoei LIN
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,7 +30,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=proxychains
 SRCNAM=proxychains-ng
-VERSION=${VERSION:-4.16}
+VERSION=${VERSION:-4.17}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -83,6 +84,9 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# CVE-2025-34451
+patch -Np1 -i $CWD/cc005b7132811c9149e77b5e33cff359fc95512e.patch
+
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 ./configure \
@@ -92,7 +96,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --build=$ARCH-slackware-linux
 
 make
-make install install-config DESTDIR=$PKG
+make install install-config install-zsh-completion DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true

--- a/network/proxychains/proxychains.info
+++ b/network/proxychains/proxychains.info
@@ -1,10 +1,12 @@
 PRGNAM="proxychains"
-VERSION="4.16"
+VERSION="4.17"
 HOMEPAGE="https://github.com/rofl0r/proxychains-ng/"
-DOWNLOAD="https://github.com/rofl0r/proxychains-ng/archive/v4.16/proxychains-ng-4.16.tar.gz"
-MD5SUM="acd5807e89df4cca70270260e85e9373"
+DOWNLOAD="https://github.com/rofl0r/proxychains-ng/archive/v4.17/proxychains-ng-4.17.tar.gz \
+          https://github.com/rofl0r/proxychains-ng/commit/cc005b7132811c9149e77b5e33cff359fc95512e.patch"
+MD5SUM="7dccfc83c2054fe074e39d5c3da6f138 \
+        c5691d258999798b6feee82348a6202c"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES=""
-MAINTAINER="D Woodfall"
-EMAIL="dave@slackbuilds.org"
+MAINTAINER="Ruoh-Shoei LIN"
+EMAIL="lin.ruohshoei+sbo@gmail.com"


### PR DESCRIPTION
 - updating to version 4.17
 - adding upstreams's patch for CVE-2025-34451
 - installing zsh completeion file from upstream
 - New Maintainer