### PR TITLE
libraries/qt6: Updated for version 6.8.4.

### DIFF
--- a/libraries/qt6/README
+++ b/libraries/qt6/README
@@ -15,5 +15,5 @@ LLVM_OPT: llvm-opt is enabled by default, since LLVM >= 17 is required
 for QDoc and QtTools. If you already installed llvm from extra or used
 llvm in current branch, LLVM_OPT could be disabled with LLVM_OPT=OFF.
 
-Qt6 requires 16GB of RAM to build, and a minimum of 49GB of available
-disk storage.
+Qt6 requires 16GB of RAM (1.5-2GB RAM per core approximately) to
+build, and a minimum of 49GB of available disk storage.

--- a/libraries/qt6/qt6.SlackBuild
+++ b/libraries/qt6/qt6.SlackBuild
@@ -27,8 +27,8 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=qt6
 SRCNAM=qt-everywhere-src
-VERSION=${VERSION:-6.8.3}
-BUILD=${BUILD:-3}
+VERSION=${VERSION:-6.8.4}
+BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -60,13 +60,15 @@ else
   LIBDIRSUFFIX=""
 fi
 
+RELEASENOTES=${RELEASENOTES:-ecfa02db7dd2317d83c212e403683b73a5e31f35}
 set -e
 
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
 rm -rf $SRCNAM-$VERSION
-tar xvf $CWD/$SRCNAM-$VERSION.tar.xz
+tar xvf $CWD/qt-everywhere-opensource-src-$VERSION.tar.xz
+tar xvf $CWD/qtreleasenotes-$RELEASENOTES.tar.gz -C $SRCNAM-$VERSION
 cd $SRCNAM-$VERSION
 chown -R root:root .
 find -L . \
@@ -100,32 +102,25 @@ if [ "$ARCH" = "i686" ]; then
     popd
 fi
 
-pushd qtbase
-patch -Np1 -i $CWD/CVE-2025-3512-qtbase-6.8.diff
-patch -Np1 -i $CWD/CVE-2025-4211-qtbase-6.8.diff
-patch -Np1 -i $CWD/CVE-2025-5455-qtbase-6.8.patch
-
-sed -i '21,36d' $CWD/CVE-2025-5992-qtbase-6.8.patch
-patch -Np1 -i $CWD/CVE-2025-5992-qtbase-6.8.patch
-
-sed -i 's/QPCCertContextPointer certificateContext;/const CERT_CONTEXT *certificateContext = nullptr;/g' $CWD/CVE-2025-6338-qtbase-6.8.patch
-patch -Np1 -i $CWD/CVE-2025-6338-qtbase-6.8.patch
-popd
-
 pushd qtsvg
 patch -Np1 -i $CWD/CVE-2025-10728-qtsvg-6.8.diff
 patch -Np1 -i $CWD/CVE-2025-10729-qtsvg-6.8.diff
 patch -Np1 -i $CWD/CVE-2026-6210-qtsvg-6.8.diff
-popd
-
-pushd qtimageformats
-patch -Np1 -i $CWD/CVE-2025-5683-qtimageformats-6.8.patch
+patch -Np1 -i $CWD/CVE-2026-8168-qtsvg-6.8-0000.diff
+patch -Np1 -i $CWD/CVE-2026-8168-qtsvg-6.8-0001.diff
+sed '87s/37,7/37,8/;91d;92s/+/ /;97s/+/ /' $CWD/CVE-2026-8168-qtsvg-6.8-0002.diff | patch -Np1
+patch -Np1 -i $CWD/CVE-2026-8168-qtsvg-6.8-0003.diff
+patch -Np1 -i $CWD/CVE-2026-8168-qtsvg-6.8-0004.diff
 popd
 
 pushd qtdeclarative
 patch -Np1 -i $CWD/CVE-2025-12385-qtdeclarative-6.8-0001.diff
 patch -Np1 -i $CWD/CVE-2025-12385-qtdeclarative-6.8-0002.diff
 patch -Np1 -i $CWD/CVE-2025-14576-qtdeclarative-6.8.diff
+popd
+
+pushd qt5compat
+patch -Np1 -i $CWD/CVE-2026-9499-qt5compat-6.8.diff
 popd
 
 export QT6PREFIX="/usr"
@@ -305,6 +300,8 @@ sed -i "/LIBDIRSUFFIX/ s/LIBDIRSUFFIX/${LIBDIRSUFFIX}/g" \
 install -Dm755 $CWD/$PRGNAM.sh $CWD/$PRGNAM.csh -t $PKG/etc/profile.d
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
+install -Dm644 qtreleasenotes-$RELEASENOTES/qt/$VERSION/release-note.md \
+	-t $PKG/usr/doc/$PRGNAM-$VERSION
 cp -a \
    LICENSES README.md \
   $PKG/usr/doc/$PRGNAM-$VERSION

--- a/libraries/qt6/qt6.info
+++ b/libraries/qt6/qt6.info
@@ -1,5 +1,5 @@
 PRGNAM="qt6"
-VERSION="6.8.3"
+VERSION="6.8.4"
 HOMEPAGE="https://qt.io"
 DOWNLOAD="UNSUPPORTED"
 MD5SUM=""
