### PR TITLE
libraries/libgnomecups: Update SlackBuild to follow SBo template.

### DIFF
--- a/libraries/libgnomecups/libgnomecups.SlackBuild
+++ b/libraries/libgnomecups/libgnomecups.SlackBuild
@@ -63,10 +63,15 @@ elif [ "$ARCH" = "s390" ]; then
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
   LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
+  LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
   LIBDIRSUFFIX=""
 fi
+
+set -e
 
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT


### PR DESCRIPTION
Notably this was missing a "set -e" line, causing build failure to output an empty package, rather than exiting.