### PR TITLE
python/python3-secretstorage: Fix README

### DIFF
--- a/python/python3-secretstorage/README
+++ b/python/python3-secretstorage/README
@@ -1,5 +1,5 @@
 This module provides a way for securely storing passwords and other
 secrets.
 
-python3-secretstorage is the last available version for Slackware 15.0.
-Later versions require Python >= 3.10.
+python3-secretstorage 3.3.3 is the last available version for Slackware
+15.0. Later versions require Python >= 3.10.


### PR DESCRIPTION
The README initially didn't specify which version is actually the last available one on Slackware 15.0.
This PR fixes this.