### PR TITLE
misc/exploitdb: Updated for version 2026_08_12.

### DIFF
--- a/misc/exploitdb/exploitdb.SlackBuild
+++ b/misc/exploitdb/exploitdb.SlackBuild
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=exploitdb
-VERSION=${VERSION:-2026_07_09}
+VERSION=${VERSION:-2026_08_12}
 SRCVER=$(echo $VERSION | tr _ -)
 
 BSNAM=exploitdb-bin-sploits

--- a/misc/exploitdb/exploitdb.info
+++ b/misc/exploitdb/exploitdb.info
@@ -1,8 +1,8 @@
 PRGNAM="exploitdb"
-VERSION="2026_07_09"
+VERSION="2026_08_12"
 HOMEPAGE="https://www.exploit-db.com/"
-DOWNLOAD="https://gitlab.com/exploit-database/exploitdb/-/archive/2026-07-09/exploitdb-2026-07-09.tar.gz https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/archive/2022-11-22/exploitdb-bin-sploits-2022-11-22.tar.gz"
-MD5SUM="d78ca8b8f507a072dca1317c80c55ffc \
+DOWNLOAD="https://gitlab.com/exploit-database/exploitdb/-/archive/2026-08-12/exploitdb-2026-08-12.tar.gz https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/archive/2022-11-22/exploitdb-bin-sploits-2022-11-22.tar.gz"
+MD5SUM="45de248e9091f7540a3f2886c8ec1fec \
         a7085246c2dcb84068065ee87519f47e"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""


### PR DESCRIPTION
Updated to latest upstream tag 2026-08-12. sbolint and test-build clean; sbopkglint reports the expected noarch/ELF warning from bundled bin-sploits (exploits for all architectures).