### PR TITLE
system/doas: update SlackBuild

### DIFF
--- a/system/doas/README
+++ b/system/doas/README
@@ -48,8 +48,3 @@ This package conflicts with the OpenDoas package available at:
 
 Both packages install /usr/bin/doas. Only one of them should be
 installed at a time.
-
-To enable compiler and linker hardening when building the Slackware
-package, use:
-
-  HARDEN=yes ./doas.SlackBuild

--- a/system/doas/doas.SlackBuild
+++ b/system/doas/doas.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=doas
 SRCNAM=doas
 VERSION=${VERSION:-6.4}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -75,13 +75,13 @@ find -L . \
 
 CFLAGS="$SLKCFLAGS"
 LDFLAGS="-lpam -lpam_misc"
+CC=${CC:-clang}
 
-if [ "${HARDEN:-no}" = "yes" ]; then
-  CFLAGS="$CFLAGS -fstack-protector-strong -D_FORTIFY_SOURCE=3"
-  LDFLAGS="$LDFLAGS -Wl,-z,relro -Wl,-z,now"
-fi
+CFLAGS="$CFLAGS -fstack-protector-strong -D_FORTIFY_SOURCE=3"
+LDFLAGS="$LDFLAGS -Wl,-z,relro -Wl,-z,now"
 
 make \
+  CC="$CC" \
   OPT="$CFLAGS" \
   LDFLAGS="$LDFLAGS" \
   PREFIX=/usr \


### PR DESCRIPTION
Additional SlackBuild changes:                                                                                                                                                                                                                                                                                                

- Builds doas with Clang by default.                                                                                                                             
- Enables compiler and linker hardening by default.                                                                                                              
- Removes the optional HARDEN=yes setting.                                                                                                                       
- Tested successfully on Slackware 15 and -current.          