### PR TITLE
Update/dfm update2

### DIFF
--- a/system/dfm/dfm-chafa-sixel-margins.patch
+++ b/system/dfm/dfm-chafa-sixel-margins.patch
@@ -1,0 +1,13 @@
+--- config.h.in
++++ config.h.in
+@@ -50,1 +50,1 @@
+-#define DFM_IMG_CHAFA_CMD "chafa", "--format=sixel", "-s"
++#define DFM_IMG_CHAFA_CMD "chafa", "--format=sixels", "--animate=off", "--colors=256", "--dither=ordered", "--margin-bottom=1", "--margin-right=1", "-s"
+--- dfm.c
++++ dfm.c
+@@ -3091,1 +3091,1 @@
+-  str_push_u32(&p->io, p->col);
++  str_push_u32(&p->io, MIN(p->col, 100));
+@@ -3093,1 +3093,1 @@
+-  str_push_u32(&p->io, p->row - 1);
++  str_push_u32(&p->io, MIN(p->row - 1, 20));

--- a/system/dfm/dfm.SlackBuild
+++ b/system/dfm/dfm.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=dfm
 VERSION=${VERSION:-1.0.2}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 ARCH=${ARCH:-}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -39,18 +39,20 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
+# LIBDIRSUFFIX is unused because dfm has no libraries.
+
 if [ "$ARCH" = i586 ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
+  #LIBDIRSUFFIX=""
 elif [ "$ARCH" = i686 ]; then
   SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
+  #LIBDIRSUFFIX=""
 elif [ "$ARCH" = x86_64 ]; then
   SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
+  #LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
+  #LIBDIRSUFFIX=""
 fi
 
 if [ -n "$PRINT_PACKAGE_NAME" ]; then
@@ -77,6 +79,8 @@ fi
 
 tar xvf $CWD/$PRGNAM-$VERSION.tar.?z*
 cd $PRGNAM-$VERSION
+
+patch -p0 < $CWD/dfm-chafa-sixel-margins.patch
 
 chown -R root:root .
 


### PR DESCRIPTION
This updates the existing SIXEL preview patch for dfm.                                                                                        
                                                                                                                                                   
Some terminals, including xterm, have a maximum SIXEL graphic size. Passing the full terminal dimensions to chafa could generate images wider than that limit, causing previews to fail for some images.                                                                                              
                                                                                                                                                   
This patch:                                                                                                                                   

- Limits SIXEL previews to 100x20 terminal cells.                                                                                             
- Disables animation for animated images.                                                                                                     
- Uses a conservative 256-color ordered-dither mode.                                                                                          
- Keeps the existing terminal margins.                                                                                                        
- Preserves the image aspect ratio.                                                                                                           
                                                                                                                                                   
The patch was tested with PNG and JPEG images in xterm + tmux using chafa. 