### PR TITLE
development/jupyter-nbformat: Update README

### DIFF
--- a/development/jupyter-nbformat/README
+++ b/development/jupyter-nbformat/README
@@ -1,2 +1,5 @@
 jupyter-nbformat contains the base implementation of the Jupyter
 Notebook format, and Python APIs for working with notebooks.
+
+jupyter-nbformat 5.10.4 is the last available version on Slackware 15.0.
+Later versions require Python >= 3.10.


### PR DESCRIPTION
jupyter-nbformat >= 5.11.0 requires Python >= 3.10.