### PR TITLE
development/rust-opt: Add aarch64.

### DIFF
--- a/development/rust-opt/README
+++ b/development/rust-opt/README
@@ -10,4 +10,6 @@ statement:
 rust-opt is not intended as a substitute for rustup or for the Slackware
 Rust package in terms of Rust development purposes.
 
-Separate downloads are available for x86_64, i686 and ARM.
+Separate downloads are available for x86_64, aarch64, i686 and ARM.
+Please note that full reverse dependency testing is performed only for
+x86_64, i686 and ARM at present.

--- a/development/rust-opt/rust-opt.info
+++ b/development/rust-opt/rust-opt.info
@@ -5,8 +5,10 @@ DOWNLOAD="https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-i686-unknown-
           https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-arm-unknown-linux-gnueabihf.tar.gz"
 MD5SUM="0c19ca3c1fa3701b0a64ce44ae3e7f02 \
         9d72f03340614775916fa291f8c30252"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-x86_64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="bbabf63ac45c56b9522164200f92353a"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-x86_64-unknown-linux-gnu.tar.gz \
+                 https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-aarch64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="bbabf63ac45c56b9522164200f92353a \
+               f9d1a446b3239a6b41cc6bc62e2d0c01"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"


### PR DESCRIPTION
Like it says in the README, I won't be doing the full reverse dependency checks for aarch64 just now (though I'll check one just to make sure it works). My plan is to stop ARM testing and pick that up after the repo turns over for the new Slackware version.

@willysr, there aren't any changes to the actual script, so I assume the reverse dependency tests aren't needed this time?