@@ -9,16 +9,17 @@ DOWNLOAD_x86_64="https://download.qt.io/archive/qt/6.8/CVE-2025-10728-qtsvg-6.8.
                  https://download.qt.io/archive/qt/6.8/CVE-2025-12385-qtdeclarative-6.8-0002.diff \
                  https://download.qt.io/archive/qt/6.8/CVE-2025-14576-qtdeclarative-6.8.diff \
                  https://download.qt.io/archive/qt/6.8/CVE-2025-23050-qtconnectivity-6.8.diff \
-                 https://download.qt.io/archive/qt/6.8/CVE-2025-3512-qtbase-6.8.diff \
-                 https://download.qt.io/archive/qt/6.8/CVE-2025-4211-qtbase-6.8.diff \
-                 https://download.qt.io/archive/qt/6.8/CVE-2025-5455-qtbase-6.8.patch \
-                 https://download.qt.io/archive/qt/6.8/CVE-2025-5683-qtimageformats-6.8.patch \
-                 https://download.qt.io/archive/qt/6.8/CVE-2025-5992-qtbase-6.8.patch \
-                 https://download.qt.io/archive/qt/6.8/CVE-2025-6338-qtbase-6.8.patch \
                  https://download.qt.io/archive/qt/6.8/CVE-2026-6210-qtsvg-6.8.diff \
+                 https://download.qt.io/archive/qt/6.8/CVE-2026-8168-qtsvg-6.8-0000.diff \
+                 https://download.qt.io/archive/qt/6.8/CVE-2026-8168-qtsvg-6.8-0001.diff \
+                 https://download.qt.io/archive/qt/6.8/CVE-2026-8168-qtsvg-6.8-0002.diff \
+                 https://download.qt.io/archive/qt/6.8/CVE-2026-8168-qtsvg-6.8-0003.diff \
+                 https://download.qt.io/archive/qt/6.8/CVE-2026-8168-qtsvg-6.8-0004.diff \
+                 https://download.qt.io/archive/qt/6.8/CVE-2026-9499-qt5compat-6.8.diff \
                  https://salsa.debian.org/qt-kde-team/qt6/qt6-webengine/-/raw/debian/6.8.2+dfsg-4/debian/patches/compressing_files.patch \
                  https://salsa.debian.org/qt-kde-team/qt6/qt6-webengine/-/raw/debian/6.8.2+dfsg-4/debian/patches/disable_32bit_node_check.patch \
-                 https://download.qt.io/archive/qt/6.8/6.8.3/single/qt-everywhere-src-6.8.3.tar.xz \
+                 https://download.qt.io/archive/qt/6.8/6.8.4/single/qt-everywhere-opensource-src-6.8.4.tar.xz \
+                 https://github.com/qt/qtreleasenotes/archive/ecfa02db7dd2317d83c212e403683b73a5e31f35/qtreleasenotes-ecfa02db7dd2317d83c212e403683b73a5e31f35.tar.gz \
                  https://salsa.debian.org/qt-kde-team/qt6/qt6-webengine/-/raw/debian/6.8.2+dfsg-4/debian/patches/support-i386.patch"
 MD5SUM_x86_64="ae252a683d070e33ecd10862d6a7cafc \
                2b35e543b1bd14db40e527f6afcacfa1 \
@@ -26,16 +27,17 @@ MD5SUM_x86_64="ae252a683d070e33ecd10862d6a7cafc \
                c7d1bf693c6a7624ac2d49d906d3a16e \
                98a0c33056da13806d3e0c54ace07496 \
                57e1509b3f645db6224468a2acafc8d0 \
-               d694e774679816f0b8c1bb2f579fa749 \
-               269fbd2ab17845fc1fe99946f51bf779 \
-               3249408dfc38852dc92c56f1c5d66bcb \
-               a7de8365cba1f08330bbd3828ce3db9e \
-               8a18cecf476e522680a598cc86ef4d56 \
-               d9058dbdf5f991c31bd57d3ccfdee9ac \
                138b07dfb1de3285aeba425f80d48717 \
+               17c683034a6eb6b4d762443df46872da \
+               7d17c4318d6d6486c0d715ab9bc7de14 \
+               4b908e836a690458535a256410197715 \
+               db7e4811a22cd3d4a2b93926caf62511 \
+               4d2a654c707b17374ba7feeb63c205d7 \
+               1d180f39ad57d31316acb772852fb3ef \
                78847281276d7b769d9d0469d9a51288 \
                a3f4a7c3dd5c3dc057aeaad5fb9295b3 \
-               10a39c4b4af4f465c4ff0352a6d18a0a \
+               b943d042e97dfd69ac03002d07cc71a8 \
+               9ad6f951778c975c26ddb8f9b1c1af62 \
                3cee913489eb2748591f19478a049a2e"
 REQUIRES="double-conversion html5lib md4c nodejs22 llvm-opt"
 MAINTAINER="Ruoh-Shoei LIN"


### PR DESCRIPTION
- apply upstream patch for CVE-2026-8168, CVE-2026-9499

- remove obsolete patches for qtbase and qtimageformats

- add qtreleasenotes