### PR TITLE
academic/getfem: do not overwrite the stock gmm library

### DIFF
--- a/academic/veusz/README
+++ b/academic/veusz/README
@@ -10,13 +10,7 @@ SAMP interfaces to its plotting facilities. It also allows for
 manipulation and editing of datasets. Data can be captured from
 external sources such as Internet sockets or other programs.
 
-See the complete release notes for Veusz 3.3.1 at
-https://veusz.github.io/releasenotes/3.3.1.txt
-
 Sphinx is an optional dependency (used to rebuild the manual).
 
-****
 Note:
-The veusz.SlackBuild script moved from Python2 to Python3 in version
-3.3.1. Please, check the dependencies.
-****
+Veusz 3.3.1 is the last version supported on Slackware 15.0.


### PR DESCRIPTION
gmm headers are removed after building getfem in order  to not overwrite the stock one. Thanks to Lockywolf.
getfem should work fine with stock gmm even if it is older than getfem own version.