### PR TITLE
Fix slack-desc parentheses

### DIFF
--- a/academic/grpn/slack-desc
+++ b/academic/grpn/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
     |-----handy-ruler------------------------------------------------------|
-grpn: grpn (graphical reverse polish notation (RPN)
+grpn: grpn (graphical reverse polish notation (RPN) calculator)
 grpn:
 grpn: GRPN is written in C and uses the GIMP Toolkit (GTK) on top of X11.
 grpn: GRPN was developed under Linux but has also been tested under SunOS

--- a/development/LLgen/slack-desc
+++ b/development/LLgen/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
      |-----handy-ruler------------------------------------------------------|
-LLgen: LLgen (an ELL(1)
+LLgen: LLgen (an ELL(1) parser generator)
 LLgen:
 LLgen: LLgen is a tool for generating an efficient recursive descent parser
 LLgen: from an ELL(1) grammar. The grammar may be ambiguous or more general

--- a/development/jdk/slack-desc
+++ b/development/jdk/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
    |-----handy-ruler------------------------------------------------------|
-jdk: jdk (Java(TM)
+jdk: jdk (Java(TM) 2 Platform Standard Edition Development Kit)
 jdk:
 jdk: The Java 2 SDK software includes tools for developing, testing, and
 jdk: running programs written in the Java programming language.  This

--- a/development/rmlmmc/slack-desc
+++ b/development/rmlmmc/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
       |-----handy-ruler------------------------------------------------------|
-rmlmmc: rmlmmc (Relational Meta-Language (RML)
+rmlmmc: rmlmmc (Relational Meta-Language (RML) and Tools)
 rmlmmc:
 rmlmmc: This is a system for developing, compiling and debugging and teaching
 rmlmmc: Structural Operational Semantics (SOS) and Natural Semantics

--- a/games/yetris/slack-desc
+++ b/games/yetris/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
       |-----handy-ruler------------------------------------------------------|
-yetris: yetris (Tetris(tm)
+yetris: yetris (Tetris(tm) clone on the terminal)
 yetris:
 yetris: yetris is a customizable Tetris(tm) clone for the terminal. It has
 yetris: some features found on modern adaptations and aims to please both

--- a/graphics/gimp-feca_hdr-plugin/slack-desc
+++ b/graphics/gimp-feca_hdr-plugin/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
                     |-----handy-ruler------------------------------------------------------|
-gimp-feca_hdr-plugin: gimp-feca_hdr-plugin (HDR (tone mapping)
+gimp-feca_hdr-plugin: gimp-feca_hdr-plugin (HDR (tone mapping) plugin for GIMP)
 gimp-feca_hdr-plugin:
 gimp-feca_hdr-plugin: Open as layers 3 images with -1 EV, normal and +1 EV
 gimp-feca_hdr-plugin: and let the script do the magic.

--- a/haskell/haskell-idna/slack-desc
+++ b/haskell/haskell-idna/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
             |-----handy-ruler------------------------------------------------------|
-haskell-idna: haskell-idna (Implements IDNA (RFC 3490)
+haskell-idna: haskell-idna (Implements IDNA (RFC 3490))
 haskell-idna:
 haskell-idna: Implements IDNA - Internationalized Domain Names in Applications
 haskell-idna: (RFC 3490).

--- a/libraries/backports-ssl-match-hostname/slack-desc
+++ b/libraries/backports-ssl-match-hostname/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
                             |-----handy-ruler------------------------------------------------------|
-backports-ssl-match-hostname: backports-ssl-match-hostname (The ssl.match_hostname()
+backports-ssl-match-hostname: backports-ssl-match-hostname (The ssl.match_hostname() function)
 backports-ssl-match-hostname:
 backports-ssl-match-hostname: The Secure Sockets layer is only actually secure if you
 backports-ssl-match-hostname: check the hostname in the certificate returned by the

--- a/libraries/freealut/slack-desc
+++ b/libraries/freealut/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
         |-----handy-ruler------------------------------------------------------|
-freealut: freealut (The OpenAL Utility Toolkit (ALUT)
+freealut: freealut (The OpenAL Utility Toolkit (ALUT))
 freealut:
 freealut: freealut is a free implementation of OpenAL's ALUT standard.
 freealut:

--- a/libraries/libkqueue/slack-desc
+++ b/libraries/libkqueue/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
          |-----handy-ruler------------------------------------------------------|
-libkqueue: libkqueue (portable userspace implementation of kqueue(2)
+libkqueue: libkqueue (portable userspace implementation of kqueue(2))
 libkqueue:
 libkqueue: libkqueue is a portable userspace implementation of the kqueue(2)
 libkqueue: kernel event notification mechanism. It acts as a translator

--- a/libraries/libscrypt/slack-desc
+++ b/libraries/libscrypt/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
          |-----handy-ruler------------------------------------------------------|
-libscrypt: libscrypt (shared library that implements scrypt()
+libscrypt: libscrypt (shared library that implements scrypt() functionality)
 libscrypt:
 libscrypt: The scrypt key derivation function was originally developed for use
 libscrypt: in the Tarsnap online backup system and is designed to be far more

--- a/libraries/nextaw/slack-desc
+++ b/libraries/nextaw/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
       |-----handy-ruler------------------------------------------------------|
-nextaw: nextaw (Athena (libXaw)
+nextaw: nextaw (Athena (libXaw) replacement library)
 nextaw:
 nextaw: neXtaw is a replacement library for the Athena (libXaw) widget set. It
 nextaw: is based on Xaw3d, by Kaleb Keithley and is almost 100% backward

--- a/libraries/pysendfile/slack-desc
+++ b/libraries/pysendfile/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
           |-----handy-ruler------------------------------------------------------|
-pysendfile: pysendfile (A Python interface to sendfile(2)
+pysendfile: pysendfile (A Python interface to sendfile(2) syscall)
 pysendfile:
 pysendfile: sendfile(2) is a system call which provides a "zero-copy" way of
 pysendfile: copying data from one file descriptor to another (a socket).

--- a/network/bsflite/slack-desc
+++ b/network/bsflite/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
        |-----handy-ruler------------------------------------------------------|
-bsflite: bsflite (minimalist client for AOL's Instant Messenger(TM)
+bsflite: bsflite (minimalist client for AOL's Instant Messenger(TM) service)
 bsflite:
 bsflite: BSFlite is a rather small and minimalist client for AOL's Instant
 bsflite: Messenger(TM) service. Instead of having a full screen console

--- a/network/ftp-cloudfs/slack-desc
+++ b/network/ftp-cloudfs/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
            |-----handy-ruler------------------------------------------------------|
-ftp-cloudfs: ftp-cloudfs (FTP interface to OpenStack Object Storage (Swift)
+ftp-cloudfs: ftp-cloudfs (FTP interface to OpenStack Object Storage (Swift))
 ftp-cloudfs:
 ftp-cloudfs: ftp-cloudfs is a ftp server acting as a proxy to OpenStack Object
 ftp-cloudfs: Storage (swift). It allow you to connect via any FTP client to do

--- a/network/pidgin-otr/slack-desc
+++ b/network/pidgin-otr/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
           |-----handy-ruler------------------------------------------------------|
-pidgin-otr: pidgin-otr (Off-the-Record (OTR)
+pidgin-otr: pidgin-otr (Off-the-Record (OTR) Messaging for Pidgin)
 pidgin-otr:
 pidgin-otr: Allows you to have private conversations over instant messaging
 pidgin-otr: when talking on Pidgin by providing:

--- a/network/sftp-cloudfs/slack-desc
+++ b/network/sftp-cloudfs/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
             |-----handy-ruler------------------------------------------------------|
-sftp-cloudfs: sftp-cloudfs (SFTP interface to OpenStack Object Storage (Swift)
+sftp-cloudfs: sftp-cloudfs (SFTP interface to OpenStack Object Storage (Swift))
 sftp-cloudfs:
 sftp-cloudfs: This is a SFTP (Secure File Transfer Protocol) interface to OpenStack
 sftp-cloudfs: Object Storage, providing a service that acts as a proxy between a

--- a/network/vblade/slack-desc
+++ b/network/vblade/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
       |-----handy-ruler------------------------------------------------------|
-vblade: vblade (virtual EtherDrive (R)
+vblade: vblade (virtual EtherDrive (R) blade)
 vblade:
 vblade: The vblade is the virtual EtherDrive (R) blade, a program that makes
 vblade: seekable file available over an ethernet local area network (LAN) via

--- a/office/flowkeeper/slack-desc
+++ b/office/flowkeeper/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
           |-----handy-ruler------------------------------------------------------|
-flowkeeper: flowkeeper (Java-based timer for Pomodoro Technique(R)
+flowkeeper: flowkeeper (Java-based timer for Pomodoro Technique(R))
 flowkeeper:
 flowkeeper: It is a new desktop software timer for Pomodoro Technique(R), which
 flowkeeper: is a very simple yet effective way to increase personal productivity.

--- a/perl/perl-Danga-Socket/slack-desc
+++ b/perl/perl-Danga-Socket/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
                  |-----handy-ruler------------------------------------------------------|
-perl-Danga-Socket: perl-Danga-Socket (epoll()
+perl-Danga-Socket: perl-Danga-Socket (epoll() interface for perl)
 perl-Danga-Socket:
 perl-Danga-Socket: An event loop and event-driven async socket base class
 perl-Danga-Socket:

--- a/perl/perl-File-Finder/slack-desc
+++ b/perl/perl-File-Finder/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
                 |-----handy-ruler------------------------------------------------------|
-perl-File-Finder: perl-File-Finder (nice wrapper for File::Find ala find(1)
+perl-File-Finder: perl-File-Finder (nice wrapper for File::Find ala find(1))
 perl-File-Finder:
 perl-File-Finder: File::Find is great, but constructing the wanted routine can
 perl-File-Finder: sometimes be a pain. This module provides a wanted-writer, using

--- a/perl/perl-Net-Pcap/slack-desc
+++ b/perl/perl-Net-Pcap/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
              |-----handy-ruler------------------------------------------------------|
-perl-Net-Pcap: perl-Net-Pcap (Interface to pcap(3)
+perl-Net-Pcap: perl-Net-Pcap (Interface to pcap(3) LBL packet capture library)
 perl-Net-Pcap:
 perl-Net-Pcap: The Net::Pcap module is a Perl binding to the LBL pcap(3) packet
 perl-Net-Pcap: capture library.

--- a/perl/perl-Text-Iconv/slack-desc
+++ b/perl/perl-Text-Iconv/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
                |-----handy-ruler------------------------------------------------------|
-perl-Text-Iconv: perl-Text-Iconv (Perl interface to the iconv()
+perl-Text-Iconv: perl-Text-Iconv (Perl interface to the iconv() function)
 perl-Text-Iconv:
 perl-Text-Iconv: This module provides a Perl interface to the iconv() codeset
 perl-Text-Iconv: conversion function. It was written by Michael Piotrowski.

--- a/perl/perl-XML-Filter-BufferText/slack-desc
+++ b/perl/perl-XML-Filter-BufferText/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
                           |-----handy-ruler------------------------------------------------------|
-perl-XML-Filter-BufferText: perl-XML-Filter-BufferText (all characters()
+perl-XML-Filter-BufferText: perl-XML-Filter-BufferText (all characters() in one event)
 perl-XML-Filter-BufferText:
 perl-XML-Filter-BufferText: Filter to put all characters() in one event.
 perl-XML-Filter-BufferText:

--- a/python/monotonic/slack-desc
+++ b/python/monotonic/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
          |-----handy-ruler------------------------------------------------------|
-monotonic: monotonic (An implementation of time.monotonic()
+monotonic: monotonic (An implementation of time.monotonic())
 monotonic:
 monotonic: This module provides a monotonic() function which returns the
 monotonic: value (in fractional seconds) of a clock which never goes

--- a/python/python3-monotonic/slack-desc
+++ b/python/python3-monotonic/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
                  |-----handy-ruler------------------------------------------------------|
-python3-monotonic: python3-monotonic (An implementation of time.monotonic()
+python3-monotonic: python3-monotonic (An implementation of time.monotonic())
 python3-monotonic:
 python3-monotonic: This module provides a python3-monotonic() function which returns the
 python3-monotonic: value (in fractional seconds) of a clock which never goes

--- a/python/wsgiref/slack-desc
+++ b/python/wsgiref/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
        |-----handy-ruler------------------------------------------------------|
-wsgiref: wsgiref (WSGI (PEP 333)
+wsgiref: wsgiref (WSGI (PEP 333) Reference Library)
 wsgiref:
 wsgiref: This is a standalone release of the wsgiref library, that
 wsgiref: provides validation support for WSGI 1.0.1 (PEP 3333) for

--- a/system/hntool/slack-desc
+++ b/system/hntool/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
       |-----handy-ruler------------------------------------------------------|
-hntool: hntool (an open source (GPLv2)
+hntool: hntool (an open source (GPLv2) hardening tool for Unix)
 hntool:
 hntool: It scans your system for vulnerabilities or problems in configuration
 hntool: files allowing you to get a quick overview of the security status

--- a/system/msitools/slack-desc
+++ b/system/msitools/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
         |-----handy-ruler------------------------------------------------------|
-msitools: msitools (Inspect and build Windows Installer (.MSI)
+msitools: msitools (Inspect and build Windows Installer (.MSI) files)
 msitools:
 msitools: msitools is a set of programs to inspect and build
 msitools: Windows Installer (.MSI) files. It is based on libmsi, a portable

--- a/system/rhash/slack-desc
+++ b/system/rhash/slack-desc
@@ -6,7 +6,7 @@
 # customary to leave one space after the ':' except on otherwise blank lines.
 
      |-----handy-ruler------------------------------------------------------|
-rhash: rhash (Utility for verifying hash sums (SFV, CRC, etc)
+rhash: rhash (Utility for verifying hash sums (SFV, CRC, etc))
 rhash:
 rhash: RHash (Recursive Hasher) is a console utility for computing and
 rhash: verifying hash sums of files. It supports CRC32, MD4, MD5, SHA1,


### PR DESCRIPTION
About ten years ago, a number of `slack-desc` files had the first line cut off at the first right parenthesis. Restore any trailing text and missing parentheses so the descriptions show up properly in `SLACKBUILDS.TXT`, `sbopkg`, `sbotools`, etc.