### PR TITLE
development/rust-opt: Updated for version 1.98.0.

### DIFF
--- a/development/rust-opt/rust-opt.SlackBuild
+++ b/development/rust-opt/rust-opt.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=rust-opt
 SRCNAM=rust
-VERSION=${VERSION:-1.97.1}
+VERSION=${VERSION:-1.98.0}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}

--- a/development/rust-opt/rust-opt.info
+++ b/development/rust-opt/rust-opt.info
@@ -1,14 +1,14 @@
 PRGNAM="rust-opt"
-VERSION="1.97.1"
+VERSION="1.98.0"
 HOMEPAGE="https://rust-lang.org"
-DOWNLOAD="https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-i686-unknown-linux-gnu.tar.gz \
-          https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-arm-unknown-linux-gnueabihf.tar.gz"
-MD5SUM="0c19ca3c1fa3701b0a64ce44ae3e7f02 \
-        9d72f03340614775916fa291f8c30252"
-DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-x86_64-unknown-linux-gnu.tar.gz \
-                 https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-aarch64-unknown-linux-gnu.tar.gz"
-MD5SUM_x86_64="bbabf63ac45c56b9522164200f92353a \
-               f9d1a446b3239a6b41cc6bc62e2d0c01"
+DOWNLOAD="https://static.rust-lang.org/dist/2026-08-20/rust-1.98.0-i686-unknown-linux-gnu.tar.gz \
+          https://static.rust-lang.org/dist/2026-08-20/rust-1.98.0-arm-unknown-linux-gnueabihf.tar.gz"
+MD5SUM="4777cca2edf834bdadfdca96b90c4d7a \
+        721554ea07440c92a51d1eeaff13c6f5"
+DOWNLOAD_x86_64="https://static.rust-lang.org/dist/2026-08-20/rust-1.98.0-x86_64-unknown-linux-gnu.tar.gz \
+                 https://static.rust-lang.org/dist/2026-08-20/rust-1.98.0-aarch64-unknown-linux-gnu.tar.gz"
+MD5SUM_x86_64="ab81343b37065953ec879833decb0237 \
+               c2a3e78a14443a74c9a9d6a7187b03ca"
 REQUIRES=""
 MAINTAINER="K. Eugene Carlson"
 EMAIL="kvngncrlsn@gmail.com"

--- a/development/rust-opt/slack-desc
+++ b/development/rust-opt/slack-desc
@@ -11,7 +11,7 @@ rust-opt:
 rust-opt: rust-opt installs a limited set of up-to-date Rust stable binaries to
 rust-opt: /opt/rust for use in SlackBuilds.
 rust-opt:
-rust-opt: See /usr/doc/rust-opt-1.97.1/README.sw for usage instructions.
+rust-opt: See /usr/doc/rust-opt-1.98.0/README.sw for usage instructions.
 rust-opt:
 rust-opt:
 rust-opt:


### PR DESCRIPTION
`games/0ad` is a known build failure. I talked to the maintainer by email, and he said he could make a commit to switch its dependency to `rust16`.