### PR TITLE
development/dmd: Protect against exported BUILD

### DIFF
--- a/development/dmd/dmd.SlackBuild
+++ b/development/dmd/dmd.SlackBuild
@@ -77,11 +77,14 @@ find -L $PRGNAM-$VERSION phobos-$VERSION \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# BUILD= should be explicitly passed, otherwise if the SlackBuild's BUILD is
+# exported dmd and phobos refuse to build demanding BUILD to be "release" or
+# "debug".
 cd $PRGNAM-$VERSION
-make HOST_DMD=$TMP/dmd2/linux/bin${ARCHSUFFIX}/dmd ENABLE_RELEASE=1 install
+make HOST_DMD=$TMP/dmd2/linux/bin${ARCHSUFFIX}/dmd ENABLE_RELEASE=1 BUILD=release install
 
 cd ../phobos-$VERSION
-make DMD_DIR=../dmd-$VERSION install
+make DMD_DIR=../dmd-$VERSION BUILD=release install
 
 cd $TMP/install
 


### PR DESCRIPTION
This is from belka's update branch to test whether it's good enough to build as  requirement for #17515 (currently FTB because of dmd failure)