### PR TITLE
network/amneziawg-go: Updated for version 3.0.3.

### DIFF
--- a/network/amneziawg-go/amneziawg-go.SlackBuild
+++ b/network/amneziawg-go/amneziawg-go.SlackBuild
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=amneziawg-go
-VERSION=${VERSION:-3.0.2}
+VERSION=${VERSION:-3.0.3}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/network/amneziawg-go/amneziawg-go.info
+++ b/network/amneziawg-go/amneziawg-go.info
@@ -1,10 +1,10 @@
 PRGNAM="amneziawg-go"
-VERSION="3.0.2"
+VERSION="3.0.3"
 HOMEPAGE="https://github.com/amnezia-vpn/amneziawg-go"
-DOWNLOAD="https://github.com/amnezia-vpn/amneziawg-go/archive/v3.0.2/amneziawg-go-3.0.2.tar.gz \
-          https://sbo.t-rg.ws/amneziawg-go-3.0.2-vendored-sources.tar.xz"
-MD5SUM="6f4d247d425eb0df395eb532eda24a5f \
-        429b1c26bd165509373bbd902c3e3e8f"
+DOWNLOAD="https://github.com/amnezia-vpn/amneziawg-go/archive/v3.0.3/amneziawg-go-3.0.3.tar.gz \
+          https://sbo.t-rg.ws/amneziawg-go-3.0.3-vendored-sources.tar.xz"
+MD5SUM="25117247338a8faa34e49e1c18f06070 \
+        4a5386dc7c118787eb33d9dc016564a6"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="google-go-lang"


### PR DESCRIPTION
Of course, at the last day the upstream released a whole bunch of important updates... This PR overrides #16851.