### PR TITLE
development/got: update SlackBuild

### DIFF
--- a/development/got/got.SlackBuild
+++ b/development/got/got.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 PRGNAM=got
 SRCNAM=got-portable
 VERSION=${VERSION:-0.127}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 ARCH=${ARCH:-}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -78,8 +78,14 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-CFLAGS="$SLKCFLAGS" \
+CC=${CC:-clang}
+CFLAGS="$SLKCFLAGS -fstack-protector-strong -D_FORTIFY_SOURCE=3"
+LDFLAGS="-Wl,-z,relro -Wl,-z,now"
+
+CC="$CC" \
+CFLAGS="$CFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
+LDFLAGS="$LDFLAGS" \
 ./configure \
   --prefix=/usr \
   --libdir=/usr/lib${LIBDIRSUFFIX} \


### PR DESCRIPTION
 Additional SlackBuild changes:                                                            

- Builds Got with Clang by default.                                                                                                                              
- Enables compiler and linker hardening by default.                                                                                                              
- Bumps the package build number to 2.                                                                                                                           
- Tested successfully on Slackware 15 and -current.           