### PR TITLE
network/proton-vpn-cli: Edit README (Add usage instructions)

### DIFF
--- a/network/proton-vpn-cli/README
+++ b/network/proton-vpn-cli/README
@@ -1,1 +1,4 @@
 This is the official Proton VPN CLI for Linux.
+
+Please read the following website for usage instructions:
+https://protonvpn.com/support/use-linux-cli


### PR DESCRIPTION
proton-vpn-cli is now at 1.0.3, but I have not updated it just yet.
It requires python3-proton-vpn-api-core to be upgraded to v5.5.6 (which is really difficult by itself.)

I also haven't been able to log in to Proton using the command `protonvpn signin username@email.address`.