### PR TITLE
desktop/cwm: update SlackBuild

### DIFF
--- a/desktop/cwm/README
+++ b/desktop/cwm/README
@@ -10,7 +10,5 @@ pleasant aesthetic.
 This version actively tracks changes in the OpenBSD CVS repository.
 Releases are roughly coordinated.
 
-To enable compiler and linker hardening when building the Slackware
-package, use:
-
-    HARDEN=yes ./cwm.SlackBuild
+The package is built with Clang and compiler/linker hardening enabled by
+default.

--- a/desktop/cwm/cwm-openbsd-numberstring.patch
+++ b/desktop/cwm/cwm-openbsd-numberstring.patch
@@ -1,0 +1,11 @@
+--- a/parse.y
++++ b/parse.y
+@@ -106,7 +106,7 @@
+ 
+ numberstring	: NUMBER				{
+ 			char	*s;
+-			if (asprintf(&s, "%lld", $1) == -1) {
++			if (asprintf(&s, "%lld", (long long)$1) == -1) {
+ 				yyerror("string: asprintf");
+ 				YYERROR;
+ 			}

--- a/desktop/cwm/cwm.SlackBuild
+++ b/desktop/cwm/cwm.SlackBuild
@@ -24,6 +24,7 @@
 #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# 20260808 r1w1s1: apply the OpenBSD fix, use Clang, and enable hardening.
 # 20260701 bkw: update for v7.9.
 # 20240322 bkw: update for v7.4.
 # 20220611 bkw: update for v7.1.
@@ -41,7 +42,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=cwm
 VERSION=${VERSION:-7.9}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -84,17 +85,16 @@ chown -R root:root .
 find -L .  -perm /111 -a \! -perm 755 -a -exec chmod 755 {} + -o \
         \! -perm /111 -a \! -perm 644 -a -exec chmod 644 {} +
 
+patch -p1 < $CWD/cwm-openbsd-numberstring.patch
+
 sed -i "s,-O2,$SLKCFLAGS," Makefile
 
-CFLAGS="$SLKCFLAGS"
-LDFLAGS=""
-
-if [ "${HARDEN:-no}" = "yes" ]; then
-  CFLAGS="$CFLAGS -fstack-protector-strong -D_FORTIFY_SOURCE=3"
-  LDFLAGS="-Wl,-z,relro -Wl,-z,now"
-fi
+CFLAGS="$SLKCFLAGS -fstack-protector-strong -D_FORTIFY_SOURCE=3"
+LDFLAGS="-Wl,-z,relro -Wl,-z,now"
+CC=${CC:-clang}
 
 make \
+  CC="$CC" \
   CFLAGS="-Wall $CFLAGS -g -D_GNU_SOURCE" \
   LDFLAGS="$LDFLAGS $(pkg-config --libs x11 xft xrandr)" \
   PREFIX=/usr \


### PR DESCRIPTION
Additional SlackBuild changes:
                                                                                                                                                             
- Applies the patch submitted upstream to OpenBSD.                                                                                                              - Builds with Clang by default.                                                                                                                                  
- Enables hardening by default: stack protector, _FORTIFY_SOURCE=3, full RELRO, and immediate binding.                                                           
- Tested successfully on Slackware 15 and -current.                          