### PR TITLE
development/velero: update to 1.18.2

### DIFF
--- a/development/velero/README.vendor
+++ b/development/velero/README.vendor
@@ -1,0 +1,17 @@
+velero SlackBuild - vendored Go dependencies
+=============================================
+
+The SlackBuild vendors Go dependencies to allow an offline and reproducible
+build in the SlackBuilds.org CI environment.
+
+The vendor archive is named:
+
+  velero-<version>-vendor.tar.gz
+
+It contains the vendor directory generated from the matching Velero source
+release. To regenerate it, obtain the source and run:
+
+  $ ./generate-vendor.sh /path/to/velero-<version> /path/to/output
+
+The generated archive must be uploaded to the slackbuilds-tarballs repository,
+then the URL and MD5 checksum in velero.info must be updated.

--- a/development/velero/generate-vendor.sh
+++ b/development/velero/generate-vendor.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  printf 'Usage: %s SOURCE_DIR OUTPUT_DIR\n' "$0" >&2
+  exit 1
+fi
+
+SOURCE_DIR=$(realpath "$1")
+OUTPUT_DIR=$(realpath "$2")
+
+if [ ! -d "$SOURCE_DIR" ] || [ ! -f "$SOURCE_DIR/go.mod" ]; then
+  printf 'Invalid source directory: %s\n' "$SOURCE_DIR" >&2
+  exit 1
+fi
+
+case "$(basename "$SOURCE_DIR")" in
+  velero-*) VERSION=${SOURCE_DIR##*/velero-} ;;
+  *)
+    printf 'Source directory must be named velero-VERSION: %s\n' "$SOURCE_DIR" >&2
+    exit 1
+    ;;
+esac
+
+command -v go >/dev/null 2>&1 || {
+  printf 'go not found\n' >&2
+  exit 1
+}
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cd "$SOURCE_DIR"
+go mod vendor
+tar czf "$OUTPUT_DIR/velero-$VERSION-vendor.tar.gz" -C "$SOURCE_DIR" vendor
+
+printf 'Created: %s\n' "$OUTPUT_DIR/velero-$VERSION-vendor.tar.gz"

--- a/development/velero/velero.SlackBuild
+++ b/development/velero/velero.SlackBuild
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=velero
-VERSION=${VERSION:-1.17.2}
+VERSION=${VERSION:-1.18.2}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -33,8 +33,13 @@ PKGTYPE=${PKGTYPE:-tgz}
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
     x86_64) ARCH=x86_64 ;;
-         *) ARCH=i686 ;;
+         *) ARCH=unsupported ;;
   esac
+fi
+
+if [ "$ARCH" != "x86_64" ]; then
+  echo "Velero does not support the $ARCH architecture."
+  exit 1
 fi
 
 # If the variable PRINT_PACKAGE_NAME is set, then this script will report what
@@ -49,19 +54,19 @@ TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
-if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
-else
-  SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
-fi
+#if [ "$ARCH" = "i586" ]; then
+#  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
+#  LIBDIRSUFFIX=""
+#elif [ "$ARCH" = "i686" ]; then
+#  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
+#  LIBDIRSUFFIX=""
+#elif [ "$ARCH" = "x86_64" ]; then
+#  SLKCFLAGS="-O2 -fPIC"
+#  LIBDIRSUFFIX="64"
+#else
+#  SLKCFLAGS="-O2"
+#  LIBDIRSUFFIX=""
+#fi
 
 set -e
 
@@ -69,11 +74,11 @@ rm -rf $PKG
 mkdir -p $TMP $PKG $PKG/usr $OUTPUT
 cd $TMP
 rm -rf $PRGNAM-$VERSION
-tar xvf $CWD/$PRGNAM-v$VERSION-linux-amd64.tar.gz
-mv $PRGNAM-v$VERSION-linux-amd64 $PRGNAM-$VERSION
+tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
 cd $PRGNAM-$VERSION
-mkdir -p bin
-mv $PRGNAM bin
+tar xf $CWD/$PRGNAM-$VERSION-vendor.tar.gz
+mkdir -p $PKG/usr/bin
+CGO_ENABLED=0 GOPROXY=off go build -mod=vendor -trimpath -o $PKG/usr/bin/$PRGNAM ./cmd/velero
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
@@ -81,9 +86,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-chmod 755 bin
-
-mv bin $PKG/usr/
+chmod 755 $PKG/usr/bin/$PRGNAM
 
 find -L $PKG -type d -exec chmod 755 {} \;
 chmod 755 $PKG/usr/bin/*

--- a/development/velero/velero.info
+++ b/development/velero/velero.info
@@ -1,10 +1,12 @@
 PRGNAM="velero"
-VERSION="1.17.2"
+VERSION="1.18.2"
 HOMEPAGE="https://velero.io"
 DOWNLOAD="UNSUPPORTED"
 MD5SUM=""
-DOWNLOAD_x86_64="https://github.com/vmware-tanzu/velero/releases/download/v1.17.2/velero-v1.17.2-linux-amd64.tar.gz"
-MD5SUM_x86_64="b56ea7c19ac507ead18f80abebe0ae8c"
-REQUIRES=""
+DOWNLOAD_x86_64="https://github.com/velero-io/velero/archive/v1.18.2/velero-1.18.2.tar.gz \
+                 https://github.com/r1w1s1/slackbuilds-tarballs/raw/refs/heads/master/velero-1.18.2-vendor.tar.gz"
+MD5SUM_x86_64="8a6f61cfd479bf9ef43f17e0db3ad6c6 \
+               b91241c950d8e93c78cacb7b37924f3a"
+REQUIRES="google-go-lang"
 MAINTAINER="r1w1s1"
-EMAIL="r1w1s1@fastmail.com"
+EMAIL="ricardsonwilliams+slackbuild@gmail.com"


### PR DESCRIPTION
- bump version
- changed the build from pre-compiled to sources build and create a new velero-bin package.