### PR TITLE
system/fastfetch: Explain the stopped updates in README.

### DIFF
--- a/system/fastfetch/README
+++ b/system/fastfetch/README
@@ -15,3 +15,8 @@ Optional dependencies include:
 
   ddcutil (get more information about external screens)
   chafa (render non-ascii images with libchafa)
+
+Version 2.66 is the last one to build with the versions of GCC or LLVM
+on Slackware 15.0. Building either one of these for a slightly newer
+screen fetch program would be overkill, so updates are suspended for
+now.


### PR DESCRIPTION
README changes only.