### PR TITLE
misc/exploitdb: Updated for version 2026_09_04.

### DIFF
--- a/misc/exploitdb/exploitdb.SlackBuild
+++ b/misc/exploitdb/exploitdb.SlackBuild
@@ -25,7 +25,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=exploitdb
-VERSION=${VERSION:-2026_08_19}
+VERSION=${VERSION:-2026_09_04}
 SRCVER=$(echo $VERSION | tr _ -)
 
 BSNAM=exploitdb-bin-sploits

--- a/misc/exploitdb/exploitdb.info
+++ b/misc/exploitdb/exploitdb.info
@@ -1,8 +1,8 @@
 PRGNAM="exploitdb"
-VERSION="2026_08_19"
+VERSION="2026_09_04"
 HOMEPAGE="https://www.exploit-db.com/"
-DOWNLOAD="https://gitlab.com/exploit-database/exploitdb/-/archive/2026-08-19/exploitdb-2026-08-19.tar.gz https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/archive/2022-11-22/exploitdb-bin-sploits-2022-11-22.tar.gz"
-MD5SUM="e8aee09d6665bacdc9f2967fd65ff4ac \
+DOWNLOAD="https://gitlab.com/exploit-database/exploitdb/-/archive/2026-09-04/exploitdb-2026-09-04.tar.gz https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/archive/2022-11-22/exploitdb-bin-sploits-2022-11-22.tar.gz"
+MD5SUM="c6f77795011ead9c90bd6892a56bdecd \
         a7085246c2dcb84068065ee87519f47e"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""


### PR DESCRIPTION
Test-built successfully on both -current and 15.0, sbolint clean.

The sbopkglint 15-noarch test reports ELF files under usr/share/exploitdb/bin-sploits (190-3.linux, 35081.bin). These are known exploit sample binaries shipped by the upstream exploitdb-bin-sploits secondary source, which stays pinned at 2022-11-22 and is unchanged by this update. The finding is pre-existing and not introduced by this version bump.