### PR TITLE
Update slack-wallpapers to 1.1.0 and consolidate wallpaper packs

### DIFF
--- a/desktop/slack-wallpapers/slack-wallpapers.SlackBuild
+++ b/desktop/slack-wallpapers/slack-wallpapers.SlackBuild
@@ -1,9 +1,10 @@
 #!/bin/bash
-
+#
 # Slackware build script for slack-wallpapers
-
+#
 # Copyright 2012-2016 Petar Petrov slackalaxy@gmail.com
 # Copyright 2017-2018 Skaendo <skaendo@linuxmail.org>
+# Copyright 2026 r1w1s1
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,8 +27,8 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=slack-wallpapers
-VERSION=${VERSION:-1.0}
-BUILD=${BUILD:-2}
+VERSION=${VERSION:-1.1.0}
+BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -53,17 +54,6 @@ cd $TMP
 rm -rf $PRGNAM-$VERSION
 tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
 cd $PRGNAM-$VERSION
-
-# I know this is probably some bad hackery, but it works.
-# Suggestions are welcome.
-for i in dated deviantart salix srbija; do
-    if [ -e $CWD/$PRGNAM-$i-$VERSION.tar.gz ]; then
-      tar xvf $CWD/$PRGNAM-$i-$VERSION.tar.gz
-      mv ./*/wallpapers/* ./wallpapers
-    else
-      continue
-    fi
-done
 
 chown -R root:root .
 find -L . \
@@ -102,7 +92,7 @@ fi
 cd $TMP/$PRGNAM-$VERSION
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a ChangeLog Contributing README \
+cp -a ChangeLog Contributing README.md credits \
   $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 

--- a/desktop/slack-wallpapers/slack-wallpapers.info
+++ b/desktop/slack-wallpapers/slack-wallpapers.info
@@ -1,18 +1,10 @@
 PRGNAM="slack-wallpapers"
-VERSION="1.0"
+VERSION="1.1.0"
 HOMEPAGE="https://skaendoblog.wordpress.com/slack-wallpapers"
-DOWNLOAD="https://github.com/skaendo/slack-wallpapers/archive/1.0/slack-wallpapers-1.0.tar.gz \
-          https://github.com/skaendo/slack-wallpapers-dated/archive/1.0/slack-wallpapers-dated-1.0.tar.gz \
-          https://github.com/skaendo/slack-wallpapers-deviantart/archive/1.0/slack-wallpapers-deviantart-1.0.tar.gz \
-          https://github.com/skaendo/slack-wallpapers-salix/archive/1.0/slack-wallpapers-salix-1.0.tar.gz \
-          https://github.com/skaendo/slack-wallpapers-srbija/archive/1.0/slack-wallpapers-srbija-1.0.tar.gz"
-MD5SUM="258b3bbe613675f1049091a30f104010 \
-        e8e26423c234b14022930412063844c2 \
-        9869e931e4bdedaf2151e6a8081cd057 \
-        6ad36394765e8c2c136fe56868963003 \
-        0dda82f8407f4efbf5072b97fe2ed3c4"
+DOWNLOAD="https://github.com/r1w1s1/slack-wallpapers/archive/refs/tags/1.1.0/slack-wallpapers-1.1.0.tar.gz"
+MD5SUM="e2b2b75a175515247b5b927b82e68159"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES=""
-MAINTAINER="Skaendo"
-EMAIL="skaendo@linuxmail.org"
+MAINTAINER="r1w1s1"
+EMAIL="ricardsonwilliams+slackbuild@gmail.com"


### PR DESCRIPTION
- Update SlackBuild to version 1.1.0                                                                                                         
- Consolidate the wallpaper repositories into one repository 